### PR TITLE
Add XML docs to small model enums and remove CS1591 suppressions

### DIFF
--- a/MediaBrowser.Model/Configuration/ImageSavingConvention.cs
+++ b/MediaBrowser.Model/Configuration/ImageSavingConvention.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Configuration
 {
+    /// <summary>
+    /// The convention used for naming saved images.
+    /// </summary>
     public enum ImageSavingConvention
     {
+        /// <summary>
+        /// The legacy naming convention.
+        /// </summary>
         Legacy,
+
+        /// <summary>
+        /// The naming convention compatible with other media servers and metadata managers.
+        /// </summary>
         Compatible
     }
 }

--- a/MediaBrowser.Model/Dto/IHasServerId.cs
+++ b/MediaBrowser.Model/Dto/IHasServerId.cs
@@ -1,10 +1,15 @@
 #nullable disable
-#pragma warning disable CS1591
 
 namespace MediaBrowser.Model.Dto
 {
+    /// <summary>
+    /// Interface for DTOs that reference the id of the server they originate from.
+    /// </summary>
     public interface IHasServerId
     {
+        /// <summary>
+        /// Gets the server id.
+        /// </summary>
         string ServerId { get; }
     }
 }

--- a/MediaBrowser.Model/Dto/MediaSourceType.cs
+++ b/MediaBrowser.Model/Dto/MediaSourceType.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dto
 {
+    /// <summary>
+    /// The type of a media source.
+    /// </summary>
     public enum MediaSourceType
     {
+        /// <summary>
+        /// A default media source.
+        /// </summary>
         Default = 0,
+
+        /// <summary>
+        /// A grouping of media sources.
+        /// </summary>
         Grouping = 1,
+
+        /// <summary>
+        /// A placeholder media source, for example a disc that has to be inserted.
+        /// </summary>
         Placeholder = 2
     }
 }

--- a/MediaBrowser.Model/Dto/RatingType.cs
+++ b/MediaBrowser.Model/Dto/RatingType.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Dto
 {
+    /// <summary>
+    /// The type of a community rating.
+    /// </summary>
     public enum RatingType
     {
+        /// <summary>
+        /// The rating is a numeric score.
+        /// </summary>
         Score,
+
+        /// <summary>
+        /// The rating is based on likes.
+        /// </summary>
         Likes
     }
 }

--- a/MediaBrowser.Model/Library/PlayAccess.cs
+++ b/MediaBrowser.Model/Library/PlayAccess.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.Library
 {
+    /// <summary>
+    /// The play access of an item.
+    /// </summary>
     public enum PlayAccess
     {
+        /// <summary>
+        /// The item can be played.
+        /// </summary>
         Full = 0,
+
+        /// <summary>
+        /// The item cannot be played.
+        /// </summary>
         None = 1
     }
 }

--- a/MediaBrowser.Model/LiveTv/DayPattern.cs
+++ b/MediaBrowser.Model/LiveTv/DayPattern.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.LiveTv
 {
+    /// <summary>
+    /// The day pattern of a recurring timer.
+    /// </summary>
     public enum DayPattern
     {
+        /// <summary>
+        /// Every day.
+        /// </summary>
         Daily,
+
+        /// <summary>
+        /// Monday through Friday.
+        /// </summary>
         Weekdays,
+
+        /// <summary>
+        /// Saturday and Sunday.
+        /// </summary>
         Weekends
     }
 }

--- a/MediaBrowser.Model/LiveTv/LiveTvServiceStatus.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvServiceStatus.cs
@@ -1,10 +1,18 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.LiveTv
 {
+    /// <summary>
+    /// The status of a live TV service.
+    /// </summary>
     public enum LiveTvServiceStatus
     {
+        /// <summary>
+        /// The service is available.
+        /// </summary>
         Ok = 0,
+
+        /// <summary>
+        /// The service is unavailable.
+        /// </summary>
         Unavailable = 1
     }
 }

--- a/MediaBrowser.Model/MediaInfo/TransportStreamTimestamp.cs
+++ b/MediaBrowser.Model/MediaInfo/TransportStreamTimestamp.cs
@@ -1,11 +1,23 @@
-#pragma warning disable CS1591
-
 namespace MediaBrowser.Model.MediaInfo
 {
+    /// <summary>
+    /// The type of timestamps used in a transport stream.
+    /// </summary>
     public enum TransportStreamTimestamp
     {
+        /// <summary>
+        /// The stream contains no timestamps.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// The stream contains zero-value timestamps.
+        /// </summary>
         Zero,
+
+        /// <summary>
+        /// The stream contains valid timestamps.
+        /// </summary>
         Valid
     }
 }


### PR DESCRIPTION
**Changes**

Adds XML documentation to eight small types in `MediaBrowser.Model` (`RatingType`, `MediaSourceType`, `IHasServerId`, `PlayAccess`, `ImageSavingConvention`, `LiveTvServiceStatus`, `DayPattern`, `TransportStreamTimestamp`) and removes the `#pragma warning disable CS1591` suppressions from those files.

**Issues**

Part of #2149