### PR TITLE
Fix NullReferenceException in user-data query filters

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.cs
@@ -2053,20 +2053,23 @@ public sealed class BaseItemRepository
 
         if (filter.IsLiked.HasValue)
         {
+            var isLiked = filter.IsLiked.Value;
             baseQuery = baseQuery
-                .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.Rating >= UserItemData.MinLikeValue);
+                .Where(e => e.UserData!.Any(ud => ud.UserId == filter.User!.Id && ud.Rating >= UserItemData.MinLikeValue) == isLiked);
         }
 
         if (filter.IsFavoriteOrLiked.HasValue)
         {
+            var isFavoriteOrLiked = filter.IsFavoriteOrLiked.Value;
             baseQuery = baseQuery
-                .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.IsFavorite == filter.IsFavoriteOrLiked);
+                .Where(e => e.UserData!.Any(ud => ud.UserId == filter.User!.Id && ud.IsFavorite) == isFavoriteOrLiked);
         }
 
         if (filter.IsFavorite.HasValue)
         {
+            var isFavorite = filter.IsFavorite.Value;
             baseQuery = baseQuery
-                .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.IsFavorite == filter.IsFavorite);
+                .Where(e => e.UserData!.Any(ud => ud.UserId == filter.User!.Id && ud.IsFavorite) == isFavorite);
         }
 
         if (filter.IsPlayed.HasValue)
@@ -2076,7 +2079,7 @@ public sealed class BaseItemRepository
             {
                 baseQuery = baseQuery.Where(e => context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId))
                     .Where(e => e.IsFolder == false && e.IsVirtualItem == false)
-                    .Where(f => f.UserData!.FirstOrDefault(e => e.UserId == filter.User!.Id && e.Played)!.Played)
+                    .Where(f => f.UserData!.Any(e => e.UserId == filter.User!.Id && e.Played))
                     .Any(f => f.SeriesPresentationUniqueKey == e.PresentationUniqueKey) == filter.IsPlayed);
             }
             else
@@ -2097,12 +2100,12 @@ public sealed class BaseItemRepository
             if (filter.IsResumable.Value)
             {
                 baseQuery = baseQuery
-                       .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.PlaybackPositionTicks > 0);
+                       .Where(e => e.UserData!.Any(f => f.UserId == filter.User!.Id && f.PlaybackPositionTicks > 0));
             }
             else
             {
                 baseQuery = baseQuery
-                       .Where(e => e.UserData!.FirstOrDefault(f => f.UserId == filter.User!.Id)!.PlaybackPositionTicks == 0);
+                       .Where(e => !e.UserData!.Any(f => f.UserId == filter.User!.Id && f.PlaybackPositionTicks > 0));
             }
         }
 


### PR DESCRIPTION
**Changes**

Rewrites the `IsLiked`, `IsFavoriteOrLiked`, `IsFavorite`, `IsResumable` and the Series `IsPlayed` user-data filters in `BaseItemRepository.TranslateQuery` to use a null-safe `.Any(...)` form instead of the chained `!.FirstOrDefault(...)!.Property` deref.

The old form cannot be translated to SQL by EF Core and is evaluated client-side in the expression interpreter, where it throws a `NullReferenceException` for items that have no matching `UserData` row. This surfaces intermittently under the concurrent `Filters=IsFavorite&Recursive=true` requests the web client issues (e.g. the Favorites view, one request per item type): a single request is fast (~13 ms on a ~189k-item library) while several concurrent ones throw and stall.

This ports the null-safe approach already present on `master` (where the query translation was refactored into `BaseItemRepository.TranslateQuery.cs`) back to the `release-10.11.z` line, so it is a targeted backport rather than new behaviour.

Note on the `IsResumable` false branch: the rewrite `!Any(... PlaybackPositionTicks > 0)` also correctly matches items that have no `UserData` row at all (previously those NRE'd), which is the intended "not resumable" set.

**Code assistance**

None.

**Issues**

Fixes #17403