### PR TITLE
Drain stderr and stdout concurrently for encoder validation

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MediaBrowser.Controller.MediaEncoding;
 using Microsoft.Extensions.Logging;
 
@@ -662,8 +663,15 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     writer.Write(testKey);
                 }
 
-                using var reader = readStdErr ? process.StandardError : process.StandardOutput;
-                return reader.ReadToEnd();
+                // Drain both streams concurrently to prevent pipe hanging, see #17429
+                using var standardOutput = process.StandardOutput;
+                using var standardError = process.StandardError;
+                var standardOutputTask = standardOutput.ReadToEndAsync();
+                var standardErrorTask = standardError.ReadToEndAsync();
+                process.WaitForExit();
+                Task.WaitAll(standardOutputTask, standardErrorTask);
+
+                return (readStdErr ? standardErrorTask : standardOutputTask).GetAwaiter().GetResult();
             }
         }
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Some ffmpeg build might output extremely long traces for its banner that consume all pipe capacity and hangs the process. We have to drain both streams regardless on which one we actually read.


**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #17429
