### PR TITLE
Fix music and series full library metadata refresh hang by handrolling a working implementation from movies library refresh

### DIFF
--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -192,10 +192,17 @@ namespace MediaBrowser.Controller.Entities.Audio
                         childUpdateType |= updateType;
                     }
                 }
-                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException ex)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // The caller's token was cancelled, not our own timeout. Propagate it.
+                        throw;
+                    }
+
                     Interlocked.Increment(ref numFailed);
                     Logger.LogError(
+                        ex,
                         "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in album '{AlbumName}'. Skipping this item and continuing with the rest of the album.",
                         _childMetadataRefreshTimeout,
                         item.GetType().Name,
@@ -203,7 +210,7 @@ namespace MediaBrowser.Controller.Entities.Audio
                         item.Path,
                         Name);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (Exception ex)
                 {
                     Interlocked.Increment(ref numFailed);
                     Logger.LogError(

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -232,6 +232,10 @@ namespace MediaBrowser.Controller.Entities.Audio
                     cancellationToken)
                 .ConfigureAwait(false);
 
+            // numFailed is mutated via Interlocked.Increment inside RefreshChildAsync, which the scheduler invokes
+            // through a delegate the analyzer cannot trace into. The preceding await on Enqueue (which awaits all
+            // worker tasks) establishes a happens-before relationship, so the value read here is correctly synchronized.
+#pragma warning disable S2583
             if (numFailed > 0)
             {
                 Logger.LogWarning(
@@ -240,6 +244,7 @@ namespace MediaBrowser.Controller.Entities.Audio
                     numFailed,
                     items.Count);
             }
+#pragma warning restore S2583
 
             var parentRefreshOptions = refreshOptions;
             if (childUpdateType > ItemUpdateType.None)

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -27,6 +27,13 @@ namespace MediaBrowser.Controller.Entities.Audio
     [Common.RequiresSourceSerialisation]
     public class MusicAlbum : Folder, IHasAlbumArtist, IHasArtist, IHasMusicGenres, IHasLookupInfo<AlbumInfo>, IMetadataContainer
     {
+        /// <summary>
+        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
+        /// A single slow or stuck provider call must not be allowed to stall the entire album refresh
+        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// </summary>
+        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
+
         public MusicAlbum()
         {
             Artists = Array.Empty<string>();
@@ -163,13 +170,6 @@ namespace MediaBrowser.Controller.Entities.Audio
 
             return id;
         }
-
-        /// <summary>
-        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
-        /// A single slow or stuck provider call must not be allowed to stall the entire album refresh
-        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
-        /// </summary>
-        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
 
         public async Task RefreshAllMetadata(MetadataRefreshOptions refreshOptions, IProgress<double> progress, CancellationToken cancellationToken)
         {

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -16,6 +16,7 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
 using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
 
 namespace MediaBrowser.Controller.Entities.Audio
@@ -163,26 +164,74 @@ namespace MediaBrowser.Controller.Entities.Audio
             return id;
         }
 
+        /// <summary>
+        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
+        /// A single slow or stuck provider call must not be allowed to stall the entire album refresh
+        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// </summary>
+        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
+
         public async Task RefreshAllMetadata(MetadataRefreshOptions refreshOptions, IProgress<double> progress, CancellationToken cancellationToken)
         {
             var items = GetRecursiveChildren();
 
-            var totalItems = items.Count;
-            var numComplete = 0;
-
             var childUpdateType = ItemUpdateType.None;
+            var updateTypeLock = new object();
+            var numFailed = 0;
 
-            foreach (var item in items)
+            async Task RefreshChildAsync(BaseItem item)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(_childMetadataRefreshTimeout);
 
-                var updateType = await item.RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
-                childUpdateType = childUpdateType | updateType;
+                try
+                {
+                    var updateType = await item.RefreshMetadata(refreshOptions, timeoutCts.Token).ConfigureAwait(false);
+                    lock (updateTypeLock)
+                    {
+                        childUpdateType |= updateType;
+                    }
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref numFailed);
+                    Logger.LogError(
+                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in album '{AlbumName}'. Skipping this item and continuing with the rest of the album.",
+                        _childMetadataRefreshTimeout,
+                        item.GetType().Name,
+                        item.Name,
+                        item.Path,
+                        Name);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Interlocked.Increment(ref numFailed);
+                    Logger.LogError(
+                        ex,
+                        "Error refreshing metadata for {ItemType} '{ItemName}' ({Path}) in album '{AlbumName}'. Skipping this item and continuing with the rest of the album.",
+                        item.GetType().Name,
+                        item.Name,
+                        item.Path,
+                        Name);
+                }
+            }
 
-                numComplete++;
-                double percent = numComplete;
-                percent /= totalItems;
-                progress.Report(percent * 95);
+            var itemsProgress = new Progress<double>(p => progress.Report(p * 0.95));
+            await LimitedConcurrencyLibraryScheduler
+                .Enqueue(
+                    items.ToArray(),
+                    (item, _) => RefreshChildAsync(item),
+                    itemsProgress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (numFailed > 0)
+            {
+                Logger.LogWarning(
+                    "Finished refreshing metadata for album '{AlbumName}': {FailedCount} of {TotalCount} child items failed or timed out and were skipped.",
+                    Name,
+                    numFailed,
+                    items.Count);
             }
 
             var parentRefreshOptions = refreshOptions;

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CA1721, CA1826, CS1591
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -28,9 +29,7 @@ namespace MediaBrowser.Controller.Entities.Audio
     public class MusicAlbum : Folder, IHasAlbumArtist, IHasArtist, IHasMusicGenres, IHasLookupInfo<AlbumInfo>, IMetadataContainer
     {
         /// <summary>
-        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
-        /// A single slow or stuck provider call must not be allowed to stall the entire album refresh
-        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// Maximum time a single child item's metadata refresh may run before it is abandoned.
         /// </summary>
         private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
 
@@ -176,8 +175,8 @@ namespace MediaBrowser.Controller.Entities.Audio
             var items = GetRecursiveChildren();
 
             var childUpdateType = ItemUpdateType.None;
-            var updateTypeLock = new object();
-            var numFailed = 0;
+            var updateTypeLock = new Lock();
+            var failedItems = new ConcurrentBag<BaseItem>();
 
             async Task RefreshChildAsync(BaseItem item)
             {
@@ -192,34 +191,26 @@ namespace MediaBrowser.Controller.Entities.Audio
                         childUpdateType |= updateType;
                     }
                 }
-                catch (OperationCanceledException ex)
+                catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        // The caller's token was cancelled, not our own timeout. Propagate it.
-                        throw;
-                    }
-
-                    Interlocked.Increment(ref numFailed);
+                    failedItems.Add(item);
                     Logger.LogError(
                         ex,
-                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in album '{AlbumName}'. Skipping this item and continuing with the rest of the album.",
+                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({ItemPath})",
                         _childMetadataRefreshTimeout,
                         item.GetType().Name,
                         item.Name,
-                        item.Path,
-                        Name);
+                        item.Path);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    Interlocked.Increment(ref numFailed);
+                    failedItems.Add(item);
                     Logger.LogError(
                         ex,
-                        "Error refreshing metadata for {ItemType} '{ItemName}' ({Path}) in album '{AlbumName}'. Skipping this item and continuing with the rest of the album.",
+                        "Error refreshing metadata for {ItemType} '{ItemName}' ({ItemPath})",
                         item.GetType().Name,
                         item.Name,
-                        item.Path,
-                        Name);
+                        item.Path);
                 }
             }
 
@@ -232,19 +223,14 @@ namespace MediaBrowser.Controller.Entities.Audio
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            // numFailed is mutated via Interlocked.Increment inside RefreshChildAsync, which the scheduler invokes
-            // through a delegate the analyzer cannot trace into. The preceding await on Enqueue (which awaits all
-            // worker tasks) establishes a happens-before relationship, so the value read here is correctly synchronized.
-#pragma warning disable S2583
-            if (numFailed > 0)
+            if (!failedItems.IsEmpty)
             {
                 Logger.LogWarning(
-                    "Finished refreshing metadata for album '{AlbumName}': {FailedCount} of {TotalCount} child items failed or timed out and were skipped.",
-                    Name,
-                    numFailed,
-                    items.Count);
+                    "Failed to refresh metadata for {FailedCount} of {TotalCount} child items in album '{AlbumName}'",
+                    failedItems.Count,
+                    items.Count,
+                    Name);
             }
-#pragma warning restore S2583
 
             var parentRefreshOptions = refreshOptions;
             if (childUpdateType > ItemUpdateType.None)

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -17,6 +17,7 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
+using Microsoft.Extensions.Logging;
 using MetadataProvider = MediaBrowser.Model.Entities.MetadataProvider;
 
 namespace MediaBrowser.Controller.Entities.TV
@@ -297,66 +298,103 @@ namespace MediaBrowser.Controller.Entities.TV
             return allEpisodes.DistinctBy(i => i.Id).Reverse();
         }
 
+        /// <summary>
+        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
+        /// A single slow or stuck provider call must not be allowed to stall the entire series refresh
+        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// </summary>
+        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
+
         public async Task RefreshAllMetadata(MetadataRefreshOptions refreshOptions, IProgress<double> progress, CancellationToken cancellationToken)
         {
             Children = null; // invalidate cached children.
             // Refresh bottom up, seasons and episodes first, then the series
             var items = GetRecursiveChildren();
 
+            var seasons = items.OfType<Season>().ToArray();
+            var others = items.Where(i => i is not Season).ToArray();
+
             var totalItems = items.Count;
-            var numComplete = 0;
+            var seasonsShare = totalItems == 0 ? 0 : (seasons.Length * 100d) / totalItems;
+            var numFailed = 0;
 
-            // Refresh seasons
-            foreach (var item in items)
+            async Task RefreshChildAsync(BaseItem item, bool skip)
             {
-                if (item is not Season)
+                if (skip || !refreshOptions.RefreshItem(item))
                 {
-                    continue;
+                    return;
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(_childMetadataRefreshTimeout);
 
-                if (refreshOptions.RefreshItem(item))
+                try
                 {
-                    await item.RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
+                    await item.RefreshMetadata(refreshOptions, timeoutCts.Token).ConfigureAwait(false);
                 }
-
-                numComplete++;
-                double percent = numComplete;
-                percent /= totalItems;
-                progress.Report(percent * 100);
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref numFailed);
+                    Logger.LogError(
+                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in series '{SeriesName}'. Skipping this item and continuing with the rest of the series.",
+                        _childMetadataRefreshTimeout,
+                        item.GetType().Name,
+                        item.Name,
+                        item.Path,
+                        Name);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Interlocked.Increment(ref numFailed);
+                    Logger.LogError(
+                        ex,
+                        "Error refreshing metadata for {ItemType} '{ItemName}' ({Path}) in series '{SeriesName}'. Skipping this item and continuing with the rest of the series.",
+                        item.GetType().Name,
+                        item.Name,
+                        item.Path,
+                        Name);
+                }
             }
 
+            // Refresh seasons first (bounded concurrency via the shared library scheduler), then episodes and other children.
+            // Seasons must exist before episodes are (re)parented against them, so these two phases stay sequential relative to each other.
+            var seasonsProgress = new Progress<double>(p => progress.Report(seasonsShare * (p / 100)));
+            await LimitedConcurrencyLibraryScheduler
+                .Enqueue(
+                    seasons,
+                    (item, _) => RefreshChildAsync(item, skip: false),
+                    seasonsProgress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
             // Refresh episodes and other children
-            foreach (var item in items)
-            {
-                if (item is Season)
-                {
-                    continue;
-                }
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                bool skipItem = item is Episode episode
-                    && refreshOptions.MetadataRefreshMode != MetadataRefreshMode.FullRefresh
-                    && !refreshOptions.ReplaceAllMetadata
-                    && episode.IsMissingEpisode
-                    && episode.LocationType == LocationType.Virtual
-                    && episode.PremiereDate.HasValue
-                    && (DateTime.UtcNow - episode.PremiereDate.Value).TotalDays > 30;
-
-                if (!skipItem)
-                {
-                    if (refreshOptions.RefreshItem(item))
+            var othersProgress = new Progress<double>(p => progress.Report(seasonsShare + ((100 - seasonsShare) * (p / 100))));
+            await LimitedConcurrencyLibraryScheduler
+                .Enqueue(
+                    others,
+                    (item, _) =>
                     {
-                        await item.RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
-                    }
-                }
+                        bool skipItem = item is Episode episode
+                            && refreshOptions.MetadataRefreshMode != MetadataRefreshMode.FullRefresh
+                            && !refreshOptions.ReplaceAllMetadata
+                            && episode.IsMissingEpisode
+                            && episode.LocationType == LocationType.Virtual
+                            && episode.PremiereDate.HasValue
+                            && (DateTime.UtcNow - episode.PremiereDate.Value).TotalDays > 30;
 
-                numComplete++;
-                double percent = numComplete;
-                percent /= totalItems;
-                progress.Report(percent * 100);
+                        return RefreshChildAsync(item, skipItem);
+                    },
+                    othersProgress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (numFailed > 0)
+            {
+                Logger.LogWarning(
+                    "Finished refreshing metadata for series '{SeriesName}': {FailedCount} of {TotalCount} child items failed or timed out and were skipped.",
+                    Name,
+                    numFailed,
+                    totalItems);
             }
 
             refreshOptions = new MetadataRefreshOptions(refreshOptions);

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -27,6 +27,13 @@ namespace MediaBrowser.Controller.Entities.TV
     /// </summary>
     public class Series : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<SeriesInfo>, IMetadataContainer, ISupportsBoxSetGrouping
     {
+        /// <summary>
+        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
+        /// A single slow or stuck provider call must not be allowed to stall the entire series refresh
+        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// </summary>
+        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
+
         public Series()
         {
             AirDays = Array.Empty<DayOfWeek>();
@@ -297,13 +304,6 @@ namespace MediaBrowser.Controller.Entities.TV
 
             return allEpisodes.DistinctBy(i => i.Id).Reverse();
         }
-
-        /// <summary>
-        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
-        /// A single slow or stuck provider call must not be allowed to stall the entire series refresh
-        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
-        /// </summary>
-        private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
 
         public async Task RefreshAllMetadata(MetadataRefreshOptions refreshOptions, IProgress<double> progress, CancellationToken cancellationToken)
         {

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -332,10 +332,17 @@ namespace MediaBrowser.Controller.Entities.TV
                 {
                     await item.RefreshMetadata(refreshOptions, timeoutCts.Token).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                catch (OperationCanceledException ex)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        // The caller's token was cancelled, not our own timeout. Propagate it.
+                        throw;
+                    }
+
                     Interlocked.Increment(ref numFailed);
                     Logger.LogError(
+                        ex,
                         "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in series '{SeriesName}'. Skipping this item and continuing with the rest of the series.",
                         _childMetadataRefreshTimeout,
                         item.GetType().Name,
@@ -343,7 +350,7 @@ namespace MediaBrowser.Controller.Entities.TV
                         item.Path,
                         Name);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (Exception ex)
                 {
                     Interlocked.Increment(ref numFailed);
                     Logger.LogError(

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -28,9 +29,7 @@ namespace MediaBrowser.Controller.Entities.TV
     public class Series : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<SeriesInfo>, IMetadataContainer, ISupportsBoxSetGrouping
     {
         /// <summary>
-        /// Maximum time a single child item's metadata refresh is allowed to run before it is abandoned as hung.
-        /// A single slow or stuck provider call must not be allowed to stall the entire series refresh
-        /// (see <see cref="MediaBrowser.Controller.LibraryTaskScheduler.ILimitedConcurrencyLibraryScheduler"/>, which bounds how many run at once but not how long any one of them may take).
+        /// Maximum time a single child item's metadata refresh may run before it is abandoned.
         /// </summary>
         private static readonly TimeSpan _childMetadataRefreshTimeout = TimeSpan.FromSeconds(60);
 
@@ -316,11 +315,19 @@ namespace MediaBrowser.Controller.Entities.TV
 
             var totalItems = items.Count;
             var seasonsShare = totalItems == 0 ? 0 : (seasons.Length * 100d) / totalItems;
-            var numFailed = 0;
+            var failedItems = new ConcurrentBag<BaseItem>();
 
-            async Task RefreshChildAsync(BaseItem item, bool skip)
+            async Task RefreshChildAsync(BaseItem item)
             {
-                if (skip || !refreshOptions.RefreshItem(item))
+                var skipItem = item is Episode episode
+                    && refreshOptions.MetadataRefreshMode != MetadataRefreshMode.FullRefresh
+                    && !refreshOptions.ReplaceAllMetadata
+                    && episode.IsMissingEpisode
+                    && episode.LocationType == LocationType.Virtual
+                    && episode.PremiereDate.HasValue
+                    && (DateTime.UtcNow - episode.PremiereDate.Value).TotalDays > 30;
+
+                if (skipItem || !refreshOptions.RefreshItem(item))
                 {
                     return;
                 }
@@ -332,82 +339,56 @@ namespace MediaBrowser.Controller.Entities.TV
                 {
                     await item.RefreshMetadata(refreshOptions, timeoutCts.Token).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException ex)
+                catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        // The caller's token was cancelled, not our own timeout. Propagate it.
-                        throw;
-                    }
-
-                    Interlocked.Increment(ref numFailed);
+                    failedItems.Add(item);
                     Logger.LogError(
                         ex,
-                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({Path}) in series '{SeriesName}'. Skipping this item and continuing with the rest of the series.",
+                        "Timed out after {Timeout} refreshing metadata for {ItemType} '{ItemName}' ({ItemPath})",
                         _childMetadataRefreshTimeout,
                         item.GetType().Name,
                         item.Name,
-                        item.Path,
-                        Name);
+                        item.Path);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    Interlocked.Increment(ref numFailed);
+                    failedItems.Add(item);
                     Logger.LogError(
                         ex,
-                        "Error refreshing metadata for {ItemType} '{ItemName}' ({Path}) in series '{SeriesName}'. Skipping this item and continuing with the rest of the series.",
+                        "Error refreshing metadata for {ItemType} '{ItemName}' ({ItemPath})",
                         item.GetType().Name,
                         item.Name,
-                        item.Path,
-                        Name);
+                        item.Path);
                 }
             }
 
-            // Refresh seasons first (bounded concurrency via the shared library scheduler), then episodes and other children.
-            // Seasons must exist before episodes are (re)parented against them, so these two phases stay sequential relative to each other.
+            // Refresh seasons, then episodes and other children.
             var seasonsProgress = new Progress<double>(p => progress.Report(seasonsShare * (p / 100)));
             await LimitedConcurrencyLibraryScheduler
                 .Enqueue(
                     seasons,
-                    (item, _) => RefreshChildAsync(item, skip: false),
+                    (item, _) => RefreshChildAsync(item),
                     seasonsProgress,
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            // Refresh episodes and other children
             var othersProgress = new Progress<double>(p => progress.Report(seasonsShare + ((100 - seasonsShare) * (p / 100))));
             await LimitedConcurrencyLibraryScheduler
                 .Enqueue(
                     others,
-                    (item, _) =>
-                    {
-                        bool skipItem = item is Episode episode
-                            && refreshOptions.MetadataRefreshMode != MetadataRefreshMode.FullRefresh
-                            && !refreshOptions.ReplaceAllMetadata
-                            && episode.IsMissingEpisode
-                            && episode.LocationType == LocationType.Virtual
-                            && episode.PremiereDate.HasValue
-                            && (DateTime.UtcNow - episode.PremiereDate.Value).TotalDays > 30;
-
-                        return RefreshChildAsync(item, skipItem);
-                    },
+                    (item, _) => RefreshChildAsync(item),
                     othersProgress,
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            // numFailed is mutated via Interlocked.Increment inside RefreshChildAsync, which the scheduler invokes
-            // through a delegate the analyzer cannot trace into. The preceding awaits on Enqueue (which awaits all
-            // worker tasks) establish a happens-before relationship, so the value read here is correctly synchronized.
-#pragma warning disable S2583
-            if (numFailed > 0)
+            if (!failedItems.IsEmpty)
             {
                 Logger.LogWarning(
-                    "Finished refreshing metadata for series '{SeriesName}': {FailedCount} of {TotalCount} child items failed or timed out and were skipped.",
-                    Name,
-                    numFailed,
-                    totalItems);
+                    "Failed to refresh metadata for {FailedCount} of {TotalCount} child items in series '{SeriesName}'",
+                    failedItems.Count,
+                    totalItems,
+                    Name);
             }
-#pragma warning restore S2583
 
             refreshOptions = new MetadataRefreshOptions(refreshOptions);
             await ProviderManager.RefreshSingleItem(this, refreshOptions, cancellationToken).ConfigureAwait(false);

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -395,6 +395,10 @@ namespace MediaBrowser.Controller.Entities.TV
                     cancellationToken)
                 .ConfigureAwait(false);
 
+            // numFailed is mutated via Interlocked.Increment inside RefreshChildAsync, which the scheduler invokes
+            // through a delegate the analyzer cannot trace into. The preceding awaits on Enqueue (which awaits all
+            // worker tasks) establish a happens-before relationship, so the value read here is correctly synchronized.
+#pragma warning disable S2583
             if (numFailed > 0)
             {
                 Logger.LogWarning(
@@ -403,6 +407,7 @@ namespace MediaBrowser.Controller.Entities.TV
                     numFailed,
                     totalItems);
             }
+#pragma warning restore S2583
 
             refreshOptions = new MetadataRefreshOptions(refreshOptions);
             await ProviderManager.RefreshSingleItem(this, refreshOptions, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Changes**
Before:
 - Both Music and Series methods walked an async for each chain that await-ran RefreshMetadata with no timeout and no failure logs.
After:
 - Both Music and Series's refresh metadata functions now utilize the ILimitedConcurrencyLibraryScheduler interface's enqueue method to concurrently (assigns runners according to cpu core related calculations, falls back to sequential if refresh was queued across the whole library due to anti-deadlock) refresh metadata with respect to the LibraryScanFanoutConcurrency setting under the library settings.
 - each metadata refresh child is capped to 60 seconds using a linked CancellationTokenSource to undercut 100 second http timer and attribute the error to the child item
 - try/catch identifies which child item went wrong
 - each child item becomes its own work item, doesn't take down the whole series's run
 - timeouts and failures now log the item type, name and path with a warning at the end that gives the failed count

**Code Assistance**
 - Used ai assistance to discover code inconsistencies and find the most elegant fix
 - Verified the fix by running a metadata refresh on a consistently (attempted retries, server restart, checked the db status, I'm aware removing and putting back the series fixes the issue) failing/hanging tv series with 200+ (Naruto 2004 and Jojo parts 1-5) episodes and multiple seasons that updated with no hangs after patch test.

**Issues**
Might be related to Issue #15075 