### PR TITLE
Avoid NRE when sorting by user-dependent keys without a user

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1969,9 +1969,16 @@ namespace Emby.Server.Implementations.Library
         {
             var comparer = Comparers.FirstOrDefault(c => name == c.Type);
 
-            // If it requires a user, create a new one, and assign the user
+            // User-dependent comparers (IUserBaseItemComparer) need a User. With no user
+            // (anonymous/API-key /Items requests), substitute the SortName comparer so the
+            // result stays deterministic instead of 500-ing with an NRE inside the LINQ sort.
             if (comparer is IUserBaseItemComparer)
             {
+                if (user is null)
+                {
+                    return Comparers.FirstOrDefault(c => c.Type == ItemSortBy.SortName);
+                }
+
                 var userComparer = (IUserBaseItemComparer)Activator.CreateInstance(comparer.GetType())!; // only null for Nullable<T> instances
 
                 userComparer.User = user;

--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -238,6 +238,7 @@ namespace Emby.Server.Implementations.Library
         /// <inheritdoc />
         public UserItemData GetUserData(User user, BaseItem item)
         {
+            ArgumentNullException.ThrowIfNull(user);
             var cacheKey = GetCacheKey(user.InternalId, item.Id);
             return _cache.GetOrAdd(
                 cacheKey,

--- a/Emby.Server.Implementations/Sorting/DateLastMediaAddedComparer.cs
+++ b/Emby.Server.Implementations/Sorting/DateLastMediaAddedComparer.cs
@@ -3,34 +3,14 @@
 
 using System;
 using Jellyfin.Data.Enums;
-using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Sorting;
 using MediaBrowser.Model.Querying;
 
 namespace Emby.Server.Implementations.Sorting
 {
-    public class DateLastMediaAddedComparer : IUserBaseItemComparer
+    public class DateLastMediaAddedComparer : IBaseItemComparer
     {
-        /// <summary>
-        /// Gets or sets the user.
-        /// </summary>
-        /// <value>The user.</value>
-        public User User { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user manager.
-        /// </summary>
-        /// <value>The user manager.</value>
-        public IUserManager UserManager { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user data manager.
-        /// </summary>
-        /// <value>The user data manager.</value>
-        public IUserDataManager UserDataManager { get; set; }
-
         /// <summary>
         /// Gets the name.
         /// </summary>

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManagerSortTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManagerSortTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Emby.Naming.Common;
+using Emby.Server.Implementations.Library;
+using Emby.Server.Implementations.Sorting;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Controller.Resolvers;
+using MediaBrowser.Controller.Sorting;
+using MediaBrowser.Model.IO;
+using Moq;
+using Xunit;
+using BaseItem = MediaBrowser.Controller.Entities.BaseItem;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class LibraryManagerSortTests
+{
+    [Fact]
+    public void Sort_UserDependentKey_NullUser_FallsBackToSortNameWithoutThrowing()
+    {
+        var libraryManager = CreateLibraryManager(
+            new IBaseItemComparer[] { new PlayCountComparer(), new SortNameComparer() });
+
+        // Items are intentionally NOT in SortName order, to prove the fallback reorders them.
+        BaseItem[] items =
+        {
+            new Audio { Name = "Zulu", SortName = "Zulu", Id = Guid.NewGuid() },
+            new Audio { Name = "Alpha", SortName = "Alpha", Id = Guid.NewGuid() },
+            new Audio { Name = "Mike", SortName = "Mike", Id = Guid.NewGuid() }
+        };
+
+        // PlayCount is a user-dependent key; with no user it must not NRE. It should fall back to
+        // SortName so the result is deterministic (the requested Descending direction is preserved).
+        var sorted = libraryManager.Sort(
+            items,
+            user: null,
+            new[] { (ItemSortBy.PlayCount, SortOrder.Descending) }).ToArray();
+
+        Assert.Equal(new[] { "Zulu", "Mike", "Alpha" }, sorted.Select(i => i.SortName));
+    }
+
+    [Fact]
+    public void Sort_DateLastContentAdded_NullUser_OrdersByDateNotSortName()
+    {
+        // DateLastMediaAddedComparer does not use User (its GetDate is static), so it must NOT be
+        // treated as a user-dependent comparer: with no user it should still sort by date, not fall
+        // back to SortName.
+        var libraryManager = CreateLibraryManager(
+            new IBaseItemComparer[] { new DateLastMediaAddedComparer(), new SortNameComparer() });
+
+        // Names are chosen so date-descending and SortName-descending DISAGREE: Alpha is newest
+        // (date-desc rank 1), but Zulu sorts last alphabetically (SortName-desc rank 1). If the
+        // comparer were still tagged IUserBaseItemComparer, the null-user SortName fallback would
+        // return [Zulu, Mike, Alpha] and this assertion would fail.
+        BaseItem[] items =
+        {
+            MakeFolder("Alpha", new DateTime(2026, 1, 1)),
+            MakeFolder("Mike", new DateTime(2025, 1, 1)),
+            MakeFolder("Zulu", new DateTime(2024, 1, 1))
+        };
+
+        var sorted = libraryManager.Sort(
+            items,
+            user: null,
+            new[] { (ItemSortBy.DateLastContentAdded, SortOrder.Descending) }).ToArray();
+
+        // Descending by date => newest first: Alpha, Mike, Zulu. (SortName-desc would be Zulu, Mike, Alpha.)
+        Assert.Equal(new[] { "Alpha", "Mike", "Zulu" }, sorted.Select(i => i.Name));
+    }
+
+    private static Folder MakeFolder(string name, DateTime dateLastMediaAdded)
+        => new() { Name = name, Id = Guid.NewGuid(), DateLastMediaAdded = dateLastMediaAdded };
+
+    private static Emby.Server.Implementations.Library.LibraryManager CreateLibraryManager(IReadOnlyCollection<IBaseItemComparer> comparers)
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        fixture.Register(() => new NamingOptions());
+        var configMock = fixture.Freeze<Mock<IServerConfigurationManager>>();
+        configMock.Setup(c => c.ApplicationPaths.ProgramDataPath).Returns("/data");
+        // BaseItem.SortName/CreateSortName dereference this static; set it so SortName-fallback
+        // paths don't NRE in-process (mirrors AudioResolverTests in the sibling test project).
+        BaseItem.ConfigurationManager ??= configMock.Object;
+        var itemRepository = fixture.Freeze<Mock<IItemRepository>>();
+        itemRepository.Setup(i => i.RetrieveItem(It.IsAny<Guid>())).Returns<BaseItem>(null);
+        var fileSystemMock = fixture.Freeze<Mock<IFileSystem>>();
+        fileSystemMock.Setup(f => f.GetFileInfo(It.IsAny<string>())).Returns<string>(path => new FileSystemMetadata { FullName = path });
+
+        return fixture.Build<Emby.Server.Implementations.Library.LibraryManager>().Do(s => s.AddParts(
+                fixture.Create<IEnumerable<IResolverIgnoreRule>>(),
+                fixture.Create<IEnumerable<IItemResolver>>(),
+                fixture.Create<IEnumerable<IIntroProvider>>(),
+                comparers,
+                fixture.Create<IEnumerable<ILibraryPostScanTask>>()))
+            .Create();
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class UserDataManagerTests
+{
+    [Fact]
+    public void GetUserData_NullUser_ThrowsArgumentNullException()
+    {
+        var manager = CreateUserDataManager();
+        BaseItem item = new Audio { Name = "Test", Id = Guid.NewGuid() };
+
+        Assert.Throws<ArgumentNullException>(() => manager.GetUserData(null!, item));
+    }
+
+    private static UserDataManager CreateUserDataManager()
+    {
+        var mockConfig = new Mock<IServerConfigurationManager>();
+        mockConfig.SetupGet(x => x.Configuration).Returns(new ServerConfiguration());
+        var mockDb = new Mock<IDbContextFactory<JellyfinDbContext>>();
+
+        return new UserDataManager(mockConfig.Object, mockDb.Object);
+    }
+}


### PR DESCRIPTION
## Changes

Fixes a `NullReferenceException` in `UserDataManager.GetUserData` that 500-ed any anonymous (API-key, no `userId`) `/Items` request sorted by a user-dependent key (`PlayCount`, `IsFavoriteOrLiked`, `DatePlayed`, `IsPlayed`, `IsUnplayed`).

- `LibraryManager.GetComparer`: when `user` is null and the requested key requires a user (`IUserBaseItemComparer`), substitute the `SortName` comparer so the result stays deterministic instead of crashing. `SortName` is the project's canonical tiebreaker (already used by `ItemsController` for album-by-artist). This closes the gap left when `GetComparer`'s `user` parameter was widened to nullable in #11191.
- `UserDataManager.GetUserData`: `ArgumentNullException.ThrowIfNull(user)` as defense in depth (matches the existing guards on the `SaveUserData` overloads in the same file), so any future null-user caller gets a clean argument exception instead of an opaque NRE deep in a sort comparer.
- `DateLastMediaAddedComparer`: re-tagged from `IUserBaseItemComparer` to `IBaseItemComparer` (its `GetDate` is `static` and never reads `User`), and dropped the unused `User`/`UserManager`/`UserDataManager` properties. Without this, the new `SortName` fallback would wrongly engage for `DateLastContentAdded` on anonymous queries, returning `SortName` order instead of date order.

The crash surfaced as `System.InvalidOperationException: Failed to compare two elements in the array` (wrapping the NRE from the LINQ sort).

## Code assistance

None — hand-written null-guard fix.

## Tests

- `UserDataManagerTests.GetUserData_NullUser_ThrowsArgumentNullException` — reproduces the crash (NRE → now `ArgumentNullException`).
- `LibraryManagerSortTests.Sort_UserDependentKey_NullUser_FallsBackToSortNameWithoutThrowing` — `Sort` with a user-dependent key + null user no longer throws and returns items ordered by the `SortName` fallback (direction preserved).
- `LibraryManagerSortTests.Sort_DateLastContentAdded_NullUser_OrdersByDateNotSortName` — guards that `DateLastContentAdded` still sorts by date with no user (fixture chosen so date-desc and SortName-desc disagree, so a revert is caught).

Full `Jellyfin.Server.Implementations.Tests` suite: 423 passed, 0 failed.

## Issues

Fixes #17393

---

Discovered while working on [jellyfin-alexa-plugin](https://github.com/paoloantinori/jellyfin-alexa-plugin); the plugin-side workaround is [paoloantinori/jellyfin-alexa-plugin\@25e5446](https://github.com/paoloantinori/jellyfin-alexa-plugin/commit/25e5446).