### PR TITLE
fix: stop Clean Cache Directory task from deleting metadata stored inside the cache path

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/DeleteCacheFileTask.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
@@ -22,7 +22,7 @@ public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
     /// Gets or sets the application paths.
     /// </summary>
     /// <value>The application paths.</value>
-    private readonly IApplicationPaths _applicationPaths;
+    private readonly IServerApplicationPaths _applicationPaths;
     private readonly ILogger<DeleteCacheFileTask> _logger;
     private readonly IFileSystem _fileSystem;
     private readonly ILocalizationManager _localization;
@@ -30,12 +30,12 @@ public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
     /// <summary>
     /// Initializes a new instance of the <see cref="DeleteCacheFileTask" /> class.
     /// </summary>
-    /// <param name="appPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
+    /// <param name="appPaths">Instance of the <see cref="IServerApplicationPaths"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     public DeleteCacheFileTask(
-        IApplicationPaths appPaths,
+        IServerApplicationPaths appPaths,
         ILogger<DeleteCacheFileTask> logger,
         IFileSystem fileSystem,
         ILocalizationManager localization)
@@ -84,7 +84,8 @@ public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
 
         try
         {
-            DeleteCacheFilesFromDirectory(_applicationPaths.CachePath, minDateModified, progress, cancellationToken);
+            var metadataPath = GetProtectedMetadataPath();
+            DeleteCacheFilesFromDirectory(_applicationPaths.CachePath, minDateModified, progress, cancellationToken, metadataPath);
         }
         catch (DirectoryNotFoundException)
         {
@@ -114,10 +115,17 @@ public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
     /// <param name="minDateModified">The min date modified.</param>
     /// <param name="progress">The progress.</param>
     /// <param name="cancellationToken">The task cancellation token.</param>
-    private void DeleteCacheFilesFromDirectory(string directory, DateTime minDateModified, IProgress<double> progress, CancellationToken cancellationToken)
+    /// <param name="excludedDirectory">An optional directory to exclude.</param>
+    private void DeleteCacheFilesFromDirectory(
+        string directory,
+        DateTime minDateModified,
+        IProgress<double> progress,
+        CancellationToken cancellationToken,
+        string? excludedDirectory = null)
     {
         var filesToDelete = _fileSystem.GetFiles(directory, true)
-            .Where(f => _fileSystem.GetLastWriteTimeUtc(f) < minDateModified)
+            .Where(f => _fileSystem.GetLastWriteTimeUtc(f) < minDateModified
+                && (excludedDirectory is null || !IsPathEqualOrSubPath(excludedDirectory, f.FullName)))
             .ToList();
 
         var index = 0;
@@ -139,5 +147,41 @@ public class DeleteCacheFileTask : IScheduledTask, IConfigurableScheduledTask
         FileSystemHelper.DeleteEmptyFolders(_fileSystem, directory, _logger);
 
         progress.Report(100);
+    }
+
+    private string? GetProtectedMetadataPath()
+    {
+        var cachePath = Path.GetFullPath(_applicationPaths.CachePath);
+        var metadataPath = Path.GetFullPath(_applicationPaths.InternalMetadataPath);
+
+        if (!IsPathEqualOrSubPath(cachePath, metadataPath))
+        {
+            return null;
+        }
+
+        _logger.LogWarning(
+            "The metadata directory {MetadataPath} is inside the cache directory {CachePath} and will be excluded from cache cleanup",
+            metadataPath,
+            cachePath);
+
+        return metadataPath;
+    }
+
+    private static bool IsPathEqualOrSubPath(string directory, string path)
+    {
+        var normalizedDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+        var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        if (string.Equals(normalizedDirectory, normalizedPath, comparison))
+        {
+            return true;
+        }
+
+        var directoryWithSeparator = normalizedDirectory.EndsWith(Path.DirectorySeparatorChar)
+            ? normalizedDirectory
+            : normalizedDirectory + Path.DirectorySeparatorChar;
+
+        return normalizedPath.StartsWith(directoryWithSeparator, comparison);
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/ScheduledTasks/DeleteCacheFileTaskTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/ScheduledTasks/DeleteCacheFileTaskTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Emby.Server.Implementations.ScheduledTasks.Tasks;
+using MediaBrowser.Controller;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.ScheduledTasks;
+
+public class DeleteCacheFileTaskTests
+{
+    private static readonly DateTime _staleLastWriteTimeUtc = DateTime.UtcNow.AddDays(-31);
+
+    [Fact]
+    public void ExecuteAsync_MetadataOutsideCache_DeletesStaleCacheFilesWithoutWarning()
+    {
+        var cachePath = GetTestPath("cache");
+        var tempPath = GetTestPath("temp");
+        var metadataPath = GetTestPath("metadata");
+        var cacheFile = CreateFile(Path.Combine(cachePath, "cache.dat"));
+        var fileSystem = CreateFileSystem(cachePath, tempPath, [cacheFile]);
+        var logger = new Mock<ILogger<DeleteCacheFileTask>>();
+        var task = CreateTask(cachePath, tempPath, metadataPath, fileSystem.Object, logger.Object);
+
+        task.ExecuteAsync(Mock.Of<IProgress<double>>(), CancellationToken.None);
+
+        fileSystem.Verify(f => f.DeleteFile(cacheFile.FullName), Times.Once);
+        VerifyWarning(logger, Times.Never());
+    }
+
+    [Fact]
+    public void ExecuteAsync_MetadataInsideCache_ExcludesMetadataButDeletesOtherCacheAndTempFiles()
+    {
+        var cachePath = GetTestPath("cache");
+        var tempPath = GetTestPath("temp");
+        var metadataPath = Path.Combine(cachePath, "metadata");
+        var cacheFile = CreateFile(Path.Combine(cachePath, "cache.dat"));
+        var metadataFile = CreateFile(Path.Combine(metadataPath, "poster.jpg"));
+        var nestedMetadataFile = CreateFile(Path.Combine(metadataPath, "library", "backdrop.jpg"));
+        var similarlyNamedFile = CreateFile(Path.Combine(cachePath, "metadata2", "cache.dat"));
+        var tempFile = CreateFile(Path.Combine(tempPath, "temp.dat"));
+        var fileSystem = CreateFileSystem(
+            cachePath,
+            tempPath,
+            [cacheFile, metadataFile, nestedMetadataFile, similarlyNamedFile],
+            [tempFile]);
+        var logger = new Mock<ILogger<DeleteCacheFileTask>>();
+        var task = CreateTask(cachePath, tempPath, metadataPath, fileSystem.Object, logger.Object);
+
+        task.ExecuteAsync(Mock.Of<IProgress<double>>(), CancellationToken.None);
+
+        fileSystem.Verify(f => f.DeleteFile(cacheFile.FullName), Times.Once);
+        fileSystem.Verify(f => f.DeleteFile(similarlyNamedFile.FullName), Times.Once);
+        fileSystem.Verify(f => f.DeleteFile(tempFile.FullName), Times.Once);
+        fileSystem.Verify(f => f.DeleteFile(metadataFile.FullName), Times.Never());
+        fileSystem.Verify(f => f.DeleteFile(nestedMetadataFile.FullName), Times.Never());
+        VerifyWarning(logger, Times.Once());
+    }
+
+    [Fact]
+    public void ExecuteAsync_MetadataEqualsCache_DoesNotDeleteCacheFiles()
+    {
+        var cachePath = GetTestPath("cache");
+        var tempPath = GetTestPath("temp");
+        var cacheFile = CreateFile(Path.Combine(cachePath, "cache.dat"));
+        var nestedCacheFile = CreateFile(Path.Combine(cachePath, "nested", "cache.dat"));
+        var fileSystem = CreateFileSystem(cachePath, tempPath, [cacheFile, nestedCacheFile]);
+        var logger = new Mock<ILogger<DeleteCacheFileTask>>();
+        var task = CreateTask(cachePath, tempPath, cachePath, fileSystem.Object, logger.Object);
+
+        task.ExecuteAsync(Mock.Of<IProgress<double>>(), CancellationToken.None);
+
+        fileSystem.Verify(f => f.DeleteFile(It.IsAny<string>()), Times.Never());
+        VerifyWarning(logger, Times.Once());
+    }
+
+    [Fact]
+    public void ExecuteAsync_CacheDirectoryDoesNotExist_CompletesProgress()
+    {
+        var cachePath = GetTestPath("cache");
+        var tempPath = GetTestPath("temp");
+        var metadataPath = GetTestPath("metadata");
+        var fileSystem = CreateFileSystem(cachePath, tempPath, []);
+        fileSystem.Setup(f => f.GetFiles(cachePath, true)).Throws<DirectoryNotFoundException>();
+        var progress = new Mock<IProgress<double>>();
+        var task = CreateTask(
+            cachePath,
+            tempPath,
+            metadataPath,
+            fileSystem.Object,
+            NullLogger<DeleteCacheFileTask>.Instance);
+
+        task.ExecuteAsync(progress.Object, CancellationToken.None);
+
+        progress.Verify(p => p.Report(100), Times.Once);
+    }
+
+    private static DeleteCacheFileTask CreateTask(
+        string cachePath,
+        string tempPath,
+        string metadataPath,
+        IFileSystem fileSystem,
+        ILogger<DeleteCacheFileTask> logger)
+    {
+        var applicationPaths = new Mock<IServerApplicationPaths>();
+        applicationPaths.SetupGet(p => p.CachePath).Returns(cachePath);
+        applicationPaths.SetupGet(p => p.TempDirectory).Returns(tempPath);
+        applicationPaths.SetupGet(p => p.InternalMetadataPath).Returns(metadataPath);
+
+        return new DeleteCacheFileTask(
+            applicationPaths.Object,
+            logger,
+            fileSystem,
+            Mock.Of<ILocalizationManager>());
+    }
+
+    private static Mock<IFileSystem> CreateFileSystem(
+        string cachePath,
+        string tempPath,
+        IReadOnlyList<FileSystemMetadata> cacheFiles,
+        IReadOnlyList<FileSystemMetadata>? tempFiles = null)
+    {
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(f => f.GetFiles(cachePath, true)).Returns(cacheFiles);
+        fileSystem.Setup(f => f.GetFiles(tempPath, true)).Returns(tempFiles ?? []);
+        fileSystem.Setup(f => f.GetLastWriteTimeUtc(It.IsAny<FileSystemMetadata>())).Returns(_staleLastWriteTimeUtc);
+        fileSystem.Setup(f => f.GetDirectoryPaths(It.IsAny<string>(), It.IsAny<bool>())).Returns([]);
+        return fileSystem;
+    }
+
+    private static FileSystemMetadata CreateFile(string path)
+        => new()
+        {
+            FullName = path,
+            Name = Path.GetFileName(path)
+        };
+
+    private static string GetTestPath(string directory)
+        => Path.Combine(Path.GetTempPath(), nameof(DeleteCacheFileTaskTests), directory);
+
+    private static void VerifyWarning(Mock<ILogger<DeleteCacheFileTask>> logger, Times times)
+    {
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("excluded from cache cleanup", StringComparison.Ordinal)),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            times);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the "Clean Cache Directory" scheduled task (`DeleteCacheFileTask`) metadata-aware so it never deletes files that live under the configured metadata directory. The task now resolves the effective metadata path through `IServerApplicationPaths.InternalMetadataPath` and, when that directory is the same as or nested inside `CachePath`, excludes every file beneath it from the cache-cleanup pass. The containment check normalizes both paths with `Path.GetFullPath`, compares case-insensitively on Windows and ordinally elsewhere, and requires a trailing directory separator, so a sibling such as `metadata2` next to `metadata` is not protected. A single warning is logged when the metadata directory is detected inside the cache directory. The short-lived `TempDirectory` pass is left unchanged, so genuinely stale cache files are still removed exactly as before.

## Background

`DeleteCacheFileTask` recursively deletes every file older than 30 days under `CachePath`. When a server's metadata directory is configured as the cache directory or a child of it, the task also deletes stored metadata images such as posters, logos, and backdrops; those images only reappear after a full library refresh, which is the root cause behind reports of artwork randomly disappearing over days or weeks. The existing top-level marker system does not protect a metadata folder nested inside the cache folder, so a metadata path that resolves inside the cache path needs to be excluded explicitly. This change prevents the data loss without altering cleanup behavior for genuinely stale cache files.

Fixes #15849
