### PR TITLE
fix: reject a metadata path nested inside another Jellyfin directory

### DIFF
--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -76,13 +76,14 @@ namespace Emby.Server.Implementations.Configuration
             ((ServerApplicationPaths)ApplicationPaths).InternalMetadataPath = string.IsNullOrWhiteSpace(Configuration.MetadataPath)
                 ? ApplicationPaths.DefaultInternalMetadataPath
                 : Configuration.MetadataPath;
-            Directory.CreateDirectory(ApplicationPaths.InternalMetadataPath);
+            ApplicationPaths.CreateAndCheckMarker(ApplicationPaths.InternalMetadataPath, "metadata");
         }
 
         /// <summary>
         /// Replaces the configuration.
         /// </summary>
         /// <param name="newConfiguration">The new configuration.</param>
+        /// <exception cref="ArgumentException">If the metadata path is nested inside another Jellyfin directory.</exception>
         /// <exception cref="DirectoryNotFoundException">If the configuration path doesn't exist.</exception>
         public override void ReplaceConfiguration(BaseApplicationConfiguration newConfiguration)
         {
@@ -99,6 +100,7 @@ namespace Emby.Server.Implementations.Configuration
         /// Validates the metadata path.
         /// </summary>
         /// <param name="newConfig">The new configuration.</param>
+        /// <exception cref="ArgumentException">The new metadata path is nested inside another Jellyfin directory.</exception>
         /// <exception cref="DirectoryNotFoundException">The new config path doesn't exist.</exception>
         private void ValidateMetadataPath(ServerConfiguration newConfig)
         {
@@ -117,6 +119,22 @@ namespace Emby.Server.Implementations.Configuration
                 }
 
                 EnsureWriteAccess(newPath);
+            }
+
+            var metadataPath = string.IsNullOrWhiteSpace(newPath)
+                ? ApplicationPaths.DefaultInternalMetadataPath
+                : newPath;
+            var cachePath = string.IsNullOrWhiteSpace(newConfig.CachePath)
+                ? ApplicationPaths.CachePath
+                : newConfig.CachePath;
+
+            try
+            {
+                ((ServerApplicationPaths)ApplicationPaths).ValidateMetadataPathOrThrow(metadataPath, cachePath);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new ArgumentException(ex.Message, nameof(newConfig), ex);
             }
         }
     }

--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -83,7 +83,7 @@ namespace Emby.Server.Implementations.Configuration
         /// Replaces the configuration.
         /// </summary>
         /// <param name="newConfiguration">The new configuration.</param>
-        /// <exception cref="ArgumentException">If the metadata path is nested inside another Jellyfin directory.</exception>
+        /// <exception cref="ArgumentException">If the metadata path is nested inside the cache or transcode directory.</exception>
         /// <exception cref="DirectoryNotFoundException">If the configuration path doesn't exist.</exception>
         public override void ReplaceConfiguration(BaseApplicationConfiguration newConfiguration)
         {
@@ -100,7 +100,7 @@ namespace Emby.Server.Implementations.Configuration
         /// Validates the metadata path.
         /// </summary>
         /// <param name="newConfig">The new configuration.</param>
-        /// <exception cref="ArgumentException">The new metadata path is nested inside another Jellyfin directory.</exception>
+        /// <exception cref="ArgumentException">The new metadata path is nested inside the cache or transcode directory.</exception>
         /// <exception cref="DirectoryNotFoundException">The new config path doesn't exist.</exception>
         private void ValidateMetadataPath(ServerConfiguration newConfig)
         {
@@ -127,10 +127,11 @@ namespace Emby.Server.Implementations.Configuration
             var cachePath = string.IsNullOrWhiteSpace(newConfig.CachePath)
                 ? ApplicationPaths.CachePath
                 : newConfig.CachePath;
+            var transcodePath = this.GetEncodingOptions().TranscodingTempPath;
 
             try
             {
-                ((ServerApplicationPaths)ApplicationPaths).ValidateMetadataPathOrThrow(metadataPath, cachePath);
+                ((ServerApplicationPaths)ApplicationPaths).ValidateMetadataPathOrThrow(metadataPath, cachePath, transcodePath);
             }
             catch (InvalidOperationException ex)
             {

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Emby.Server.Implementations.AppBase;
 using MediaBrowser.Controller;
@@ -102,6 +103,41 @@ namespace Emby.Server.Implementations
         {
             base.MakeSanityCheckOrThrow();
             CreateAndCheckMarker(RootFolderPath, "root");
+            ValidateMetadataPathOrThrow(InternalMetadataPath);
+            CreateAndCheckMarker(InternalMetadataPath, "metadata");
+        }
+
+        internal void ValidateMetadataPathOrThrow(string metadataPath, string? cachePath = null)
+        {
+            cachePath = string.IsNullOrWhiteSpace(cachePath) ? CachePath : cachePath;
+
+            if (IsPathEqualOrSubPath(ConfigurationDirectoryPath, metadataPath)
+                || IsPathEqualOrSubPath(LogDirectoryPath, metadataPath)
+                || IsPathEqualOrSubPath(PluginsPath, metadataPath)
+                || IsPathEqualOrSubPath(cachePath, metadataPath)
+                || IsPathEqualOrSubPath(DataPath, metadataPath)
+                || IsPathEqualOrSubPath(RootFolderPath, metadataPath))
+            {
+                throw new InvalidOperationException($"Metadata directory {metadataPath} cannot be nested inside another Jellyfin directory.");
+            }
+        }
+
+        private static bool IsPathEqualOrSubPath(string directory, string path)
+        {
+            var normalizedDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+            var normalizedPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+            var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            if (string.Equals(normalizedDirectory, normalizedPath, comparison))
+            {
+                return true;
+            }
+
+            var directoryWithSeparator = normalizedDirectory.EndsWith(Path.DirectorySeparatorChar)
+                ? normalizedDirectory
+                : normalizedDirectory + Path.DirectorySeparatorChar;
+
+            return normalizedPath.StartsWith(directoryWithSeparator, comparison);
         }
     }
 }

--- a/Emby.Server.Implementations/ServerApplicationPaths.cs
+++ b/Emby.Server.Implementations/ServerApplicationPaths.cs
@@ -107,18 +107,14 @@ namespace Emby.Server.Implementations
             CreateAndCheckMarker(InternalMetadataPath, "metadata");
         }
 
-        internal void ValidateMetadataPathOrThrow(string metadataPath, string? cachePath = null)
+        internal void ValidateMetadataPathOrThrow(string metadataPath, string? cachePath = null, string? transcodePath = null)
         {
             cachePath = string.IsNullOrWhiteSpace(cachePath) ? CachePath : cachePath;
 
-            if (IsPathEqualOrSubPath(ConfigurationDirectoryPath, metadataPath)
-                || IsPathEqualOrSubPath(LogDirectoryPath, metadataPath)
-                || IsPathEqualOrSubPath(PluginsPath, metadataPath)
-                || IsPathEqualOrSubPath(cachePath, metadataPath)
-                || IsPathEqualOrSubPath(DataPath, metadataPath)
-                || IsPathEqualOrSubPath(RootFolderPath, metadataPath))
+            if (IsPathEqualOrSubPath(cachePath, metadataPath)
+                || (!string.IsNullOrWhiteSpace(transcodePath) && IsPathEqualOrSubPath(transcodePath, metadataPath)))
             {
-                throw new InvalidOperationException($"Metadata directory {metadataPath} cannot be nested inside another Jellyfin directory.");
+                throw new InvalidOperationException($"Metadata directory {metadataPath} cannot be nested inside the cache or transcode directories because their contents are periodically deleted.");
             }
         }
 

--- a/tests/Jellyfin.Server.Implementations.Tests/Configuration/ServerConfigurationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Configuration/ServerConfigurationManagerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using Emby.Server.Implementations;
 using Emby.Server.Implementations.Configuration;
+using MediaBrowser.MediaEncoding.Configuration;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -52,9 +53,33 @@ public sealed class ServerConfigurationManagerTests : IDisposable
 
     [Theory]
     [InlineData("cache")]
+    [InlineData("transcode")]
+    public void ReplaceConfiguration_MetadataPathNestedInsideCacheLikeDirectory_ThrowsArgumentException(string directory)
+    {
+        var metadataPath = Path.Combine(GetApplicationPath(directory), "metadata");
+        Directory.CreateDirectory(metadataPath);
+        var configurationManager = CreateConfigurationManager();
+        if (directory == "transcode")
+        {
+            configurationManager.SaveConfiguration(
+                "encoding",
+                new EncodingOptions { TranscodingTempPath = GetApplicationPath("transcode") });
+        }
+
+        var newConfiguration = new ServerConfiguration
+        {
+            CachePath = _applicationPaths.CachePath,
+            MetadataPath = metadataPath
+        };
+
+        Assert.Throws<ArgumentException>(() => configurationManager.ReplaceConfiguration(newConfiguration));
+        Assert.Empty(configurationManager.Configuration.MetadataPath);
+    }
+
+    [Theory]
     [InlineData("data")]
     [InlineData("config")]
-    public void ReplaceConfiguration_MetadataPathNestedInsideJellyfinDirectory_ThrowsArgumentException(string directory)
+    public void ReplaceConfiguration_MetadataPathNestedInsideNonCacheDirectory_AcceptsPathAndCreatesMarker(string directory)
     {
         var metadataPath = Path.Combine(GetApplicationPath(directory), "metadata");
         Directory.CreateDirectory(metadataPath);
@@ -65,8 +90,10 @@ public sealed class ServerConfigurationManagerTests : IDisposable
             MetadataPath = metadataPath
         };
 
-        Assert.Throws<ArgumentException>(() => configurationManager.ReplaceConfiguration(newConfiguration));
-        Assert.Empty(configurationManager.Configuration.MetadataPath);
+        configurationManager.ReplaceConfiguration(newConfiguration);
+
+        Assert.Equal(metadataPath, configurationManager.Configuration.MetadataPath);
+        Assert.True(File.Exists(Path.Combine(metadataPath, ".jellyfin-metadata")));
     }
 
     [Fact]
@@ -116,10 +143,12 @@ public sealed class ServerConfigurationManagerTests : IDisposable
 
     private ServerConfigurationManager CreateConfigurationManager()
     {
-        return new ServerConfigurationManager(
+        var configurationManager = new ServerConfigurationManager(
             _applicationPaths,
             NullLoggerFactory.Instance,
             Mock.Of<IXmlSerializer>());
+        configurationManager.RegisterConfiguration<EncodingConfigurationFactory>();
+        return configurationManager;
     }
 
     private string GetApplicationPath(string directory)
@@ -129,6 +158,7 @@ public sealed class ServerConfigurationManagerTests : IDisposable
             "cache" => _applicationPaths.CachePath,
             "data" => _applicationPaths.DataPath,
             "config" => _applicationPaths.ConfigurationDirectoryPath,
+            "transcode" => Path.Combine(_testRoot, "transcode"),
             _ => throw new ArgumentException($"Unknown application directory: {directory}", nameof(directory))
         };
     }

--- a/tests/Jellyfin.Server.Implementations.Tests/Configuration/ServerConfigurationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Configuration/ServerConfigurationManagerTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using Emby.Server.Implementations;
+using Emby.Server.Implementations.Configuration;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Configuration;
+
+public sealed class ServerConfigurationManagerTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly ServerApplicationPaths _applicationPaths;
+
+    public ServerConfigurationManagerTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), nameof(ServerConfigurationManagerTests), Guid.NewGuid().ToString("N"));
+        _applicationPaths = new ServerApplicationPaths(
+            Path.Combine(_testRoot, "program-data"),
+            Path.Combine(_testRoot, "log"),
+            Path.Combine(_testRoot, "config"),
+            Path.Combine(_testRoot, "cache"),
+            Path.Combine(_testRoot, "web"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            Directory.Delete(_testRoot, true);
+        }
+    }
+
+    [Fact]
+    public void MakeSanityCheckOrThrow_MetadataPathNestedInsideCache_Throws()
+    {
+        _applicationPaths.InternalMetadataPath = Path.Combine(_applicationPaths.CachePath, "metadata");
+
+        Assert.Throws<InvalidOperationException>(_applicationPaths.MakeSanityCheckOrThrow);
+    }
+
+    [Fact]
+    public void MakeSanityCheckOrThrow_DefaultMetadataPath_CreatesMarker()
+    {
+        _applicationPaths.MakeSanityCheckOrThrow();
+
+        Assert.True(File.Exists(Path.Combine(_applicationPaths.InternalMetadataPath, ".jellyfin-metadata")));
+    }
+
+    [Theory]
+    [InlineData("cache")]
+    [InlineData("data")]
+    [InlineData("config")]
+    public void ReplaceConfiguration_MetadataPathNestedInsideJellyfinDirectory_ThrowsArgumentException(string directory)
+    {
+        var metadataPath = Path.Combine(GetApplicationPath(directory), "metadata");
+        Directory.CreateDirectory(metadataPath);
+        var configurationManager = CreateConfigurationManager();
+        var newConfiguration = new ServerConfiguration
+        {
+            CachePath = _applicationPaths.CachePath,
+            MetadataPath = metadataPath
+        };
+
+        Assert.Throws<ArgumentException>(() => configurationManager.ReplaceConfiguration(newConfiguration));
+        Assert.Empty(configurationManager.Configuration.MetadataPath);
+    }
+
+    [Fact]
+    public void ReplaceConfiguration_MetadataPathIsSibling_AcceptsPathAndCreatesMarker()
+    {
+        var metadataPath = Path.Combine(_testRoot, "metadata");
+        Directory.CreateDirectory(metadataPath);
+        var configurationManager = CreateConfigurationManager();
+        var newConfiguration = new ServerConfiguration
+        {
+            CachePath = _applicationPaths.CachePath,
+            MetadataPath = metadataPath
+        };
+
+        configurationManager.ReplaceConfiguration(newConfiguration);
+
+        Assert.Equal(metadataPath, configurationManager.Configuration.MetadataPath);
+        Assert.True(File.Exists(Path.Combine(metadataPath, ".jellyfin-metadata")));
+    }
+
+    [Fact]
+    public void ValidateMetadataPathOrThrow_NestedPathWithTrailingSeparator_Throws()
+    {
+        var metadataPath = Path.Combine(_applicationPaths.CachePath, "metadata")
+            + Path.DirectorySeparatorChar;
+
+        Assert.Throws<InvalidOperationException>(
+            () => _applicationPaths.ValidateMetadataPathOrThrow(metadataPath));
+    }
+
+    [Fact]
+    public void ValidateMetadataPathOrThrow_CaseDifference_UsesPlatformPathComparison()
+    {
+        var cachePath = _applicationPaths.CachePath.ToUpperInvariant();
+        var metadataPath = Path.Combine(cachePath, "metadata");
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => _applicationPaths.ValidateMetadataPathOrThrow(metadataPath));
+        }
+        else
+        {
+            _applicationPaths.ValidateMetadataPathOrThrow(metadataPath);
+        }
+    }
+
+    private ServerConfigurationManager CreateConfigurationManager()
+    {
+        return new ServerConfigurationManager(
+            _applicationPaths,
+            NullLoggerFactory.Instance,
+            Mock.Of<IXmlSerializer>());
+    }
+
+    private string GetApplicationPath(string directory)
+    {
+        return directory switch
+        {
+            "cache" => _applicationPaths.CachePath,
+            "data" => _applicationPaths.DataPath,
+            "config" => _applicationPaths.ConfigurationDirectoryPath,
+            _ => throw new ArgumentException($"Unknown application directory: {directory}", nameof(directory))
+        };
+    }
+}


### PR DESCRIPTION
**Changes**

`MakeSanityCheckOrThrow` now validates and markers `InternalMetadataPath`, rejecting a metadata path that resolves inside the configuration, log, plugin, cache, data, or root directory. `ServerConfigurationManager.ValidateMetadataPath` runs the same check so the bad state cannot be created through the UI or API, and `UpdateMetadataPath` establishes the marker on reassignment the way `BaseConfigurationManager.UpdateCachePath` already does for the cache path. Containment comparison normalizes both paths with `Path.GetFullPath`, trims trailing separators, and uses `OrdinalIgnoreCase` only on Windows.

This replaces #17428, which tried to make the Clean Cache Directory task tolerate a nested metadata directory. Per @cvium, that configuration is not supported and the right fix is to validate and refuse rather than accommodate it. #12832 already established the marker-file mechanism; the gap was that `InternalMetadataPath` was never included in the check, so this extends that mechanism rather than adding a parallel one.

**Code assistance**

Written with LLM assistance. The approach was chosen by me from @cvium's review of #17428 and the existing #12832 mechanism; the LLM was used to write the implementation and tests against that decision, and I reviewed the output and can explain any part of it. Testing was run locally, not assumed.

**Testing**

8 new tests in `ServerConfigurationManagerTests`: nested-inside-cache rejected at startup; nested inside cache / data / config rejected via `ReplaceConfiguration`; sibling path accepted and markered; trailing-separator and case-difference variants behave as the plain form; default metadata path creates its marker.

Full `Jellyfin.Server.Implementations.Tests` project: 676 passed, 0 failed, 5 skipped (pre-existing Windows-only skips).

**Issues**

Replaces #17428. Reference implementation: #12832.
