### PR TITLE
fix: don't throw ArgumentNullException on partial UpdateItem payloads (#17366)

### DIFF
--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -236,7 +236,7 @@ public class ItemUpdateController : BaseJellyfinApiController
         return NoContent();
     }
 
-    private async Task UpdateItem(BaseItemDto request, BaseItem item)
+    internal async Task UpdateItem(BaseItemDto request, BaseItem item)
     {
         item.Name = request.Name;
         item.ForcedSortName = request.ForcedSortName;

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -250,7 +250,11 @@ public class ItemUpdateController : BaseJellyfinApiController
         item.IndexNumber = request.IndexNumber;
         item.ParentIndexNumber = request.ParentIndexNumber;
         item.Overview = request.Overview;
-        item.Genres = request.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+        if (request.Genres is not null)
+        {
+            item.Genres = request.Genres.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        }
 
         if (item is Episode episode)
         {
@@ -293,10 +297,20 @@ public class ItemUpdateController : BaseJellyfinApiController
         item.CustomRating = request.CustomRating;
 
         var currentTags = item.Tags;
-        var newTags = request.Tags.Select(t => t.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
-        var removedTags = currentTags.Except(newTags).ToList();
-        var addedTags = newTags.Except(currentTags).ToList();
-        item.Tags = newTags;
+        List<string> removedTags;
+        List<string> addedTags;
+        if (request.Tags is not null)
+        {
+            var newTags = request.Tags.Select(t => t.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+            removedTags = currentTags.Except(newTags).ToList();
+            addedTags = newTags.Except(currentTags).ToList();
+            item.Tags = newTags;
+        }
+        else
+        {
+            removedTags = [];
+            addedTags = [];
+        }
 
         if (item is Series rseries)
         {
@@ -408,15 +422,18 @@ public class ItemUpdateController : BaseJellyfinApiController
             item.RunTimeTicks = request.RunTimeTicks;
         }
 
-        foreach (var pair in request.ProviderIds.ToList())
+        if (request.ProviderIds is not null)
         {
-            if (string.IsNullOrEmpty(pair.Value))
+            foreach (var pair in request.ProviderIds.ToList())
             {
-                request.ProviderIds.Remove(pair.Key);
+                if (string.IsNullOrEmpty(pair.Value))
+                {
+                    request.ProviderIds.Remove(pair.Key);
+                }
             }
-        }
 
-        item.ProviderIds = request.ProviderIds;
+            item.ProviderIds = request.ProviderIds;
+        }
 
         if (item is Video video)
         {

--- a/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class ItemUpdateControllerTests
+{
+    private readonly ItemUpdateController _subject;
+
+    public ItemUpdateControllerTests()
+    {
+        _subject = new ItemUpdateController(
+            Mock.Of<IFileSystem>(),
+            Mock.Of<ILibraryManager>(),
+            Mock.Of<IProviderManager>(),
+            Mock.Of<ILocalizationManager>(),
+            Mock.Of<IServerConfigurationManager>());
+    }
+
+    [Fact]
+    public async Task UpdateItem_WhenOnlyTagsFieldSupplied_DoesNotThrowAndAppliesTags()
+    {
+        // Regression test for https://github.com/jellyfin/jellyfin/issues/17366
+        // A partial update payload that only sets "Tags" leaves every other
+        // BaseItemDto collection property null (they have no default
+        // initializer). Genres and ProviderIds used to be fed straight into
+        // Distinct()/ToList() without a null check, so this call used to throw
+        // ArgumentNullException before the fix below was applied.
+        var movie = new Movie();
+        var request = new BaseItemDto
+        {
+            Tags = new[] { "new-tag-1", "new-tag-2" }
+        };
+
+        await InvokeUpdateItem(request, movie);
+
+        Assert.Equal(new[] { "new-tag-1", "new-tag-2" }, movie.Tags);
+        Assert.Empty(movie.Genres);
+        Assert.Empty(movie.ProviderIds);
+    }
+
+    [Fact]
+    public async Task UpdateItem_WhenGenresAndProviderIdsOmitted_LeavesExistingValuesUnchanged()
+    {
+        var movie = new Movie
+        {
+            Genres = new[] { "Action" }
+        };
+        movie.ProviderIds["Imdb"] = "tt1234567";
+
+        var request = new BaseItemDto
+        {
+            Tags = Array.Empty<string>()
+        };
+
+        await InvokeUpdateItem(request, movie);
+
+        Assert.Equal(new[] { "Action" }, movie.Genres);
+        Assert.Equal("tt1234567", movie.ProviderIds["Imdb"]);
+    }
+
+    private Task InvokeUpdateItem(BaseItemDto request, BaseItem item)
+    {
+        var method = typeof(ItemUpdateController).GetMethod(
+            "UpdateItem",
+            BindingFlags.NonPublic | BindingFlags.Instance,
+            null,
+            new[] { typeof(BaseItemDto), typeof(BaseItem) },
+            null);
+
+        Assert.NotNull(method);
+
+        return (Task)method!.Invoke(_subject, new object[] { request, item })!;
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using Jellyfin.Api.Controllers;
 using MediaBrowser.Controller.Configuration;
@@ -73,15 +72,6 @@ public class ItemUpdateControllerTests
 
     private Task InvokeUpdateItem(BaseItemDto request, BaseItem item)
     {
-        var method = typeof(ItemUpdateController).GetMethod(
-            "UpdateItem",
-            BindingFlags.NonPublic | BindingFlags.Instance,
-            null,
-            new[] { typeof(BaseItemDto), typeof(BaseItem) },
-            null);
-
-        Assert.NotNull(method);
-
-        return (Task)method!.Invoke(_subject, new object[] { request, item })!;
+        return _subject.UpdateItem(request, item);
     }
 }


### PR DESCRIPTION
Fixes #17366

## Root cause

`BaseItemDto.Genres`, `.Tags`, and `.ProviderIds` are plain auto-properties with no default initializer, so they deserialize to `null` when a client's `POST /Items/{itemId}` body omits them — which the OpenAPI spec explicitly allows since every `BaseItemDto` field is optional. `ItemUpdateController.UpdateItem` fed these three properties straight into `Distinct()`/`Select()`/`ToList()` without a null check, so a partial payload that only sets `Tags` throws `ArgumentNullException("source")` as soon as it reaches the unguarded `Genres` line, before `Tags` is even processed.

## Fix

Guard the `Genres`, `Tags`, and `ProviderIds` assignments with the same `if (request.X is not null)` pattern already used for neighboring optional fields (e.g. `Studios`, `Taglines`, `ProductionLocations`) in this method, so an omitted field leaves the existing value unchanged instead of crashing the whole request.

## Test evidence

Added `Jellyfin.Api.Tests.Controllers.ItemUpdateControllerTests` covering:
- The reported repro: a request with only `Tags` populated no longer throws, and the tags are applied.
- A companion case asserting existing `Genres`/`ProviderIds` are preserved when omitted from the payload.

```
Passed Jellyfin.Api.Tests.Controllers.ItemUpdateControllerTests.UpdateItem_WhenGenresAndProviderIdsOmitted_LeavesExistingValuesUnchanged [95 ms]
Passed Jellyfin.Api.Tests.Controllers.ItemUpdateControllerTests.UpdateItem_WhenOnlyTagsFieldSupplied_DoesNotThrowAndAppliesTags [2 ms]
Total tests: 2, Passed: 2
```

Also ran `dotnet format --verify-no-changes --verbosity minimal` locally with no reported changes.

---
Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.