### PR TITLE
Exempt people from the allowed tags visibility check

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -447,6 +447,7 @@ public sealed partial class BaseItemRepository
         if (filter.IncludeInheritedTags.Length > 0)
         {
             var includeTags = filter.IncludeInheritedTags.Select(e => e.GetCleanValue()).ToArray();
+            var personTypeName = _itemTypeLookup.BaseItemKindNames[BaseItemKind.Person];
             var allowedTagItemIds = context.ItemValuesMap
                 .Where(f => f.ItemValue.Type == ItemValueType.Tags && includeTags.Contains(f.ItemValue.CleanValue))
                 .Select(f => f.ItemId);
@@ -455,7 +456,10 @@ public sealed partial class BaseItemRepository
                 allowedTagItemIds.Contains(e.Id)
                 || (e.SeriesId.HasValue && allowedTagItemIds.Contains(e.SeriesId.Value))
                 || e.Parents!.Any(p => allowedTagItemIds.Contains(p.ParentItemId))
-                || (e.TopParentId.HasValue && allowedTagItemIds.Contains(e.TopParentId.Value)));
+                || (e.TopParentId.HasValue && allowedTagItemIds.Contains(e.TopParentId.Value))
+
+                // People don't carry the tags of the media they appear in and would never match
+                || e.Type == personTypeName);
         }
 
         // Exclude alternate versions (have PrimaryVersionId set) and owned non-extra items.

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -1084,6 +1084,7 @@ public sealed partial class BaseItemRepository
         {
             var includeTags = filter.IncludeInheritedTags.Select(e => e.GetCleanValue()).ToArray();
             var isPlaylistOnlyQuery = includeTypes.Length == 1 && includeTypes.FirstOrDefault() == BaseItemKind.Playlist;
+            var personTypeName = _itemTypeLookup.BaseItemKindNames[BaseItemKind.Person];
             var allowedTagItemIds = context.ItemValuesMap
                 .Where(f => f.ItemValue.Type == ItemValueType.Tags && includeTags.Contains(f.ItemValue.CleanValue))
                 .Select(f => f.ItemId);
@@ -1093,6 +1094,9 @@ public sealed partial class BaseItemRepository
                 || (e.SeriesId.HasValue && allowedTagItemIds.Contains(e.SeriesId.Value))
                 || e.Parents!.Any(p => allowedTagItemIds.Contains(p.ParentItemId))
                 || (e.TopParentId.HasValue && allowedTagItemIds.Contains(e.TopParentId.Value))
+
+                // People don't carry the tags of the media they appear in and would never match
+                || e.Type == personTypeName
 
                 // A playlist should be accessible to its owner regardless of allowed tags
                 || (isPlaylistOnlyQuery && e.Data!.Contains($"OwnerUserId\":\"{filter.User!.Id:N}\"")));

--- a/MediaBrowser.Controller/Entities/Person.cs
+++ b/MediaBrowser.Controller/Entities/Person.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Providers;
 using Microsoft.Extensions.Logging;
@@ -73,6 +74,16 @@ namespace MediaBrowser.Controller.Entities
         public override bool CanDelete()
         {
             return false;
+        }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// People don't carry the tags of the media they appear in, so the allowed tags check
+        /// is skipped for them; otherwise no person would be visible to users with allowed tags configured.
+        /// </remarks>
+        public override bool IsVisible(User user, bool skipAllowedTagsCheck = false)
+        {
+            return base.IsVisible(user, true);
         }
 
         public override bool IsSaveLocalMetadataEnabled()


### PR DESCRIPTION
**Changes**

When a user has "Allow items with tags" configured, the tag filter was also applied to `Person` items. People never carry the tags of the media they appear in, so for those users the Cast & Crew section disappeared entirely and searching for any person returned no results.

This exempts people from the allowed tags check in the three places it was applied:

- `Person` now overrides `IsVisible` and skips the allowed tags part of the check. Blocked tags and parental ratings still apply, so nothing that parental controls are meant to protect is weakened. This fixes the Cast & Crew section (filtered in `DtoService.AttachPeople`) and `/Persons` (filtered in `LibraryManager.GetPeopleItems`).
- The allowed-tags predicate in `BaseItemRepository.TranslateQuery` and `BaseItemRepository.ApplyAccessFiltering` no longer filters out `Person` rows (analogous to the existing playlist owner exemption), which fixes person search.

**Issues**

Fixes #14926