### PR TITLE
Fix hyphenated numbers in episode titles parsed as multi-episodes

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -361,7 +361,10 @@ namespace Emby.Naming.Common
                 // Not a Kodi rule as well, but the expression below also causes false positives,
                 // so we make sure this one gets tested first.
                 // "Foo Bar 889"
-                new EpisodeExpression(@".*[\\\/](?![Ee]pisode)(?<seriesname>[\w\s]+?)\s(?<epnumber>[0-9]{1,4})(-(?<endingepnumber>[0-9]{2,4}))*[^\\\/x]*$")
+                // Names carrying an SxxEyy marker are excluded because the Kodi expression above already covers them.
+                // Without that guard this expression reads digits out of the title instead, turning
+                // "S01E01 1-23-45 [Bluray-1080p]" into episodes 1 through 45.
+                new EpisodeExpression(@".*[\\\/](?![Ee]pisode)(?![^\\\/]*[Ss][0-9]+[][ ._-]*[Ee][0-9]+)(?<seriesname>[\w\s]+?)\s(?<epnumber>[0-9]{1,4})(-(?<endingepnumber>[0-9]{2,4}))*[^\\\/x]*$")
                 {
                     IsNamed = true
                 },

--- a/tests/Jellyfin.Naming.Tests/TV/MultiEpisodeTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/MultiEpisodeTests.cs
@@ -69,6 +69,11 @@ namespace Jellyfin.Naming.Tests.TV
         [InlineData("Season 1/series-s09e14-720i.mkv", null)]
         [InlineData("Season 1/MOONLIGHTING_s01e01-e04.mkv", 4)]
         [InlineData("Season 1/MOONLIGHTING_s01e01-e04", 4)]
+        // Hyphenated numbers in the episode title must not be read as an episode range
+        [InlineData("Season 1/S01E01 The 6-10 to Lubbock [WEBRip-1080p][AV1 Opus].mkv", null)]
+        [InlineData("Season 5/S05E23 11-59 [HDTV-1080p][x265 AC3].mkv", null)]
+        [InlineData("Season 5/S05E23 11-59 [HDTV-1080p][HEVC AC3].mkv", null)]
+        [InlineData("Season 1/S01E01 1-23-45 [Bluray-1080p][AV1 Opus].mkv", null)]
         public void TestGetEndingEpisodeNumberFromFile(string filename, int? endingEpisodeNumber)
         {
             var result = _episodePathParser.Parse(filename, false);


### PR DESCRIPTION
The `Foo Bar 889` fallback expression matched filenames that already carry an SxxEyy marker, reading digits out of the title as an episode range: `S01E01 1-23-45 [Bluray-1080p]` became episodes 1 through 45 and `S01E01 The 6-10 to Lubbock` became episodes 1 through 10.
It never won the primary parse, the Kodi expression above it did, but reached these files through `FillAdditional`'s series-name recovery path, where it also set SeriesName to `S01E01`.

**Changes**
Exclude those names with the same marker pattern the Kodi expression uses, so the fallback steps aside exactly when that rule applies.

**Code assistance**
None

**Issues**
Fixes #17431