### PR TITLE
Recreate missing UserData placeholder BaseItem on startup

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/EnsureUserDataPlaceholderItem.cs
+++ b/Jellyfin.Server/Migrations/Routines/EnsureUserDataPlaceholderItem.cs
@@ -1,0 +1,65 @@
+#pragma warning disable RS0030 // Do not use banned APIs
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Item;
+using Jellyfin.Server.ServerSetupApp;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Server.Migrations.Routines;
+
+/// <summary>
+/// Recreates the placeholder BaseItem used to detach UserData on item deletion
+/// (see migration DetachUserDataInsteadOfDelete) if it is missing.
+/// Without it, every <see cref="BaseItemRepository.DeleteItem"/> call fails with a
+/// FOREIGN KEY constraint violation, which library scans swallow per-item, leaving the
+/// scan looking like it worked while silently corrupting delete/watch-state handling.
+/// </summary>
+[JellyfinMigration("2026-07-20T00:00:00", nameof(EnsureUserDataPlaceholderItem))]
+internal class EnsureUserDataPlaceholderItem : IAsyncMigrationRoutine
+{
+    private readonly IStartupLogger _logger;
+    private readonly IDbContextFactory<JellyfinDbContext> _provider;
+
+    public EnsureUserDataPlaceholderItem(
+        IStartupLogger<EnsureUserDataPlaceholderItem> startupLogger,
+        IDbContextFactory<JellyfinDbContext> provider)
+    {
+        _logger = startupLogger;
+        _provider = provider;
+    }
+
+    public async Task PerformAsync(CancellationToken cancellationToken)
+    {
+        var dbContext = await _provider.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        await using (dbContext.ConfigureAwait(false))
+        {
+            var exists = await dbContext.BaseItems
+                .AnyAsync(e => e.Id == BaseItemRepository.PlaceholderId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (exists)
+            {
+                return;
+            }
+
+            _logger.LogWarning(
+                "UserData placeholder item {PlaceholderId} is missing. Recreating it now; " +
+                "without it, item deletion during library scans fails silently with a FOREIGN KEY constraint error.",
+                BaseItemRepository.PlaceholderId);
+
+            dbContext.BaseItems.Add(new BaseItemEntity
+            {
+                Id = BaseItemRepository.PlaceholderId,
+                Type = "PLACEHOLDER",
+                Name = "This is a placeholder item for UserData that has been detacted from its original item"
+            });
+
+            await dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`BaseItemRepository.DeleteItem()` detaches `UserData` by reassigning it to a well-known placeholder `BaseItem` (`00000000-0000-0000-0000-000000000001`), seeded by the `DetachUserDataInsteadOfDelete` migration. If that seeded row is ever missing on a given server (observed in the wild — migration recorded as applied in `__EFMigrationsHistory`, but the row itself absent from `BaseItems`), every subsequent item delete fails with a SQLite `FOREIGN KEY constraint failed` on the `UserData` reassignment `ExecuteUpdate`.

Library scans call `DeleteItem` per-item for entries they believe are gone, including transient cases (e.g. a brief stat failure on a network filesystem during a large recursive scan). The scan swallows this exception per item and continues, so the failure is invisible in normal use — but the item's `DateModified` is still bumped before the failure, so it keeps surfacing as continuous "everything changed" library-sync churn to companion clients (observed via the Kodi Sync Queue plugin: hundreds of items reported "updated" every night) with no visible server-side error apart from log noise.

This is likely related in spirit (same `UserData` tombstone mechanism, different trigger) to #15496, #15578, #14295, and #16975.

## Fix

Add a startup migration routine (`EnsureUserDataPlaceholderItem`) that checks for the placeholder row and recreates it — using the exact same values as the original seed migration — if it's missing, so a server that lost this row for whatever reason self-heals instead of failing this way indefinitely.

## Test plan

- [x] `dotnet build Jellyfin.Server/Jellyfin.Server.csproj` succeeds with no new warnings/errors
- [x] Reproduced the underlying `FOREIGN KEY constraint failed` on a production database missing the placeholder row (confirmed via the exact `UPDATE UserData SET ItemId = <placeholder> ...` statement from `DeleteItem`)
- [x] Manually re-inserted the placeholder row with the same shape this routine produces; confirmed `PRAGMA foreign_key_check` is clean afterward and the previously-failing `UserData` reassignment now succeeds
- [ ] Did not add an automated test — no existing test coverage for this class of startup `IAsyncMigrationRoutine` (checked `tests/Jellyfin.Server.Implementations.Tests`), followed existing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)