### PR TITLE
perf: avoid unnecessary list allocation in CheckForIdlePlayback

### DIFF
--- a/Emby.Server.Implementations/Session/SessionManager.cs
+++ b/Emby.Server.Implementations/Session/SessionManager.cs
@@ -641,8 +641,7 @@ namespace Emby.Server.Implementations.Session
             if (playingSessions.Count > 0)
             {
                 var idle = playingSessions
-                    .Where(i => (DateTime.UtcNow - i.LastPlaybackCheckIn).TotalMinutes > 5)
-                    .ToList();
+                    .Where(i => (DateTime.UtcNow - i.LastPlaybackCheckIn).TotalMinutes > 5);
 
                 foreach (var session in idle)
                 {


### PR DESCRIPTION
## Summary

Removes an unnecessary `.ToList()` call in `CheckForIdlePlayback`.

`playingSessions` is already a materialized `List<T>` snapshot; the filtered `idle` enumerable is only iterated once with `foreach`, so materializing it into a second list serves no purpose and causes an avoidable heap allocation on every idle-check timer tick.