### PR TITLE
Check the "name" tag for audio/subtitle probe to fix MP4 not showing correctly - Fixes issue #17418

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -233,6 +233,7 @@
  - [MSalman5230](https://github.com/MSalman5230)
  - [dwandw](https://github.com/dwandw)
  - [Lampan-git](https://github.com/Lampan-git)
+ - [rwebster85](https://github.com/rwebster85)
 
 # Emby Contributors
 

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -757,11 +757,17 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: fall back to handler_name if populated and not the default "SoundHandler"
-                    string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
-                    if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SoundHandler", StringComparison.OrdinalIgnoreCase))
+                    // mp4 missing track title workaround: some muxers store the track title in a "name" tag
+                    stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
+
+                    if (string.IsNullOrEmpty(stream.Title))
                     {
-                        stream.Title = handlerName;
+                        // fall back to handler_name if populated and not the default "SoundHandler"
+                        string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
+                        if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SoundHandler", StringComparison.OrdinalIgnoreCase))
+                        {
+                            stream.Title = handlerName;
+                        }
                     }
                 }
             }
@@ -781,11 +787,17 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: fall back to handler_name if populated and not the default "SubtitleHandler"
-                    string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
-                    if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SubtitleHandler", StringComparison.OrdinalIgnoreCase))
+                    // mp4 missing track title workaround: some muxers store the track title in a "name" tag
+                    stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
+
+                    if (string.IsNullOrEmpty(stream.Title))
                     {
-                        stream.Title = handlerName;
+                        // fall back to handler_name if populated and not the default "SubtitleHandler"
+                        string handlerName = GetDictionaryValue(streamInfo.Tags, "handler_name");
+                        if (!string.IsNullOrEmpty(handlerName) && !string.Equals(handlerName, "SubtitleHandler", StringComparison.OrdinalIgnoreCase))
+                        {
+                            stream.Title = handlerName;
+                        }
                     }
                 }
             }

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -757,7 +757,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: some muxers store the track title in a "name" tag
+                    // mp4 missing track title workaround: FFprobe exposes MP4 track names via the name tag rather than title
                     stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
 
                     if (string.IsNullOrEmpty(stream.Title))
@@ -787,7 +787,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: some muxers store the track title in a "name" tag
+                    // mp4 missing track title workaround: FFprobe exposes MP4 track names via the name tag rather than title
                     stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
 
                     if (string.IsNullOrEmpty(stream.Title))

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -757,7 +757,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: FFprobe exposes MP4 track names via the name tag rather than title
+                    // FFprobe exposes MP4 track names via the name tag rather than title
                     stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
 
                     if (string.IsNullOrEmpty(stream.Title))
@@ -787,7 +787,7 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (string.IsNullOrEmpty(stream.Title))
                 {
-                    // mp4 missing track title workaround: FFprobe exposes MP4 track names via the name tag rather than title
+                    // FFprobe exposes MP4 track names via the name tag rather than title
                     stream.Title = GetDictionaryValue(streamInfo.Tags, "name");
 
                     if (string.IsNullOrEmpty(stream.Title))

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeResultNormalizerTests.cs
@@ -219,7 +219,7 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
             Assert.Equal("eng", res.MediaStreams[4].Language);
             Assert.Equal(MediaStreamType.Subtitle, res.MediaStreams[4].Type);
             Assert.Equal("mov_text", res.MediaStreams[4].Codec);
-            Assert.Null(res.MediaStreams[4].Title);
+            Assert.Equal("SDH", res.MediaStreams[4].Title);
             Assert.True(res.MediaStreams[4].IsHearingImpaired);
 
             Assert.Equal("eng", res.MediaStreams[5].Language);

--- a/tests/Jellyfin.MediaEncoding.Tests/Test Data/Probing/video_mp4_metadata.json
+++ b/tests/Jellyfin.MediaEncoding.Tests/Test Data/Probing/video_mp4_metadata.json
@@ -95,7 +95,8 @@
             "tags": {
                 "creation_time": "2021-09-13T22:42:42.000000Z",
                 "language": "eng",
-                "handler_name": "Surround 6.1",
+                "handler_name": "SoundHandler",
+                "name": "Surround 6.1",
                 "vendor_id": "[0][0][0][0]"
             }
         },
@@ -215,7 +216,8 @@
             "tags": {
                 "creation_time": "2021-09-13T22:42:42.000000Z",
                 "language": "eng",
-                "handler_name": "SubtitleHandler"
+                "handler_name": "SubtitleHandler",
+                "name": "SDH"
             }
         },
         {


### PR DESCRIPTION
**Changes**
After checking for a "title" tag, check for a "name" tag before defaulting to checking the "handler_name". MP4 files use the "name" tag, not the "title" tag.

**FFprobe result**

MKV file:

<img width="866" height="262" alt="mkv-tags" src="https://github.com/user-attachments/assets/10b11a3a-d5e9-4a0b-94a2-870eb1c8ccf5" />

MP4 file:

<img width="481" height="122" alt="mp4-tags" src="https://github.com/user-attachments/assets/bfd352ec-6416-47bf-acb9-dbe7ec7e5028" />


**Before fix**

<img width="835" height="160" alt="mp4-audio-before" src="https://github.com/user-attachments/assets/ecd85118-d7f3-4abd-9a8a-621f2aaa2972" />

<img width="837" height="192" alt="mp4-subtitles-before" src="https://github.com/user-attachments/assets/20acf3e1-144e-4642-a2cf-8c1861b55d6d" />


**After fix**

<img width="843" height="136" alt="mp4-audio-after" src="https://github.com/user-attachments/assets/8413c527-6cba-4961-83a1-b51dbdec3bc9" />

<img width="838" height="160" alt="mp4-subtitles-after" src="https://github.com/user-attachments/assets/1ef8ae52-7e7b-4510-b080-cea4360d590c" />


**Code assistance**
Used Claude to quickly spin up different environments to verify code fix alongside testing newer ffmpeg release.

**Issues**
Fixed #17418 

**Additional**
Version 8.1.2 of ffmpeg is required for this fix to take effect, which is the latest version in the Jellyfin-ffmpeg repo.