### PR TITLE
Fix trickplay generation for hardware-scaled frames with off-by-a-pixel dimensions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -233,6 +233,7 @@
  - [MSalman5230](https://github.com/MSalman5230)
  - [dwandw](https://github.com/dwandw)
  - [Lampan-git](https://github.com/Lampan-git)
+ - [AhmadRafiq90](https://github.com/AhmadRafiq90)
 
 # Emby Contributors
 

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -731,12 +731,9 @@ public class SkiaEncoder : IImageEncoder
                 throw new InvalidDataException("Could not decode image data.");
             }
 
-            if (firstImg.Width != imgWidth)
-            {
-                throw new InvalidOperationException("Image width does not match provided width.");
-            }
-
-            imgHeight = firstImg.Height;
+            var derivedHeight = (int)Math.Round(firstImg.Height * (double)imgWidth / firstImg.Width);
+            derivedHeight += derivedHeight % 2; // keep even for the JPEG encoder
+            imgHeight = derivedHeight;
         }
 
         // Make horizontal strips using every provided image.
@@ -760,17 +757,18 @@ public class SkiaEncoder : IImageEncoder
                     throw new InvalidDataException("Could not decode image data.");
                 }
 
-                if (img.Width != imgWidth)
+                if (img.Width != imgWidth || img.Height != imgHeight.Value)
                 {
-                    throw new InvalidOperationException("Image width does not match provided width.");
+                    // Normalize any off-by-a-few-pixels hardware-scaled frame to the exact
+                    // cell size so the grid stays aligned with the stored trickplay width.
+                    var targetInfo = new SKImageInfo(imgWidth, imgHeight.Value, img.ColorType, img.AlphaType, img.ColorSpace);
+                    using var resized = ResizeImage(img, targetInfo);
+                    canvas.DrawImage(resized, x * imgWidth, y * imgHeight.Value);
                 }
-
-                if (img.Height != imgHeight)
+                else
                 {
-                    throw new InvalidOperationException("Image height does not match first image height.");
+                    canvas.DrawBitmap(img, x * imgWidth, y * imgHeight.Value, DefaultSamplingOptions);
                 }
-
-                canvas.DrawBitmap(img, x * imgWidth, y * imgHeight.Value, DefaultSamplingOptions);
             }
         }
 


### PR DESCRIPTION
**Changes**
`CreateTrickplayTile` threw when a decoded frame's dimensions didn't exactly match the configured trickplay size. Hardware scalers (d3d11va/opencl) can emit frames a couple of pixels off — a 320px tier receiving 318px frames — aborting generation even though ffmpeg succeeded. Now the cell height is derived from the first frame's aspect ratio, and off-size frames are resized to the exact cell (via existing ResizeImage) instead of throwing. The cell stays locked to the configured width, so tile geometry and stored metadata stay aligned. Exact-size frames still composite directly, unchanged. Changes were tested on local build with a ~2.2:1 1080p source

**Code assistance**
LLM was used to find possible edge cases and check if code missed any obvious best practices

**Issues**
Fixes #17346 
