### PR TITLE
fix(encoding): honor AudioStreamIndex for audio requests on video items

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7502,7 +7502,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
             else
             {
-                state.AudioStream = GetMediaStream(mediaStreams, null, MediaStreamType.Audio, true);
+                state.AudioStream = GetMediaStream(mediaStreams, state.BaseRequest.AudioStreamIndex, MediaStreamType.Audio, true);
             }
 
             state.MediaSource = mediaSource;


### PR DESCRIPTION
When requesting an audio stream from a video item via /Audio/{itemId}/stream?audioStreamIndex=N, the server always returned the first audio track regardless of the requested index. Both requests produced identical output and identical FFmpeg commands with no -map selection.

The cause is in EncodingHelper.AttachMediaSourceInfo: the non-video-request branch (used by the audio endpoints) hardcoded null as the desired index when selecting the audio stream, instead of forwarding the AudioStreamIndex from the request. This meant GetMediaStream fell through to its default first-track selection and the caller's index was silently dropped.

This passes state.BaseRequest.AudioStreamIndex so the requested track is actually honored on the transcode path, mirroring what the video-request branch already does.