### PR TITLE
Auto-scale default SQLite cache_size to fix slow ItemsByName endpoints

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -26,7 +26,14 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     /// Initializes a new instance of the <see cref="PragmaConnectionInterceptor"/> class.
     /// </summary>
     /// <param name="logger">The logger.</param>
-    /// <param name="cacheSize">Cache size.</param>
+    /// <param name="cacheSize">
+    /// The <see href="https://sqlite.org/pragma.html#pragma_cache_size">cache_size</see> pragma value.
+    /// A positive value is a number of pages; a negative value is a size in KiB (page-size independent).
+    /// When <see langword="null"/> no <c>PRAGMA cache_size</c> is emitted and SQLite keeps its 2 MiB
+    /// default. Operators can override it with the <c>cacheSize</c> custom provider option; when unset it
+    /// is auto-scaled to available memory by
+    /// <see cref="SqliteDatabaseProvider.GetDefaultCacheSize"/> (see jellyfin/jellyfin#17405).
+    /// </param>
     /// <param name="lockingMode">Locking mode.</param>
     /// <param name="journalSizeLimit">Journal Size.</param>
     /// <param name="tempStoreMode">The https://sqlite.org/pragma.html#pragma_temp_store pragma.</param>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -83,7 +83,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                     .Ignore(RelationalEventId.MultipleCollectionIncludeWarning))
             .AddInterceptors(new PragmaConnectionInterceptor(
                 _logger,
-                GetOption<int?>(customOptions, "cacheSize", e => int.Parse(e, CultureInfo.InvariantCulture)),
+                GetOption<int?>(customOptions, "cacheSize", e => int.Parse(e, CultureInfo.InvariantCulture), () => GetDefaultCacheSize()),
                 GetOption(customOptions, "lockingmode", e => e, () => "NORMAL")!,
                 GetOption(customOptions, "journalsizelimit", int.Parse, () => 134_217_728),
                 GetOption(customOptions, "tempstoremode", int.Parse, () => 2),
@@ -96,6 +96,45 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             options.EnableSensitiveDataLogging(enableSensitiveDataLogging);
             _logger.LogInformation("EnableSensitiveDataLogging is enabled on SQLite connection");
         }
+    }
+
+    /// <summary>
+    /// Computes the default SQLite <c>PRAGMA cache_size</c> when the operator has not set an explicit
+    /// <c>cacheSize</c> custom provider option.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SQLite defaults to a 2 MiB page cache. The Jellyfin database uses a 64 KiB page size, so the
+    /// default is only ~32 pages. The ItemsByName queries (<c>/Artists</c>, <c>/Studios</c>,
+    /// <c>/Genres</c>, ...) run a window sort over an <c>IN (&lt;subquery over ItemValuesMap&gt;)</c>
+    /// whose working set does not fit in ~32 pages, so on large libraries the connection thrashes the
+    /// page cache and every request re-reads the same pages from disk. A cache large enough to hold the
+    /// hot working set removes the thrashing (see jellyfin/jellyfin#17405).
+    /// </para>
+    /// <para>
+    /// The value is returned as a negative number, which SQLite interprets as a size in KiB (so it is
+    /// independent of the page size). It is scaled to a small fraction of the memory actually available
+    /// to the process — <see cref="GCMemoryInfo.TotalAvailableMemoryBytes"/> honours cgroup / container
+    /// limits, so a memory-limited container is respected — and clamped to a sane range. This keeps the
+    /// footprint negligible on small devices (Raspberry Pi, NAS) while giving large installs enough
+    /// cache to avoid the thrashing. Note that SQLite allocates the cache lazily and per connection, so
+    /// the clamp is an upper bound on each pooled connection's cache, not a fixed reservation.
+    /// </para>
+    /// </remarks>
+    /// <returns>The default <c>cache_size</c> PRAGMA value (negative = KiB).</returns>
+    public static int GetDefaultCacheSize()
+    {
+        // Bounds (in KiB, negated on return). The performance win saturates well before 128 MiB on a
+        // ~200k-item library, so there is no benefit to going higher; 16 MiB is plenty for tiny libraries.
+        const long MinCacheKiB = 16L * 1024; // 16 MiB
+        const long MaxCacheKiB = 128L * 1024; // 128 MiB
+
+        // Target ~1/16th of the memory available to the process, container/cgroup aware.
+        var availableBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+        var targetKiB = availableBytes > 0 ? availableBytes / 16 / 1024 : MaxCacheKiB;
+
+        var clampedKiB = Math.Clamp(targetKiB, MinCacheKiB, MaxCacheKiB);
+        return -(int)clampedKiB;
     }
 
     /// <inheritdoc/>

--- a/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteCacheSizeTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Data/SqliteCacheSizeTests.cs
@@ -1,0 +1,41 @@
+using Jellyfin.Database.Providers.Sqlite;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Data;
+
+/// <summary>
+/// Regression tests for the default SQLite <c>PRAGMA cache_size</c> (jellyfin/jellyfin#17405).
+/// Before the fix the <c>cacheSize</c> option defaulted to <c>null</c>, so no <c>PRAGMA cache_size</c>
+/// was emitted and SQLite used its 2 MiB default — which thrashes on the ItemsByName queries on
+/// large libraries. These tests guard the default from silently regressing back to "unset".
+/// </summary>
+public static class SqliteCacheSizeTests
+{
+    [Fact]
+    public static void GetDefaultCacheSize_IsNegative_SoItIsInterpretedAsKiBAndAlwaysEmitted()
+    {
+        // A negative value means "size in KiB" to SQLite and, crucially, is non-null so the
+        // interceptor actually emits `PRAGMA cache_size`. The pre-fix bug was this being unset.
+        Assert.True(SqliteDatabaseProvider.GetDefaultCacheSize() < 0);
+    }
+
+    [Fact]
+    public static void GetDefaultCacheSize_IsClampedToSaneRange()
+    {
+        // KiB, negated. Must stay within [16 MiB, 128 MiB] regardless of host memory:
+        // small enough not to hurt a Raspberry Pi, large enough to hold the ItemsByName working set.
+        const int MinKiB = 16 * 1024;
+        const int MaxKiB = 128 * 1024;
+
+        var sizeKiB = -SqliteDatabaseProvider.GetDefaultCacheSize();
+
+        Assert.InRange(sizeKiB, MinKiB, MaxKiB);
+    }
+
+    [Fact]
+    public static void GetDefaultCacheSize_IsDeterministic()
+    {
+        // Same process/host => same value on every connection open.
+        Assert.Equal(SqliteDatabaseProvider.GetDefaultCacheSize(), SqliteDatabaseProvider.GetDefaultCacheSize());
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj
+++ b/tests/Jellyfin.Server.Implementations.Tests/Jellyfin.Server.Implementations.Tests.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\Jellyfin.Server.Implementations\Jellyfin.Server.Implementations.csproj" />
     <ProjectReference Include="..\Jellyfin.Server.Integration.Tests\Jellyfin.Server.Integration.Tests.csproj" />
     <ProjectReference Include="..\..\src\Jellyfin.Database\Jellyfin.Database.Implementations\Jellyfin.Database.Implementations.csproj" />
+    <ProjectReference Include="..\..\src\Jellyfin.Database\Jellyfin.Database.Providers.Sqlite\Jellyfin.Database.Providers.Sqlite.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**Changes**

The SQLite provider already exposes a `cacheSize` custom option that feeds `PragmaConnectionInterceptor`, but it defaults to `null`, so no `PRAGMA cache_size` is emitted and SQLite falls back to its 2 MiB default. On large libraries the ItemsByName queries (`/Artists`, `/Studios`, `/Genres`, `/AlbumArtists`) run a `ROW_NUMBER() ... PARTITION BY PresentationUniqueKey` window sort over an `IN (<subquery over the ~777k-row ItemValuesMap>)`, whose working set does not fit in a 2 MiB cache, so the connection thrashes and re-reads pages from disk on every request.

This PR gives `cacheSize` a default when the operator has not set one. It scales to ~1/16 of the memory available to the process (`GC.GetGCMemoryInfo().TotalAvailableMemoryBytes`, which is cgroup/container aware), clamped to [16 MiB, 128 MiB]. Small devices stay light, large installs get enough cache to hold the working set. `cache_size` only affects performance, never results, and operators can still override via the `cacheSize` option.

**Correction on the earlier page-size claim**

My original writeup said "the Jellyfin DB uses a 64 KiB page size, making that only ~32 pages". That is wrong as a general statement, @LTe pointed this out. A fresh 12.0-rc install creates a database with SQLite's default 4096 byte page size (verified). My own databases are 64 KiB, but that is specific to my install (created during a restore somewhere along a multi-year upgrade path), not something Jellyfin sets. Jellyfin does not set `page_size` anywhere in code, in any version. The fix does not depend on page size, so I re-ran everything on a 4 KiB database.

**Measurements**

All against a ~189k item library, PII-redacted copy, only HTTP 200 responses timed, `cacheSize=-262144` (256 MiB) for the "after" column.

4 KiB page size (the default, matching a normal install):

| endpoint | before (2 MiB default) | after |
|---|---|---|
| `/Studios` | ~16 s | **~3.2 s** |
| `/Artists` (favorites) | ~16 s | **~3.3 s** |
| `/Genres` | ~16 s | **~3.3 s** |

64 KiB page size (my install, kept for reference, this is the number I originally posted):

| endpoint | before | after |
|---|---|---|
| `/Studios` | ~35 s | ~2.1 s |
| `/Artists` (favorites) | ~35 s | ~2.2 s |
| `/Genres` | ~35 s | ~2.3 s |

So the effect is smaller on a stock 4 KiB DB than my original 64 KiB numbers implied, but it is still a large win (~5x). Page size shifts the magnitude, not the conclusion: the 2 MiB default is too small for a large library's working set regardless.

Cache-size sweep on the exact representative-id statement via `Microsoft.Data.Sqlite` against a cold DB copy, 4 KiB page size (cold / warm ms):

| cache_size | cold | warm |
|---|---|---|
| 2 MiB (default) | 127 | 117 |
| 8 MiB | 83 | 194 |
| 32 MiB | 75 | 15 |
| 128 MiB | 74 | 15 |
| 256 MiB | 72 | 17 |

The win flattens out by ~128 MiB, which is why the auto-scaled default clamps there.

Adds regression tests (`SqliteCacheSizeTests`) asserting the default is emitted (non-null, the actual regression), negative (interpreted as KiB), deterministic, and clamped to the sane range. Full solution builds clean and the tests pass locally (`dotnet test`, 3/3).

**Documentation**

Since the existing `cacheSize` / `#PRAGMA:` knobs (merged in 10.11) are undocumented, I opened jellyfin/jellyfin.org#1955 to document `database.xml` and cache_size guidance for large libraries, independent of whether this default change lands. Per @LTe's point in #15986, that covers the "leave it to the admin" path too.

**Code assistance**

Investigation, root-cause isolation (Stopwatch instrumentation plus a standalone `Microsoft.Data.Sqlite` probe to rule out EF translation and prove the page-cache cause), the cache-size sweep, benchmarking, and drafting were done with LLM assistance. All code, measurements, and the passing build/tests were reviewed and verified by me.

**Issues**

Refs #17405

