### PR TITLE
Fix: Prevent resume position from being wiped by 0 stop position

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -434,9 +434,20 @@ namespace Emby.Server.Implementations.Library
             };
         }
 
-        /// <inheritdoc />
-        public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks)
+        private long GetCommittedPositionTicks(Guid itemId, Guid userId)
         {
+            using var dbContext = _repository.CreateDbContext();
+            return dbContext.UserData
+                .Where(e => e.ItemId == itemId && e.UserId == userId)
+                .Select(e => e.PlaybackPositionTicks)
+                .OrderByDescending(t => t)
+                .FirstOrDefault();
+        }
+
+        /// <inheritdoc />
+        public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, User? user = null, bool wasStopped = false)
+        {
+            var previousPositionTicks = data.PlaybackPositionTicks;
             var playedToCompletion = false;
 
             var runtimeTicks = item.GetRunTimeTicksForPlayState();
@@ -493,6 +504,15 @@ namespace Emby.Server.Implementations.Library
                 // If we don't know the runtime we'll just have to assume it was fully played
                 data.Played = playedToCompletion = true;
                 positionTicks = 0;
+            }
+
+            if (wasStopped && reportedPositionTicks == 0 && positionTicks == 0 && !playedToCompletion && user is not null && previousPositionTicks > 0 && item.SupportsPositionTicksResume)
+            {
+                var committedPositionTicks = GetCommittedPositionTicks(item.Id, user.Id);
+                if (committedPositionTicks > 0)
+                {
+                    positionTicks = committedPositionTicks;
+                }
             }
 
             if (!item.SupportsPlayedStatus)

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -445,70 +445,23 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <inheritdoc />
-        public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, User? user = null, bool wasStopped = false)
+        public bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, Guid userId = default, bool wasStopped = false)
         {
             var previousPositionTicks = data.PlaybackPositionTicks;
-            var playedToCompletion = false;
-
             var runtimeTicks = item.GetRunTimeTicksForPlayState();
-
             var positionTicks = reportedPositionTicks ?? runtimeTicks;
-            var hasRuntime = runtimeTicks > 0;
 
-            // If a position has been reported, and if we know the duration
-            if (positionTicks > 0 && hasRuntime && item is not AudioBook && item is not Book)
+            (positionTicks, var playedToCompletion) = ResolveResumePosition(item, positionTicks, runtimeTicks);
+            if (playedToCompletion)
             {
-                var pctIn = decimal.Divide(positionTicks, runtimeTicks) * 100;
-
-                if (pctIn < _config.Configuration.MinResumePct)
-                {
-                    // ignore progress during the beginning
-                    positionTicks = 0;
-                }
-                else if (pctIn > _config.Configuration.MaxResumePct || positionTicks >= (runtimeTicks - TimeSpan.TicksPerSecond))
-                {
-                    // mark as completed close to the end
-                    positionTicks = 0;
-                    data.Played = playedToCompletion = true;
-                }
-                else
-                {
-                    // Enforce MinResumeDuration
-                    var durationSeconds = TimeSpan.FromTicks(runtimeTicks).TotalSeconds;
-                    if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
-                    {
-                        positionTicks = 0;
-                        data.Played = playedToCompletion = true;
-                    }
-                }
-            }
-            else if (positionTicks > 0 && hasRuntime && item is AudioBook)
-            {
-                var playbackPositionInMinutes = TimeSpan.FromTicks(positionTicks).TotalMinutes;
-                var remainingTimeInMinutes = TimeSpan.FromTicks(runtimeTicks - positionTicks).TotalMinutes;
-
-                if (playbackPositionInMinutes < _config.Configuration.MinAudiobookResume)
-                {
-                    // ignore progress during the beginning
-                    positionTicks = 0;
-                }
-                else if (remainingTimeInMinutes < _config.Configuration.MaxAudiobookResume || positionTicks >= runtimeTicks)
-                {
-                    // mark as completed close to the end
-                    positionTicks = 0;
-                    data.Played = playedToCompletion = true;
-                }
-            }
-            else if (!hasRuntime)
-            {
-                // If we don't know the runtime we'll just have to assume it was fully played
-                data.Played = playedToCompletion = true;
-                positionTicks = 0;
+                data.Played = true;
             }
 
-            if (wasStopped && reportedPositionTicks == 0 && positionTicks == 0 && !playedToCompletion && user is not null && previousPositionTicks > 0 && item.SupportsPositionTicksResume)
+            var stoppedAtStartWithoutCompletion = wasStopped && reportedPositionTicks == 0 && positionTicks == 0 && !playedToCompletion;
+            var hasResumableHistory = userId != Guid.Empty && previousPositionTicks > 0 && item.SupportsPositionTicksResume;
+            if (stoppedAtStartWithoutCompletion && hasResumableHistory)
             {
-                var committedPositionTicks = GetCommittedPositionTicks(item.Id, user.Id);
+                var committedPositionTicks = GetCommittedPositionTicks(item.Id, userId);
                 if (committedPositionTicks > 0)
                 {
                     positionTicks = committedPositionTicks;
@@ -529,6 +482,69 @@ namespace Emby.Server.Implementations.Library
             data.PlaybackPositionTicks = positionTicks;
 
             return playedToCompletion;
+        }
+
+        private (long PositionTicks, bool PlayedToCompletion) ResolveResumePosition(BaseItem item, long positionTicks, long runtimeTicks)
+        {
+            var hasRuntime = runtimeTicks > 0;
+
+            if (positionTicks > 0 && hasRuntime && item is not AudioBook && item is not Book)
+            {
+                return ResolveVideoResume(positionTicks, runtimeTicks);
+            }
+
+            if (positionTicks > 0 && hasRuntime && item is AudioBook)
+            {
+                return ResolveAudiobookResume(positionTicks, runtimeTicks);
+            }
+
+            if (!hasRuntime)
+            {
+                return (0, true);
+            }
+
+            return (positionTicks, false);
+        }
+
+        private (long PositionTicks, bool PlayedToCompletion) ResolveVideoResume(long positionTicks, long runtimeTicks)
+        {
+            var pctIn = decimal.Divide(positionTicks, runtimeTicks) * 100;
+
+            if (pctIn < _config.Configuration.MinResumePct)
+            {
+                return (0, false);
+            }
+
+            if (pctIn > _config.Configuration.MaxResumePct || positionTicks >= runtimeTicks - TimeSpan.TicksPerSecond)
+            {
+                return (0, true);
+            }
+
+            var durationSeconds = TimeSpan.FromTicks(runtimeTicks).TotalSeconds;
+            if (durationSeconds < _config.Configuration.MinResumeDurationSeconds)
+            {
+                return (0, true);
+            }
+
+            return (positionTicks, false);
+        }
+
+        private (long PositionTicks, bool PlayedToCompletion) ResolveAudiobookResume(long positionTicks, long runtimeTicks)
+        {
+            var playbackPositionInMinutes = TimeSpan.FromTicks(positionTicks).TotalMinutes;
+            var remainingTimeInMinutes = TimeSpan.FromTicks(runtimeTicks - positionTicks).TotalMinutes;
+
+            if (playbackPositionInMinutes < _config.Configuration.MinAudiobookResume)
+            {
+                return (0, false);
+            }
+
+            if (remainingTimeInMinutes < _config.Configuration.MaxAudiobookResume || positionTicks >= runtimeTicks)
+            {
+                return (0, true);
+            }
+
+            return (positionTicks, false);
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -970,7 +970,7 @@ namespace Emby.Server.Implementations.Session
 
             if (positionTicks.HasValue)
             {
-                _userDataManager.UpdatePlayState(item, data, positionTicks.Value);
+                _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user);
                 changed = true;
             }
 
@@ -1171,7 +1171,7 @@ namespace Emby.Server.Implementations.Session
             bool playedToCompletion;
             if (positionTicks.HasValue)
             {
-                playedToCompletion = _userDataManager.UpdatePlayState(item, data, positionTicks.Value);
+                playedToCompletion = _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user, wasStopped: true);
             }
             else
             {

--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -970,7 +970,7 @@ namespace Emby.Server.Implementations.Session
 
             if (positionTicks.HasValue)
             {
-                _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user);
+                _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user.Id);
                 changed = true;
             }
 
@@ -1171,7 +1171,7 @@ namespace Emby.Server.Implementations.Session
             bool playedToCompletion;
             if (positionTicks.HasValue)
             {
-                playedToCompletion = _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user, wasStopped: true);
+                playedToCompletion = _userDataManager.UpdatePlayState(item, data, positionTicks.Value, user.Id, wasStopped: true);
             }
             else
             {

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -96,10 +96,10 @@ namespace MediaBrowser.Controller.Library
         /// <param name="item">Item to update.</param>
         /// <param name="data">Data to update.</param>
         /// <param name="reportedPositionTicks">New playstate.</param>
-        /// <param name="user">The user.</param>
+        /// <param name="userId">The user id.</param>
         /// <param name="wasStopped">Whether this update was triggered by a playback stop.</param>
         /// <returns>True if playstate was updated.</returns>
-        bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, User? user = null, bool wasStopped = false);
+        bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, Guid userId = default, bool wasStopped = false);
 
         /// <summary>
         /// Clears any stored audio and subtitle stream selections for the given user/item pair.

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -96,8 +96,10 @@ namespace MediaBrowser.Controller.Library
         /// <param name="item">Item to update.</param>
         /// <param name="data">Data to update.</param>
         /// <param name="reportedPositionTicks">New playstate.</param>
+        /// <param name="user">The user.</param>
+        /// <param name="wasStopped">Whether this update was triggered by a playback stop.</param>
         /// <returns>True if playstate was updated.</returns>
-        bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks);
+        bool UpdatePlayState(BaseItem item, UserItemData data, long? reportedPositionTicks, User? user = null, bool wasStopped = false);
 
         /// <summary>
         /// Clears any stored audio and subtitle stream selections for the given user/item pair.

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Emby.Server.Implementations.Library;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
@@ -7,6 +8,7 @@ using Jellyfin.Database.Implementations.Locking;
 using Jellyfin.Database.Providers.Sqlite;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Model.Configuration;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -38,11 +40,20 @@ public sealed class UserDataManagerTests : IDisposable
             ctx.Database.EnsureCreated();
         }
 
+        var config = new Mock<IServerConfigurationManager>();
+        config.SetupGet(c => c.Configuration).Returns(new ServerConfiguration
+        {
+            MinResumePct = 5,
+            MaxResumePct = 90,
+            MinResumeDurationSeconds = 300,
+            MinAudiobookResume = 5,
+            MaxAudiobookResume = 5
+        });
+
         var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
         factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
-
-        var config = new Mock<IServerConfigurationManager>();
-        config.SetupGet(c => c.Configuration).Returns(new ServerConfiguration());
+        factory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateDbContext);
 
         _userDataManager = new UserDataManager(config.Object, factory.Object);
         _user = new User("user", "auth-provider", "reset-provider")
@@ -65,6 +76,23 @@ public sealed class UserDataManagerTests : IDisposable
             new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
     }
 
+    private void SeedCommittedPosition(Guid itemId, Guid userId, long positionTicks)
+    {
+        using var dbContext = CreateDbContext();
+        dbContext.BaseItems.Add(new BaseItemEntity { Id = itemId, Type = typeof(AudioBook).FullName! });
+        dbContext.Users.Add(new User("seed-user", "default", "default") { Id = userId });
+        dbContext.UserData.Add(new UserData
+        {
+            ItemId = itemId,
+            UserId = userId,
+            CustomDataKey = "test-key",
+            PlaybackPositionTicks = positionTicks,
+            Item = null,
+            User = null
+        });
+        dbContext.SaveChanges();
+    }
+
     private AudioBook CreateAudioBook()
     {
         // GetUserDataKeys(): ["Author-Series-0001Book Title", "<item id N>"]
@@ -78,6 +106,22 @@ public sealed class UserDataManagerTests : IDisposable
         };
     }
 
+    private static AudioBook CreateAudioBook(TimeSpan runtime)
+    {
+        return new AudioBook
+        {
+            RunTimeTicks = runtime.Ticks
+        };
+    }
+
+    private static Movie CreateMovie(TimeSpan runtime)
+    {
+        return new Movie
+        {
+            RunTimeTicks = runtime.Ticks
+        };
+    }
+
     private UserData CreateUserDataRow(AudioBook item, string key, long positionTicks)
     {
         return new UserData
@@ -87,6 +131,15 @@ public sealed class UserDataManagerTests : IDisposable
             UserId = _user.Id,
             User = null,
             CustomDataKey = key,
+            PlaybackPositionTicks = positionTicks
+        };
+    }
+
+    private static UserItemData CreateUserData(long positionTicks)
+    {
+        return new UserItemData
+        {
+            Key = "test-key",
             PlaybackPositionTicks = positionTicks
         };
     }
@@ -205,5 +258,151 @@ public sealed class UserDataManagerTests : IDisposable
 
         Assert.Equal(222, result[fossilItem.Id].PlaybackPositionTicks);
         Assert.Equal(333, result[retiredItem.Id].PlaybackPositionTicks);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearStartReportAfterLongResume_ResetsToZero()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, TimeSpan.FromSeconds(20).Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+        Assert.False(data.Played);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearStartReportWithNoExistingResume_StaysZero()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var data = CreateUserData(0);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, TimeSpan.FromSeconds(20).Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookLiteralZeroReportAfterLongResume_HonorsExplicitRestart()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookStopAtZeroAfterResume_PreservesResume()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(18));
+        item.Id = Guid.NewGuid();
+        var existingResume = TimeSpan.FromHours(4) + TimeSpan.FromMinutes(18);
+        var data = CreateUserData(existingResume.Ticks);
+        var user = new User("test", "default", "default");
+        SeedCommittedPosition(item.Id, user.Id, existingResume.Ticks);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user, wasStopped: true);
+
+        Assert.Equal(existingResume.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+        Assert.False(data.Played);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookProgressAtZeroAfterResume_HonorsRestart()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(18));
+        var existingResume = TimeSpan.FromHours(4) + TimeSpan.FromMinutes(18);
+        var data = CreateUserData(existingResume.Ticks);
+        var user = new User("test", "default", "default");
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user, wasStopped: false);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNormalForwardProgress_UpdatesPosition()
+    {
+        var item = CreateAudioBook(TimeSpan.FromHours(16));
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromHours(6);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(reported.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_AudioBookNearEndReport_MarksCompletedAndClearsResume()
+    {
+        var runtime = TimeSpan.FromHours(16);
+        var item = CreateAudioBook(runtime);
+        var existingResume = TimeSpan.FromHours(5) + TimeSpan.FromMinutes(49);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = runtime - TimeSpan.FromMinutes(2);
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.True(playedToCompletion);
+        Assert.True(data.Played);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieBelowMinResumePctAfterHalfwayResume_ResetsToZero()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.01));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieGenuineBackwardSeek_PreservesReportedPosition()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.40));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(reported.Ticks, data.PlaybackPositionTicks);
+        Assert.False(playedToCompletion);
+    }
+
+    [Fact]
+    public void UpdatePlayState_MovieAboveMaxResumePct_MarksCompletedAndClearsResume()
+    {
+        var runtime = TimeSpan.FromHours(2);
+        var item = CreateMovie(runtime);
+        var existingResume = TimeSpan.FromTicks(runtime.Ticks / 2);
+        var data = CreateUserData(existingResume.Ticks);
+        var reported = TimeSpan.FromTicks((long)(runtime.Ticks * 0.96));
+
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, reported.Ticks);
+
+        Assert.Equal(0, data.PlaybackPositionTicks);
+        Assert.True(playedToCompletion);
+        Assert.True(data.Played);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -309,7 +309,7 @@ public sealed class UserDataManagerTests : IDisposable
         var user = new User("test", "default", "default");
         SeedCommittedPosition(item.Id, user.Id, existingResume.Ticks);
 
-        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user, wasStopped: true);
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user.Id, wasStopped: true);
 
         Assert.Equal(existingResume.Ticks, data.PlaybackPositionTicks);
         Assert.False(playedToCompletion);
@@ -324,7 +324,7 @@ public sealed class UserDataManagerTests : IDisposable
         var data = CreateUserData(existingResume.Ticks);
         var user = new User("test", "default", "default");
 
-        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user, wasStopped: false);
+        var playedToCompletion = _userDataManager.UpdatePlayState(item, data, 0, user.Id, wasStopped: false);
 
         Assert.Equal(0, data.PlaybackPositionTicks);
         Assert.False(playedToCompletion);


### PR DESCRIPTION
**Changes**
There's a bug on the Android app where a harsh bluetooth disconnect sends a stop position of 0ms. If the client doesn't continue playing afterwards, it will store their current position at 0. Regardless of whether the Android issue gets fixed, the server should be able to determine in the vast majority of cases whether the 0 position is intended or not.

**Code assistance**
Opus wrote the tests for me; I wrote the non test code

**Issues**
https://github.com/jellyfin/jellyfin-android/issues/2084

**Notes**
I previously had [this](https://github.com/jellyfin/jellyfin/pull/17226) fix, but that was when I thought the issue was for near zero, not actually zero.
