### PR TITLE
Add XML docs to small entity interfaces and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Controller/Entities/IHasSpecialFeatures.cs
+++ b/MediaBrowser.Controller/Entities/IHasSpecialFeatures.cs
@@ -1,12 +1,13 @@
 #nullable disable
 
-#pragma warning disable CS1591
-
 using System;
 using System.Collections.Generic;
 
 namespace MediaBrowser.Controller.Entities
 {
+    /// <summary>
+    /// Interface for items that have special features.
+    /// </summary>
     public interface IHasSpecialFeatures
     {
         /// <summary>

--- a/MediaBrowser.Controller/Entities/IHasStartDate.cs
+++ b/MediaBrowser.Controller/Entities/IHasStartDate.cs
@@ -1,11 +1,15 @@
-#pragma warning disable CS1591
-
 using System;
 
 namespace MediaBrowser.Controller.Entities
 {
+    /// <summary>
+    /// Interface for items that have a start date.
+    /// </summary>
     public interface IHasStartDate
     {
+        /// <summary>
+        /// Gets or sets the start date.
+        /// </summary>
         DateTime StartDate { get; set; }
     }
 }

--- a/MediaBrowser.Controller/Entities/IItemByName.cs
+++ b/MediaBrowser.Controller/Entities/IItemByName.cs
@@ -1,19 +1,28 @@
-#pragma warning disable CS1591
-
 using System.Collections.Generic;
 
 namespace MediaBrowser.Controller.Entities
 {
     /// <summary>
-    /// Marker interface.
+    /// Marker interface for items that represent a name, like a genre or a studio.
     /// </summary>
     public interface IItemByName
     {
+        /// <summary>
+        /// Gets the items tagged with this name.
+        /// </summary>
+        /// <param name="query">The query.</param>
+        /// <returns>The tagged items.</returns>
         IReadOnlyList<BaseItem> GetTaggedItems(InternalItemsQuery query);
     }
 
+    /// <summary>
+    /// Interface for by-name items that can also be accessed as a regular library item.
+    /// </summary>
     public interface IHasDualAccess : IItemByName
     {
+        /// <summary>
+        /// Gets a value indicating whether the item is accessed by name.
+        /// </summary>
         bool IsAccessedByName { get; }
     }
 }

--- a/MediaBrowser.Controller/Entities/ISupportsPlaceHolders.cs
+++ b/MediaBrowser.Controller/Entities/ISupportsPlaceHolders.cs
@@ -1,7 +1,8 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Entities
 {
+    /// <summary>
+    /// Interface for items that can be placeholders.
+    /// </summary>
     public interface ISupportsPlaceHolders
     {
         /// <summary>

--- a/MediaBrowser.Controller/Entities/SourceType.cs
+++ b/MediaBrowser.Controller/Entities/SourceType.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Controller.Entities
 {
+    /// <summary>
+    /// The source of an item.
+    /// </summary>
     public enum SourceType
     {
+        /// <summary>
+        /// The item comes from a library.
+        /// </summary>
         Library = 0,
+
+        /// <summary>
+        /// The item comes from a channel.
+        /// </summary>
         Channel = 1,
+
+        /// <summary>
+        /// The item comes from live TV.
+        /// </summary>
         LiveTV = 2
     }
 }


### PR DESCRIPTION
**Changes**

Adds XML documentation to five small files in `MediaBrowser.Controller.Entities` (`IHasStartDate`, `SourceType`, `ISupportsPlaceHolders`, `IHasSpecialFeatures`, `IItemByName`/`IHasDualAccess`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149