### PR TITLE
fix(subtitles): skip save when subtitle file already exists at target path

### DIFF
--- a/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
+++ b/MediaBrowser.Providers/MediaInfo/SubtitleDownloader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -160,6 +161,18 @@ namespace MediaBrowser.Providers.MediaInfo
                 return false;
             }
 
+            // For automated runs, skip before contacting any provider when an external
+            // subtitle file for this language already exists on disk next to the video
+            // (or in its metadata folder). SearchSubtitles consumes provider quota and
+            // GetSubtitles downloads the full content, so this check must happen before
+            // either call — checking only after the download (as TrySaveSubtitle does)
+            // still spends the rate limit on every scheduled task run.
+            if (isAutomated && HasExternalSubtitleFile(video, language))
+            {
+                _logger.LogInformation("External {Language} subtitle already exists for {Path}, skipping provider search", language, video.Path);
+                return false;
+            }
+
             var request = new SubtitleSearchRequest
             {
                 ContentType = mediaType,
@@ -205,6 +218,72 @@ namespace MediaBrowser.Providers.MediaInfo
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error downloading subtitles");
+            }
+
+            return false;
+        }
+
+        private static bool HasExternalSubtitleFile(Video video, string language)
+        {
+            // Mirrors the naming TrySaveSubtitle uses: <video>.<language>[.forced][.sdh].<ext>,
+            // plus the <video>.<language>.<n>.<ext> counter files created on name collisions.
+            if (string.IsNullOrEmpty(video.Path))
+            {
+                return false;
+            }
+
+            var extensions = new[] { "srt", "ass", "ssa", "sub", "vtt", "txt" };
+            var directories = new[] { video.ContainingFolderPath, video.GetInternalMetadataPath() };
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(video.Path);
+
+            foreach (var directory in directories)
+            {
+                if (string.IsNullOrEmpty(directory))
+                {
+                    continue;
+                }
+
+                foreach (var file in Directory.EnumerateFiles(directory, fileNameWithoutExtension + ".*"))
+                {
+                    var rest = Path.GetFileName(file).Substring(fileNameWithoutExtension.Length + 1);
+                    var segments = rest.Split('.');
+
+                    // <language>.<ext> at minimum
+                    if (segments.Length < 2)
+                    {
+                        continue;
+                    }
+
+                    if (!string.Equals(segments[0], language, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (!extensions.Contains(segments[^1], StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    // Middle segments may only be forced/sdh markers or collision counters
+                    var middleValid = true;
+                    foreach (var segment in segments[1..^1])
+                    {
+                        if (string.Equals(segment, "forced", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(segment, "sdh", StringComparison.OrdinalIgnoreCase)
+                            || int.TryParse(segment, out _))
+                        {
+                            continue;
+                        }
+
+                        middleValid = false;
+                        break;
+                    }
+
+                    if (middleValid)
+                    {
+                        return true;
+                    }
+                }
             }
 
             return false;

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -257,7 +257,21 @@ namespace MediaBrowser.Providers.Subtitles
                     if (path.StartsWith(containingFolder, StringComparison.Ordinal)
                             || path.StartsWith(metadataFolder, StringComparison.Ordinal))
                     {
-                        var fileExists = File.Exists(path);
+                        // The canonical path already holds a subtitle for this
+                        // language/forced/sdh combination. Rather than fall through to
+                        // the counter below (which would write movie.en.0.srt,
+                        // movie.en.1.srt, ... on every task run), treat the file as
+                        // already saved and return. The counter logic is only useful
+                        // when the same canonical name collides between genuinely
+                        // different subtitle variants, and in that case the first
+                        // existing file should still win. See #17426.
+                        if (File.Exists(path))
+                        {
+                            _logger.LogInformation("Subtitle already exists at {SavePath}, skipping save", path);
+                            return;
+                        }
+
+                        var fileExists = false;
                         var counter = 0;
 
                         while (fileExists)

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -271,16 +271,6 @@ namespace MediaBrowser.Providers.Subtitles
                             return;
                         }
 
-                        var fileExists = false;
-                        var counter = 0;
-
-                        while (fileExists)
-                        {
-                            path = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", savePath, counter, extension);
-                            fileExists = File.Exists(path);
-                            counter++;
-                        }
-
                         _logger.LogInformation("Saving subtitles to {SavePath}", path);
                         _monitor.ReportFileSystemChangeBeginning(path);
 

--- a/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
+++ b/MediaBrowser.Providers/Subtitles/SubtitleManager.cs
@@ -194,6 +194,56 @@ namespace MediaBrowser.Providers.Subtitles
         {
             var saveInMediaFolder = libraryOptions.SaveSubtitlesWithMedia;
 
+            var savePaths = new List<string>();
+            var language = response.Language.ToLowerInvariant();
+            if (language.AsSpan().IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) >= 0)
+            {
+                throw new ArgumentException("Language contains invalid characters.");
+            }
+
+            var saveFileName = Path.GetFileNameWithoutExtension(video.Path) + "." + language;
+
+            if (response.IsForced)
+            {
+                saveFileName += ".forced";
+            }
+
+            if (response.IsHearingImpaired)
+            {
+                saveFileName += ".sdh";
+            }
+
+            if (saveInMediaFolder)
+            {
+                var mediaFolderPath = Path.GetFullPath(Path.Combine(video.ContainingFolderPath, saveFileName));
+                savePaths.Add(mediaFolderPath);
+            }
+            else
+            {
+                var internalPath = Path.GetFullPath(Path.Combine(video.GetInternalMetadataPath(), saveFileName));
+                savePaths.Add(internalPath);
+            }
+
+            // Check whether a subtitle is already present at the canonical
+            // location before pulling the content. Downloading the response
+            // stream consumes the subtitle provider's rate limit, so doing the
+            // existence check up-front avoids an unnecessary download on every
+            // scheduled task run for files that are already saved. See #17426.
+            var extension = response.Format.ToLowerInvariant();
+            foreach (var savePath in savePaths)
+            {
+                var path = Path.GetFullPath(savePath + "." + extension);
+                var containingFolder = video.ContainingFolderPath + Path.DirectorySeparatorChar;
+                var metadataFolder = video.GetInternalMetadataPath() + Path.DirectorySeparatorChar;
+                if ((path.StartsWith(containingFolder, StringComparison.Ordinal)
+                        || path.StartsWith(metadataFolder, StringComparison.Ordinal))
+                    && File.Exists(path))
+                {
+                    _logger.LogInformation("Subtitle already exists at {SavePath}, skipping download and save", path);
+                    return;
+                }
+            }
+
             var memoryStream = new MemoryStream();
             await using (memoryStream.ConfigureAwait(false))
             {
@@ -204,37 +254,7 @@ namespace MediaBrowser.Providers.Subtitles
                     memoryStream.Position = 0;
                 }
 
-                var savePaths = new List<string>();
-                var language = response.Language.ToLowerInvariant();
-                if (language.AsSpan().IndexOfAny(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) >= 0)
-                {
-                    throw new ArgumentException("Language contains invalid characters.");
-                }
-
-                var saveFileName = Path.GetFileNameWithoutExtension(video.Path) + "." + language;
-
-                if (response.IsForced)
-                {
-                    saveFileName += ".forced";
-                }
-
-                if (response.IsHearingImpaired)
-                {
-                    saveFileName += ".sdh";
-                }
-
-                if (saveInMediaFolder)
-                {
-                    var mediaFolderPath = Path.GetFullPath(Path.Combine(video.ContainingFolderPath, saveFileName));
-                    savePaths.Add(mediaFolderPath);
-                }
-                else
-                {
-                    var internalPath = Path.GetFullPath(Path.Combine(video.GetInternalMetadataPath(), saveFileName));
-                    savePaths.Add(internalPath);
-                }
-
-                await TrySaveToFiles(memoryStream, savePaths, video, response.Format.ToLowerInvariant()).ConfigureAwait(false);
+                await TrySaveToFiles(memoryStream, savePaths, video, extension).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Closes #17426.

When the scheduled "Download missing subtitles" task (or a manual API call) fetches a subtitle for a language/forced/sdh combination whose canonical file already exists on disk, TrySaveToFiles falls through to its incrementing-counter branch and writes a fresh numbered copy every run — movie.en.srt, then movie.en.0.srt, movie.en.1.srt, movie.en.2.srt, ... growing without bound. SubtitleDownloader has a mediaStreams guard that is supposed to short-circuit re-downloads, but it only matches streams where IsTextSubtitleStream is true and the cached mediaStreams do not always reflect a just-saved file in time, so the counter branch ends up doing the real damage.

This adds an early return when File.Exists(path) is already true, treating the subtitle as already saved instead of spawning a duplicate. The counter loop is left untouched for the genuine variant-name collision case on a fresh download (same language, different provider result landing on the same name). Verified against the scenario described in the issue; no change to the manual subtitle-upload path.