### PR TITLE
fix(subtitles): skip duplicate download when file already exists

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
+++ b/MediaBrowser.Providers/MediaInfo/FFProbeVideoInfo.cs
@@ -553,7 +553,8 @@ namespace MediaBrowser.Providers.MediaInfo
             {
                 var downloadedLanguages = await new SubtitleDownloader(
                     _logger,
-                    _subtitleManager).DownloadSubtitles(
+                    _subtitleManager,
+                    _localization).DownloadSubtitles(
                         video,
                         currentStreams.Concat(externalSubtitleStreams).ToList(),
                         libraryOptions.SkipSubtitlesIfEmbeddedSubtitlesPresent,

--- a/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Subtitles;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
 using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Providers.MediaInfo
@@ -22,11 +23,36 @@ namespace MediaBrowser.Providers.MediaInfo
     {
         private readonly ILogger _logger;
         private readonly ISubtitleManager _subtitleManager;
+        private readonly ILocalizationManager _localization;
 
-        public SubtitleDownloader(ILogger logger, ISubtitleManager subtitleManager)
+        public SubtitleDownloader(ILogger logger, ISubtitleManager subtitleManager, ILocalizationManager localization)
         {
             _logger = logger;
             _subtitleManager = subtitleManager;
+            _localization = localization;
+        }
+
+        /// <summary>
+        /// Normalizes an ISO language code (2-letter, 3-letter, or full name) to the
+        /// canonical <see cref="CultureDto.Name"/> so two codes referring to the same
+        /// language compare equal. Returns the input unchanged when no culture matches.
+        /// </summary>
+        /// <remarks>
+        /// Media streams store the language detected by FFprobe via <c>ExternalPathParser</c>,
+        /// which prefers the ISO 639-3 code (e.g. "eng"), while library options and subtitle
+        /// requests commonly use ISO 639-2 codes (e.g. "en"). A plain ordinal compare lets
+        /// an existing subtitle slip through the pre-download guard, causing a redundant
+        /// download that consumes the OpenSubtitles daily quota and re-creates the file.
+        /// </remarks>
+        private string NormalizeLanguage(string language)
+        {
+            if (string.IsNullOrEmpty(language))
+            {
+                return string.Empty;
+            }
+
+            var culture = _localization.FindLanguageInfo(language);
+            return culture?.Name ?? language;
         }
 
         public async Task<List<string>> DownloadSubtitles(
@@ -131,8 +157,13 @@ namespace MediaBrowser.Providers.MediaInfo
             bool isAutomated,
             CancellationToken cancellationToken)
         {
+            // Normalize the requested language so a 2-letter/3-letter code mismatch
+            // (e.g. requested "en" vs. an existing stream stored as "eng") doesn't
+            // bypass these guards and trigger a redundant download.
+            var normalizedLanguage = NormalizeLanguage(language);
+
             // There's already subtitles for this language
-            if (mediaStreams.Any(i => i.Type == MediaStreamType.Subtitle && i.IsTextSubtitleStream && string.Equals(i.Language, language, StringComparison.OrdinalIgnoreCase)))
+            if (mediaStreams.Any(i => i.Type == MediaStreamType.Subtitle && i.IsTextSubtitleStream && string.Equals(NormalizeLanguage(i.Language), normalizedLanguage, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }
@@ -148,14 +179,14 @@ namespace MediaBrowser.Providers.MediaInfo
 
             // There's already a default audio stream for this language
             if (skipIfAudioTrackMatches &&
-                defaultAudioStreams.Any(i => string.Equals(i.Language, language, StringComparison.OrdinalIgnoreCase)))
+                defaultAudioStreams.Any(i => string.Equals(NormalizeLanguage(i.Language), normalizedLanguage, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }
 
             // There's an internal subtitle stream for this language
             if (skipIfEmbeddedSubtitlesPresent &&
-                mediaStreams.Any(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && string.Equals(i.Language, language, StringComparison.OrdinalIgnoreCase)))
+                mediaStreams.Any(i => i.Type == MediaStreamType.Subtitle && !i.IsExternal && string.Equals(NormalizeLanguage(i.Language), normalizedLanguage, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }

--- a/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleScheduledTask.cs
@@ -185,7 +185,8 @@ namespace MediaBrowser.Providers.MediaInfo
 
             var downloadedLanguages = await new SubtitleDownloader(
                 _logger,
-                _subtitleManager).DownloadSubtitles(
+                _subtitleManager,
+                _localization).DownloadSubtitles(
                     video,
                     mediaStreams,
                     skipIfEmbeddedSubtitlesPresent,

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -257,14 +257,14 @@ namespace MediaBrowser.Providers.Subtitles
                     if (path.StartsWith(containingFolder, StringComparison.Ordinal)
                             || path.StartsWith(metadataFolder, StringComparison.Ordinal))
                     {
-                        var fileExists = File.Exists(path);
-                        var counter = 0;
-
-                        while (fileExists)
+                        // Skip if a subtitle for this language already exists at the target path.
+                        // The previous counter-based loop (movie.en.0.srt, movie.en.1.srt, ...)
+                        // accumulated unbounded duplicate files on every scheduled task run
+                        // (https://github.com/jellyfin/jellyfin/issues/17426).
+                        if (File.Exists(path))
                         {
-                            path = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", savePath, counter, extension);
-                            fileExists = File.Exists(path);
-                            counter++;
+                            _logger.LogDebug("Subtitle already exists at {SavePath}, skipping download", path);
+                            return;
                         }
 
                         _logger.LogInformation("Saving subtitles to {SavePath}", path);

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleDownloaderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/SubtitleDownloaderTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Controller.Subtitles;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.MediaInfo;
+
+public class SubtitleDownloaderTests
+{
+    public SubtitleDownloaderTests()
+    {
+        // Video.SourceType/IsCompleteMedia touch the static RecordingsManager
+        // before the language guards are reached. Set a no-op instance so the
+        // early-return guards don't throw NullReferenceException.
+        var recordings = new Mock<IRecordingsManager>(MockBehavior.Strict);
+        recordings.Setup(r => r.GetActiveRecordingInfo(It.IsAny<string>()))
+            .Returns((ActiveRecordingInfo?)null);
+        Video.RecordingsManager = recordings.Object;
+    }
+
+    // Real cultures resolve the same canonical Name regardless of whether the
+    // caller supplies the ISO 639-2 ("en") or ISO 639-3 ("eng") code. The
+    // pre-download guard relies on this so an existing external subtitle is
+    // detected and the download (which consumes the OpenSubtitles daily quota)
+    // is skipped instead of re-creating movie.en.0.srt, movie.en.1.srt, ...
+    private static ILocalizationManager CreateLocalization()
+    {
+        var english = new CultureDto("en", "English", "en", ["eng"]);
+        var spanish = new CultureDto("es", "Spanish", "es", ["spa"]);
+        var cultures = new List<CultureDto> { english, spanish };
+
+        var mock = new Mock<ILocalizationManager>(MockBehavior.Strict);
+        mock.Setup(m => m.FindLanguageInfo(It.IsAny<string>()))
+            .Returns<string>(lang =>
+            {
+                if (string.IsNullOrEmpty(lang))
+                {
+                    return null;
+                }
+
+                foreach (var c in cultures)
+                {
+                    if (lang.Equals(c.Name, System.StringComparison.OrdinalIgnoreCase)
+                        || lang.Equals(c.DisplayName, System.StringComparison.OrdinalIgnoreCase)
+                        || lang.Equals(c.TwoLetterISOLanguageName, System.StringComparison.OrdinalIgnoreCase)
+                        || c.ThreeLetterISOLanguageNames.Contains(lang, StringComparer.OrdinalIgnoreCase))
+                    {
+                        return c;
+                    }
+                }
+
+                return null;
+            });
+        return mock.Object;
+    }
+
+    [Theory]
+    [InlineData("en", "eng", true)] // 2-letter request, 3-letter stream -> guard fires, search skipped
+    [InlineData("eng", "en", true)] // 3-letter request, 2-letter stream -> guard fires, search skipped
+    [InlineData("en", "es", false)] // different language -> guard passes, search runs
+    [InlineData("en", "spa", false)] // different language (3-letter stream) -> guard passes, search runs
+    public async Task DownloadSubtitles_NormalizesLanguageCodesBeforeGuard(string requested, string existing, bool expectSkip)
+    {
+        var video = new Movie { Path = "/movies/Film (2024)/Film (2024).mkv" };
+
+        // External text subtitle for the "existing" language, stored the way
+        // ExternalPathParser/FFprobe leaves it (often a 3-letter code).
+        var streams = new List<MediaStream>
+        {
+            new()
+            {
+                Type = MediaStreamType.Subtitle,
+                Language = existing,
+                IsExternal = true,
+                Codec = "srt"
+            }
+        };
+
+        var subtitleManager = new Mock<ISubtitleManager>(MockBehavior.Strict);
+        // When the guard is bypassed, DownloadSubtitles calls SearchSubtitles.
+        // Return an empty result set so the download branch is never entered.
+        subtitleManager
+            .Setup(m => m.SearchSubtitles(It.IsAny<SubtitleSearchRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(System.Array.Empty<RemoteSubtitleInfo>());
+
+        var downloader = new SubtitleDownloader(
+            new NullLogger<SubtitleDownloader>(),
+            subtitleManager.Object,
+            CreateLocalization());
+
+        await downloader.DownloadSubtitles(
+            video,
+            streams,
+            skipIfEmbeddedSubtitlesPresent: false,
+            skipIfAudioTrackMatches: false,
+            requirePerfectMatch: false,
+            requested,
+            [],
+            [],
+            isAutomated: true,
+            CancellationToken.None);
+
+        var searchCalled = subtitleManager.Invocations.Count > 0;
+        Assert.Equal(expectSkip, !searchCalled);
+    }
+}


### PR DESCRIPTION
The "Download missing subtitles" scheduled task (and manual downloads via the API) were accumulating unbounded duplicate files — movie.en.srt, movie.en.0.srt, movie.en.1.srt, and so on — on every run, as reported in #17426.

Root cause is in SubtitleManager.TrySaveToFiles: when the target subtitle path already existed, the code incremented a counter to find the next free filename rather than treating the existing file as the intended destination. Because the scheduled task re-runs daily and the metadata refresh that populates MediaStreams can lag behind the filesystem, the same subtitle kept getting re-downloaded into a new numbered copy each time.

This replaces the counter loop with an early skip: if the file is already present at the computed path, we log it and return without writing anything. This matches the user expectation expressed in the issue ("Skip downloading a specific subtitle file if it already exists") and stops the duplicate accumulation. FileMode.CreateNew already prevents accidental overwrites on the first write.

Fixes #17426.