### PR TITLE
remove ogg from video extensions since it should only be used for audio

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -57,7 +57,6 @@ namespace Emby.Naming.Common
                 ".nrg",
                 ".nsv",
                 ".nuv",
-                ".ogg",
                 ".ogm",
                 ".ogv",
                 ".pva",


### PR DESCRIPTION
**Changes**

The use of `.ogg` has only been valid for audio files since [2008](https://www.ietf.org/rfc/rfc5334.txt) so we should reflect that. It should also be noted that `.ogm` was never officially supported but I have no horse in that race.

**Code Assistance**

None

**Issues**

None