### PR TITLE
Fix Resume query performance

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -291,8 +291,8 @@ namespace Emby.Server.Implementations.Library
             {
                 using var dbContext = _repository.CreateDbContext();
                 withLocalAlternates = dbContext.LinkedChildren
-                    .Where(lc => lc.ChildType == Jellyfin.Database.Implementations.Entities.LinkedChildType.LocalAlternateVersion
-                        && localProbeIds.Contains(lc.ParentId))
+                    .Where(lc => lc.ChildType == Jellyfin.Database.Implementations.Entities.LinkedChildType.LocalAlternateVersion)
+                    .WhereOneOrMany(localProbeIds, lc => lc.ParentId)
                     .Select(lc => lc.ParentId)
                     .Distinct()
                     .ToHashSet();

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -557,8 +557,13 @@ public sealed partial class BaseItemRepository
                     : baseQuery.Where(e => inProgressIds.Contains(e.Id));
 
                 // When several versions of the same item are in progress, keep only the most recently played one, use id as tiebreaker.
+                // Only in-progress siblings can eliminate a candidate: a version without progress has a NULL max LastPlayedDate,
+                // which is never greater and never ties. Restricting the sibling scan to the in-progress set keeps this bounded by
+                // the user's Continue Watching count instead of forcing a full BaseItems scan (COALESCE keys are non-indexable) per row.
                 baseQuery = baseQuery.Where(e => e.Type == seriesTypeName || !context.BaseItems
-                    .Where(s => s.Id != e.Id && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
+                    .Where(s => s.Id != e.Id
+                        && inProgressIds.Contains(s.Id)
+                        && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
                     .Any(s =>
                         inProgress.Where(su => su.ItemId == s.Id).Max(su => su.LastPlayedDate)
                             > inProgress.Where(eu => eu.ItemId == e.Id).Max(eu => eu.LastPlayedDate)

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/AlternateVersionQueryTranslationTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/AlternateVersionQueryTranslationTests.cs
@@ -60,7 +60,9 @@ public sealed class AlternateVersionQueryTranslationTests : IDisposable
                 .Where(e => seededIds.Contains(e.Id))
                 .Where(e => inProgressIds.Contains(e.Id))
                 .Where(e => !ctx.BaseItems
-                    .Where(s => s.Id != e.Id && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
+                    .Where(s => s.Id != e.Id
+                        && inProgressIds.Contains(s.Id)
+                        && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
                     .Any(s =>
                         inProgress.Where(su => su.ItemId == s.Id).Max(su => su.LastPlayedDate)
                             > inProgress.Where(eu => eu.ItemId == e.Id).Max(eu => eu.LastPlayedDate)
@@ -110,7 +112,9 @@ public sealed class AlternateVersionQueryTranslationTests : IDisposable
                 .Where(e => seededIds.Contains(e.Id))
                 .Where(e => inProgressIds.Contains(e.Id))
                 .Where(e => !ctx.BaseItems
-                    .Where(s => s.Id != e.Id && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
+                    .Where(s => s.Id != e.Id
+                        && inProgressIds.Contains(s.Id)
+                        && (s.PrimaryVersionId ?? s.Id) == (e.PrimaryVersionId ?? e.Id))
                     .Any(s =>
                         inProgress.Where(su => su.ItemId == s.Id).Max(su => su.LastPlayedDate)
                             > inProgress.Where(eu => eu.ItemId == e.Id).Max(eu => eu.LastPlayedDate)


### PR DESCRIPTION
The created queries by EF core were inefficient.

**Changes**
* Fix tie-breaker calculation in version ordering query
* Fix user data batch query performance

**Code assistance**
Used Claude Opus 4.8 to debug the generated queries by ef core

**Issues**
Fixes: #17357