### PR TITLE
Write resized-image cache entries atomically

### DIFF
--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -214,7 +214,16 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
                         return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
                     }
 
-                    File.Move(tempFilePath, cacheFilePath, overwrite: true);
+                    try
+                    {
+                        File.Move(tempFilePath, cacheFilePath, overwrite: true);
+                    }
+                    catch (IOException) when (new FileInfo(cacheFilePath) is { Exists: true, Length: > 0 })
+                    {
+                        // Lost the publish race: a concurrent request already wrote this cache
+                        // entry and a reader holds it open (Windows denies replacing an open
+                        // file). The published entry is complete, so serve that one.
+                    }
                 }
                 finally
                 {

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -218,11 +218,13 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
                     {
                         File.Move(tempFilePath, cacheFilePath, overwrite: true);
                     }
-                    catch (IOException) when (new FileInfo(cacheFilePath) is { Exists: true, Length: > 0 })
+                    catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException)
+                        && new FileInfo(cacheFilePath) is { Exists: true, Length: > 0 })
                     {
                         // Lost the publish race: a concurrent request already wrote this cache
                         // entry and a reader holds it open (Windows denies replacing an open
-                        // file). The published entry is complete, so serve that one.
+                        // file with UnauthorizedAccessException). The published entry is
+                        // complete, so serve that one.
                     }
                 }
                 finally

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -194,19 +194,34 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
 
         try
         {
-            if (!File.Exists(cacheFilePath))
+            var cacheFile = new FileInfo(cacheFilePath);
+            if (!cacheFile.Exists || cacheFile.Length == 0)
             {
                 string resultPath;
 
-                // Limit number of parallel (more precisely: concurrent) image encodings to prevent a high memory usage
-                using (await _parallelEncodingLimit.LockAsync().ConfigureAwait(false))
-                {
-                    resultPath = _imageEncoder.EncodeImage(originalImagePath, dateModified, cacheFilePath, autoOrient, orientation, quality, options, outputFormat);
-                }
+                var tempFilePath = string.Concat(cacheFilePath, ".", Guid.NewGuid().ToString("N"), ".tmp");
 
-                if (string.Equals(resultPath, originalImagePath, StringComparison.OrdinalIgnoreCase))
+                try
                 {
-                    return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
+                    // Limit number of parallel (more precisely: concurrent) image encodings to prevent a high memory usage
+                    using (await _parallelEncodingLimit.LockAsync().ConfigureAwait(false))
+                    {
+                        resultPath = _imageEncoder.EncodeImage(originalImagePath, dateModified, tempFilePath, autoOrient, orientation, quality, options, outputFormat);
+                    }
+
+                    if (string.Equals(resultPath, originalImagePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (originalImagePath, MimeTypes.GetMimeType(originalImagePath), dateModified);
+                    }
+
+                    File.Move(tempFilePath, cacheFilePath, overwrite: true);
+                }
+                finally
+                {
+                    if (File.Exists(tempFilePath))
+                    {
+                        File.Delete(tempFilePath);
+                    }
                 }
             }
 

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/ImageControllerCacheTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/ImageControllerCacheTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Jellyfin.Drawing;
+using MediaBrowser.Controller.Drawing;
+using Microsoft.Extensions.DependencyInjection;
+using SkiaSharp;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers
+{
+    public sealed class ImageControllerCacheTests : IClassFixture<JellyfinApplicationFactory>
+    {
+        private readonly JellyfinApplicationFactory _factory;
+        private static string? _accessToken;
+
+        public ImageControllerCacheTests(JellyfinApplicationFactory factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task GetUserImage_ParallelRequestsForUncachedImage_AllReceiveCompleteImage()
+        {
+            Assert.SkipWhen(
+                _factory.Services.GetRequiredService<IImageEncoder>() is NullImageEncoder,
+                "Requires an image encoder (Skia native library not available).");
+
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+            var userId = (await AuthHelper.GetUserDtoAsync(client)).Id;
+
+            var noisePngBase64 = Convert.ToBase64String(GenerateNoisePng(1600, 2400));
+
+            for (var round = 0; round < 2; round++)
+            {
+                using (var content = new StringContent(noisePngBase64))
+                {
+                    content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png");
+                    using var uploadResponse = await client.PostAsync($"UserImage?userId={userId}", content, TestContext.Current.CancellationToken);
+                    Assert.Equal(HttpStatusCode.NoContent, uploadResponse.StatusCode);
+                }
+
+                foreach (var format in new[] { "Jpg", "Webp" })
+                {
+                    var url = $"UserImage?userId={userId}&format={format}";
+
+                    var responses = await Task.WhenAll(Enumerable.Range(0, 40)
+                        .Select(_ => client.GetAsync(url, TestContext.Current.CancellationToken)));
+
+                    try
+                    {
+                        Assert.All(responses, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
+
+                        var bodyLengths = await Task.WhenAll(responses.Select(async r =>
+                            (await r.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken)).Length));
+
+                        Assert.All(bodyLengths, length => Assert.NotEqual(0, length));
+                        Assert.Single(bodyLengths.Distinct());
+                    }
+                    finally
+                    {
+                        foreach (var response in responses)
+                        {
+                            response.Dispose();
+                        }
+                    }
+                }
+            }
+        }
+
+        private static byte[] GenerateNoisePng(int width, int height)
+        {
+            using var bitmap = new SKBitmap(width, height);
+            var pixelBytes = new byte[bitmap.ByteCount];
+            new Random(17135).NextBytes(pixelBytes);
+            Marshal.Copy(pixelBytes, 0, bitmap.GetPixels(), pixelBytes.Length);
+
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            return data.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
ImageProcessor encoded resized images to file that need to be served. In the process it created empty file and then fill in with the results. In case of the parallel requests user can get empty file instead of processed image.

Encode to a unique temporary file and publish it with an atomic rename, so a cache entry is either fully present or absent. 

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

I was debugging root cause with LLM

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #17135
