### PR TITLE
Add ListingProviders/Types endpoint

### DIFF
--- a/Jellyfin.Api/Controllers/LiveTvController.cs
+++ b/Jellyfin.Api/Controllers/LiveTvController.cs
@@ -1093,6 +1093,17 @@ public class LiveTvController : BaseJellyfinApiController
         => _tunerHostManager.GetTunerHostTypes();
 
     /// <summary>
+    /// Get listing provider types.
+    /// </summary>
+    /// <response code="200">Listing provider types returned.</response>
+    /// <returns>An <see cref="OkResult"/> containing the listing provider types.</returns>
+    [HttpGet("ListingProviders/Types")]
+    [Authorize(Policy = Policies.LiveTvAccess)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IEnumerable<NameIdPair> GetListingProviderTypes()
+        => _listingsManager.GetListingProviderTypes();
+
+    /// <summary>
     /// Discover tuners.
     /// </summary>
     /// <param name="newDevicesOnly">Only discover new tuners.</param>

--- a/MediaBrowser.Controller/LiveTv/IListingsManager.cs
+++ b/MediaBrowser.Controller/LiveTv/IListingsManager.cs
@@ -14,6 +14,12 @@ namespace MediaBrowser.Controller.LiveTv;
 public interface IListingsManager
 {
     /// <summary>
+    /// Gets the available listing provider types.
+    /// </summary>
+    /// <returns>The available listing provider types.</returns>
+    IEnumerable<NameIdPair> GetListingProviderTypes();
+
+    /// <summary>
     /// Saves the listing provider.
     /// </summary>
     /// <param name="info">The listing provider information.</param>

--- a/src/Jellyfin.LiveTv/Listings/ListingsManager.cs
+++ b/src/Jellyfin.LiveTv/Listings/ListingsManager.cs
@@ -52,6 +52,14 @@ public class ListingsManager : IListingsManager
     }
 
     /// <inheritdoc />
+    public IEnumerable<NameIdPair> GetListingProviderTypes()
+        => _listingsProviders.OrderBy(i => i.Name).Select(i => new NameIdPair
+        {
+            Name = i.Name,
+            Id = i.Type
+        });
+
+    /// <inheritdoc />
     public async Task<ListingsProviderInfo> SaveListingProvider(ListingsProviderInfo info, bool validateLogin, bool validateListings)
     {
         ArgumentNullException.ThrowIfNull(info);


### PR DESCRIPTION
**Changes**
Adds a `ListingProviders/Types` endpoint mirroring the existing `TunerHosts/Types`, so clients can enumerate the available guide provider types (name and id) the same way they already can for tuner hosts. Implemented as `IListingsManager.GetListingProviderTypes()` and exposed on `LiveTvController` next to the tuner-types endpoint. Existing endpoints are unchanged.

Without this, the web client falls back to a hardcoded list and renders any third-party guide provider as "Unknown" with no way to configure it. Motivating case: https://github.com/vk496/jellyfin-htsp-tuner registers a tuner host and a matching HTSP guide provider; the tuner appears by name, the guide provider shows as "Unknown".

**Code assistance**

**Issues**
Part of #17372.
