### PR TITLE
Warm up ItemsByName query plans at startup to avoid ~37s first-request stall

### DIFF
--- a/Jellyfin.Server/QueryPlanWarmupHost.cs
+++ b/Jellyfin.Server/QueryPlanWarmupHost.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Server
+{
+    /// <summary>
+    /// <see cref="IHostedService"/> that pre-compiles the EF Core query plans for the
+    /// ItemsByName endpoints (Artists/AlbumArtists/Studios/Genres/MusicGenres) combined with
+    /// a user-data filter. These query shapes build large expression trees whose first-use
+    /// compilation (Expression.Compile + JIT) can take tens of seconds on large libraries,
+    /// blocking the first request (e.g. loading the Favorites view or logging in). Executing
+    /// them once at startup on a background thread moves that one-time cost off the request path.
+    /// This does not change any query behaviour; the results are discarded.
+    /// </summary>
+    public sealed class QueryPlanWarmupHost : IHostedService
+    {
+        private readonly ILogger<QueryPlanWarmupHost> _logger;
+        private readonly ILibraryManager _libraryManager;
+        private readonly IUserManager _userManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryPlanWarmupHost"/> class.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{TCategoryName}"/>.</param>
+        /// <param name="libraryManager">The <see cref="ILibraryManager"/>.</param>
+        /// <param name="userManager">The <see cref="IUserManager"/>.</param>
+        public QueryPlanWarmupHost(
+            ILogger<QueryPlanWarmupHost> logger,
+            ILibraryManager libraryManager,
+            IUserManager userManager)
+        {
+            _logger = logger;
+            _libraryManager = libraryManager;
+            _userManager = userManager;
+        }
+
+        /// <inheritdoc />
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Fire-and-forget on a background thread; never block startup.
+            _ = Task.Run(() => Warmup(cancellationToken), cancellationToken);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        private void Warmup(CancellationToken cancellationToken)
+        {
+            var user = _userManager.GetUsers().FirstOrDefault();
+            if (user is null)
+            {
+                return;
+            }
+
+            try
+            {
+                var start = DateTime.UtcNow;
+                RunItemsByNameQueries(user);
+                _logger.LogInformation(
+                    "ItemsByName query plans warmed up in {Elapsed}",
+                    DateTime.UtcNow - start);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutting down; ignore.
+            }
+            catch (Exception ex)
+            {
+                // Warm-up is best-effort and must never affect server startup.
+                _logger.LogDebug(ex, "ItemsByName query plan warm-up failed");
+            }
+        }
+
+        private void RunItemsByNameQueries(User user)
+        {
+            InternalItemsQuery Query() => new(user)
+            {
+                IsFavorite = true,
+                Recursive = true,
+                Limit = 1
+            };
+
+            // Each of these is a distinct query shape with its own one-time plan
+            // compilation, and every ILibraryManager call opens its own DbContext,
+            // so they can be compiled concurrently to reduce total warm-up time.
+            Parallel.Invoke(
+                () => _libraryManager.GetArtists(Query()),
+                () => _libraryManager.GetAlbumArtists(Query()),
+                () => _libraryManager.GetStudios(Query()),
+                () => _libraryManager.GetGenres(Query()),
+                () => _libraryManager.GetMusicGenres(Query()));
+        }
+    }
+}

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -155,6 +155,7 @@ namespace Jellyfin.Server
             services.AddHostedService<LibraryChangedNotifier>();
             services.AddHostedService<UserDataChangeNotifier>();
             services.AddHostedService<RecordingNotifier>();
+            services.AddHostedService<QueryPlanWarmupHost>();
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

Adds `QueryPlanWarmupHost`, an `IHostedService` that, once at startup on a background thread, executes the ItemsByName queries (`GetArtists`/`GetAlbumArtists`/`GetStudios`/`GetGenres`/`GetMusicGenres`) with a user-data filter (`IsFavorite=true, Recursive=true, Limit=1`) and discards the results. This moves the one-time EF Core query-plan compilation cost off the first user request.

**Why**

On a large library (~189k items) these ItemsByName + user-data-filter query shapes take ~37 s on their first execution after a server restart, then ~30 ms once warm. Profiling (see #17405) shows the cold cost is EF Core building the query's shaper/materializer expression tree and `Expression.Compile()` + JIT compiling the generated delegates — CPU-bound on a single core, not SQL (the underlying SQLite query returns in milliseconds). Because the plan is cached per distinct query, the first Favorites-view load (or even login, which triggers per-user data) blocks for the full compile time. Warming these plans at startup pays that cost before any request arrives.

The five shapes are independent and each `ILibraryManager` call opens its own `DbContext`, so they are compiled concurrently via `Parallel.Invoke` to reduce total warm-up wall-time. Warm-up is best-effort: failures are swallowed and logged at debug level, and it never blocks startup.

This is additive and changes no query behaviour or results.

**Notes / status**

- Draft. Verified it **compiles** against `master` (`fc43f15`, i.e. 12.0-rc3) with the .NET 10 SDK; I have **not** yet measured the end-to-end startup warm-up effect on a live large-library instance, and there is no test yet. Feedback welcome on whether a startup hosted-service is the preferred approach vs. `EF.CompileQuery`/precompiled queries or reducing the shaper complexity for these paths.
- The warmed query shapes are a reasonable representative set for the ItemsByName + user-data paths, but may not cover every variant the web client issues.

**Code assistance**

Developed with AI assistance for profiling and drafting.

**Issues**

Fixes #17405