### PR TITLE
Add HDR passthrough for transcoding

### DIFF
--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -466,9 +466,23 @@ public class DynamicHlsHelper
                     }
                 }
             }
+            else if (_encodingHelper.IsHdrPassthroughAvailable(state, _serverConfigurationManager.GetEncodingOptions()))
+            {
+                // Clients configure their decoder from this field; announcing SDR while
+                // delivering PQ prevents playback.
+                switch (videoRangeType)
+                {
+                    case VideoRangeType.HLG:
+                    case VideoRangeType.DOVIWithHLG:
+                        builder.Append(",VIDEO-RANGE=HLG");
+                        break;
+                    default:
+                        builder.Append(",VIDEO-RANGE=PQ");
+                        break;
+                }
+            }
             else
             {
-                // Currently we only encode to SDR.
                 builder.Append(",VIDEO-RANGE=SDR");
             }
         }
@@ -815,6 +829,14 @@ public class DynamicHlsHelper
                 || string.Equals(state.ActualOutputVideoCodec, "av1", StringComparison.OrdinalIgnoreCase))
             {
                 profileString ??= "main";
+
+                // Passthrough encodes HEVC as Main 10; announcing Main describes an 8-bit
+                // stream and the client fails to initialise on the 10-bit init segment.
+                if (!string.Equals(state.ActualOutputVideoCodec, "av1", StringComparison.OrdinalIgnoreCase)
+                    && _encodingHelper.IsHdrPassthroughAvailable(state, _serverConfigurationManager.GetEncodingOptions()))
+                {
+                    profileString = "main10";
+                }
             }
         }
 

--- a/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
+++ b/Jellyfin.Api/Helpers/DynamicHlsHelper.cs
@@ -441,52 +441,26 @@ public class DynamicHlsHelper
     /// <param name="state">StreamState of the current stream.</param>
     private void AppendPlaylistVideoRangeField(StringBuilder builder, StreamState state)
     {
-        if (state.VideoStream is not null && state.VideoStream.VideoRange != VideoRange.Unknown)
+        if (state.VideoStream is null || state.VideoStream.VideoRange == VideoRange.Unknown)
         {
-            var videoRange = state.VideoStream.VideoRange;
-            var videoRangeType = state.VideoStream.VideoRangeType;
-            if (EncodingHelper.IsCopyCodec(state.OutputVideoCodec))
-            {
-                if (videoRange == VideoRange.SDR)
-                {
-                    builder.Append(",VIDEO-RANGE=SDR");
-                }
-
-                if (videoRange == VideoRange.HDR)
-                {
-                    switch (videoRangeType)
-                    {
-                        case VideoRangeType.HLG:
-                        case VideoRangeType.DOVIWithHLG:
-                            builder.Append(",VIDEO-RANGE=HLG");
-                            break;
-                        default:
-                            builder.Append(",VIDEO-RANGE=PQ");
-                            break;
-                    }
-                }
-            }
-            else if (_encodingHelper.IsHdrPassthroughAvailable(state, _serverConfigurationManager.GetEncodingOptions()))
-            {
-                // Clients configure their decoder from this field; announcing SDR while
-                // delivering PQ prevents playback.
-                switch (videoRangeType)
-                {
-                    case VideoRangeType.HLG:
-                    case VideoRangeType.DOVIWithHLG:
-                        builder.Append(",VIDEO-RANGE=HLG");
-                        break;
-                    default:
-                        builder.Append(",VIDEO-RANGE=PQ");
-                        break;
-                }
-            }
-            else
-            {
-                builder.Append(",VIDEO-RANGE=SDR");
-            }
+            return;
         }
+
+        // A copy keeps the source range, and so does a passthrough transcode. Anything else is
+        // tone mapped. Clients configure their decoder from this field, so announcing SDR while
+        // delivering PQ prevents playback.
+        var keepsSourceRange = EncodingHelper.IsCopyCodec(state.OutputVideoCodec)
+                               || _encodingHelper.IsHdrPassthroughAvailable(state, _serverConfigurationManager.GetEncodingOptions());
+
+        var range = keepsSourceRange && state.VideoStream.VideoRange == VideoRange.HDR
+            ? GetHdrPlaylistVideoRange(state.VideoStream.VideoRangeType)
+            : "SDR";
+
+        builder.Append(",VIDEO-RANGE=").Append(range);
     }
+
+    private static string GetHdrPlaylistVideoRange(VideoRangeType videoRangeType)
+        => videoRangeType is VideoRangeType.HLG or VideoRangeType.DOVIWithHLG ? "HLG" : "PQ";
 
     /// <summary>
     /// Appends a CODECS field containing formatted strings of

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -343,11 +343,89 @@ namespace MediaBrowser.Controller.MediaEncoding
             // Let transpose_vt optional for the time being.
         }
 
+        /// <summary>
+        /// Determines whether the source HDR can be kept through a re-encode instead of being
+        /// tone mapped to SDR.
+        /// </summary>
+        /// <param name="state">Encoding state.</param>
+        /// <param name="options">Encoding options.</param>
+        /// <returns><c>true</c> if the transcode should stay HDR.</returns>
+        public bool IsHdrPassthroughAvailable(EncodingJobInfo state, EncodingOptions options)
+        {
+            if (!options.EnableHdrPassthrough
+                || state.VideoStream is null
+                || state.VideoStream.VideoRange != VideoRange.HDR
+                || GetVideoColorBitDepth(state) < 10)
+            {
+                return false;
+            }
+
+            // Dolby Vision without an HDR10 or HLG base layer decodes to invalid colours once the
+            // RPU is dropped, and no encoder here can rewrite one.
+            var rangeType = state.VideoStream.VideoRangeType;
+            var isHlg = rangeType is VideoRangeType.HLG or VideoRangeType.DOVIWithHLG;
+            if (!isHlg
+                && rangeType is not (VideoRangeType.HDR10 or VideoRangeType.HDR10Plus)
+                && !IsDoviWithHdr10Bl(state.VideoStream))
+            {
+                return false;
+            }
+
+            // An undeclared range means unknown client capabilities, which is not the same as
+            // HDR being safe to send.
+            var outputCodec = state.ActualOutputVideoCodec ?? string.Empty;
+            var requiredRange = isHlg ? VideoRangeType.HLG : VideoRangeType.HDR10;
+            if (!state.GetRequestedRangeTypes(outputCodec)
+                    .Contains(requiredRange.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var encoder = GetHdrPassthroughEncoder(outputCodec, options.HardwareAccelerationType);
+
+            return encoder.Length > 0 && _mediaEncoder.SupportsEncoder(encoder);
+        }
+
+        /// <summary>
+        /// The encoder that would carry an HDR passthrough, or an empty string when this codec and
+        /// accelerator combination cannot produce 10-bit.
+        /// </summary>
+        /// <param name="outputCodec">Output video codec.</param>
+        /// <param name="accelerationType">Configured hardware accelerator.</param>
+        /// <returns>The encoder name, or an empty string.</returns>
+        private static string GetHdrPassthroughEncoder(string outputCodec, HardwareAccelerationType accelerationType)
+        {
+            var isAv1 = outputCodec.Contains("av1", StringComparison.OrdinalIgnoreCase);
+
+            // H.264 High 10 has no practical client support, and no other codec here carries HDR.
+            if (!isAv1
+                && !outputCodec.Contains("hevc", StringComparison.OrdinalIgnoreCase)
+                && !outputCodec.Contains("h265", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            return accelerationType switch
+            {
+                HardwareAccelerationType.none => isAv1 ? "libsvtav1" : "libx265",
+                HardwareAccelerationType.nvenc => isAv1 ? "av1_nvenc" : "hevc_nvenc",
+                HardwareAccelerationType.qsv => isAv1 ? "av1_qsv" : "hevc_qsv",
+                HardwareAccelerationType.vaapi => isAv1 ? "av1_vaapi" : "hevc_vaapi",
+                HardwareAccelerationType.amf => isAv1 ? "av1_amf" : "hevc_amf",
+                HardwareAccelerationType.rkmpp => isAv1 ? string.Empty : "hevc_rkmpp",
+                HardwareAccelerationType.videotoolbox => isAv1 ? string.Empty : "hevc_videotoolbox",
+
+                // V4L2 M2M is 8-bit only.
+                _ => string.Empty,
+            };
+        }
+
         private bool IsSwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
         {
             if (state.VideoStream is null
                 || GetVideoColorBitDepth(state) < 10
-                || !_mediaEncoder.SupportsFilter("tonemapx"))
+                || !_mediaEncoder.SupportsFilter("tonemapx")
+                || IsHdrPassthroughAvailable(state, options))
             {
                 return false;
             }
@@ -359,7 +437,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || IsHdrPassthroughAvailable(state, options))
             {
                 return false;
             }
@@ -399,6 +478,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // libplacebo has partial Dolby Vision to SDR tonemapping support.
             return options.EnableTonemapping
+                   && !IsHdrPassthroughAvailable(state, options)
                    && state.VideoStream.VideoRange == VideoRange.HDR
                    && GetVideoColorBitDepth(state) == 10;
         }
@@ -407,7 +487,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVppTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || IsHdrPassthroughAvailable(state, options))
             {
                 return false;
             }
@@ -431,7 +512,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVideoToolboxTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || IsHdrPassthroughAvailable(state, options))
             {
                 return false;
             }
@@ -2204,11 +2286,22 @@ namespace MediaBrowser.Controller.MediaEncoding
                 profile = string.Empty;
             }
 
-            // We only transcode to HEVC 8-bit for now, force Main Profile.
-            if (profile.Contains("main10", StringComparison.OrdinalIgnoreCase)
-                || profile.Contains("mainstill", StringComparison.OrdinalIgnoreCase))
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, encodingOptions);
+
+            // HEVC is transcoded as 8-bit Main, except under passthrough where HDR10 needs
+            // Main 10.
+            if (profile.Contains("mainstill", StringComparison.OrdinalIgnoreCase)
+                || (profile.Contains("main10", StringComparison.OrdinalIgnoreCase) && !doHdrPassthrough))
             {
                 profile = "main";
+            }
+            else if (doHdrPassthrough
+                     && string.Equals("hevc", targetVideoCodec, StringComparison.OrdinalIgnoreCase)
+                     && profile.Contains("main", StringComparison.OrdinalIgnoreCase)
+                     && !profile.Contains("main10", StringComparison.OrdinalIgnoreCase))
+            {
+                // The encoder refuses Main against 10-bit frames.
+                profile = "main10";
             }
 
             // Extended Profile is not supported by any known h264 encoders, force Main Profile.
@@ -3870,6 +3963,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doToneMap = IsSwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
             var requireDoviReshaping = doToneMap && state.VideoStream.VideoRangeType == VideoRangeType.DOVI;
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
@@ -3884,7 +3978,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doToneMap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doToneMap));
 
             // INPUT sw surface(memory/copy-back from vram)
             // sw deint
@@ -3903,6 +3997,12 @@ namespace MediaBrowser.Controller.MediaEncoding
             else if (isV4l2Encoder)
             {
                 outFormat = "yuv420p";
+            }
+
+            // V4L2 M2M is left alone, those encoders are 8-bit only.
+            if (doHdrPassthrough && !isV4l2Encoder)
+            {
+                outFormat = isVaapiEncoder ? "p010le" : "yuv420p10le";
             }
 
             // sw scale
@@ -4022,6 +4122,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doubleRateDeint = options.DeinterlaceDoubleRate && (state.VideoStream?.ReferenceFrameRate ?? 60) <= 30;
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doCuTonemap = IsHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
@@ -4042,7 +4143,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doCuTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doCuTonemap));
 
             if (isSwDecoder)
             {
@@ -4054,7 +4155,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doCuTonemap ? "p010le" : "yuv420p";
+                var outFormat = doCuTonemap || doHdrPassthrough ? "p010le" : "yuv420p";
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 // sw scale
                 mainFilters.Add(swScaleFilter);
@@ -4084,7 +4185,10 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 var isRext = IsVideoStreamHevcRext(state);
-                var outFormat = doCuTonemap ? (isRext ? "p010" : string.Empty) : "yuv420p";
+
+                var outFormat = doCuTonemap
+                    ? (isRext ? "p010" : string.Empty)
+                    : (doHdrPassthrough ? "p010" : "yuv420p");
                 var hwScaleFilter = GetHwScaleFilter("scale", "cuda", outFormat, false, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
                 // hw scale
                 mainFilters.Add(hwScaleFilter);
@@ -4103,9 +4207,9 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 memoryOutput = true;
 
-                // OUTPUT yuv420p surface(memory)
+                // OUTPUT yuv420p/p010le surface(memory)
                 mainFilters.Add("hwdownload");
-                mainFilters.Add("format=yuv420p");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=yuv420p");
             }
 
             // OUTPUT yuv420p surface(memory)
@@ -4231,6 +4335,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doOclTonemap = IsHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
@@ -4252,7 +4357,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doOclTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doOclTonemap));
 
             if (isSwDecoder)
             {
@@ -4264,7 +4369,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doOclTonemap ? "yuv420p10le" : "yuv420p";
+                var outFormat = doOclTonemap ? "yuv420p10le" : (doHdrPassthrough ? "p010le" : "yuv420p");
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 // sw scale
                 mainFilters.Add(swScaleFilter);
@@ -4300,7 +4405,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add($"transpose_opencl=dir={transposeDir}");
                 }
 
-                var outFormat = doOclTonemap ? string.Empty : "nv12";
+                var outFormat = doOclTonemap ? string.Empty : (doHdrPassthrough ? "p010" : "nv12");
                 var hwScaleFilter = GetHwScaleFilter("scale", "opencl", outFormat, false, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
                 // hw scale
                 mainFilters.Add(hwScaleFilter);
@@ -4323,7 +4428,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // prefer hwmap to hwdownload on opencl.
                 var hwTransferFilter = hasGraphicalSubs ? "hwdownload" : "hwmap=mode=read";
                 mainFilters.Add(hwTransferFilter);
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT yuv420p surface
@@ -4479,6 +4584,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doVppTonemap = IsIntelVppTonemapAvailable(state, options);
             var doOclTonemap = !doVppTonemap && IsHwTonemapAvailable(state, options);
             var doTonemap = doVppTonemap || doOclTonemap;
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
@@ -4499,7 +4605,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doTonemap));
 
             if (isSwDecoder)
             {
@@ -4511,7 +4617,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doOclTonemap ? "yuv420p10le" : (hasGraphicalSubs ? "yuv420p" : "nv12");
+                var outFormat = doOclTonemap ? "yuv420p10le" : (doHdrPassthrough ? "p010le" : (hasGraphicalSubs ? "yuv420p" : "nv12"));
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 if (isMjpegEncoder && !doOclTonemap)
                 {
@@ -4576,7 +4682,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                     }
                 }
 
-                var outFormat = doOclTonemap ? ((doVppTranspose || isRext) ? "p010" : string.Empty) : "nv12";
+                var outFormat = doOclTonemap
+                    ? ((doVppTranspose || isRext) ? "p010" : string.Empty)
+                    : (doHdrPassthrough ? "p010" : "nv12");
                 outFormat = twoPassVppTonemap ? "p010" : outFormat;
 
                 var swapOutputWandH = doVppTranspose && swapWAndH;
@@ -4634,7 +4742,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // force bt709 just in case vpp tonemap is not triggered or using MSDK instead of VPL.
                 if (doVppTonemap)
                 {
-                    mainFilters.Add(GetOverwriteColorPropertiesParam(state, false));
+                    mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, false));
                 }
             }
 
@@ -4662,7 +4770,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // prefer hwmap to hwdownload on opencl.
                 // qsv hwmap is not fully implemented for the time being.
                 mainFilters.Add(isHwmapUsable ? "hwmap=mode=read" : "hwdownload");
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT nv12 surface(memory)
@@ -4770,6 +4878,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doVaVppTonemap = IsIntelVppTonemapAvailable(state, options);
             var doOclTonemap = !doVaVppTonemap && IsHwTonemapAvailable(state, options);
             var doTonemap = doVaVppTonemap || doOclTonemap;
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
             var doDeintH2645 = IsDeinterlaceAvailable(state);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
@@ -4791,7 +4900,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doTonemap));
 
             if (isSwDecoder)
             {
@@ -4803,7 +4912,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doOclTonemap ? "yuv420p10le" : (hasGraphicalSubs ? "yuv420p" : "nv12");
+                var outFormat = doOclTonemap ? "yuv420p10le" : (doHdrPassthrough ? "p010le" : (hasGraphicalSubs ? "yuv420p" : "nv12"));
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 if (isMjpegEncoder && !doOclTonemap)
                 {
@@ -4846,7 +4955,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add($"transpose_vaapi=dir={transposeDir}");
                 }
 
-                var outFormat = doTonemap ? (((isQsvDecoder && doVppTranspose) || isRext) ? "p010" : string.Empty) : "nv12";
+                var outFormat = doTonemap
+                    ? (((isQsvDecoder && doVppTranspose) || isRext) ? "p010" : string.Empty)
+                    : (doHdrPassthrough ? "p010" : "nv12");
                 var swapOutputWandH = isQsvDecoder && doVppTranspose && swapWAndH;
                 var hwScalePrefix = isQsvDecoder ? "vpp" : "scale";
                 var hwScaleFilter = GetHwScaleFilter(hwScalePrefix, hwFilterSuffix, outFormat, swapOutputWandH, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
@@ -4917,7 +5028,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // prefer hwmap to hwdownload on opencl/vaapi.
                 // qsv hwmap is not fully implemented for the time being.
                 mainFilters.Add(isHwmapUsable ? "hwmap=mode=read" : "hwdownload");
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT nv12 surface(memory)
@@ -5099,6 +5210,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doVaVppTonemap = isVaapiDecoder && IsIntelVppTonemapAvailable(state, options);
             var doOclTonemap = !doVaVppTonemap && IsHwTonemapAvailable(state, options);
             var doTonemap = doVaVppTonemap || doOclTonemap;
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
             var doDeintH2645 = IsDeinterlaceAvailable(state);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
@@ -5120,7 +5232,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doTonemap));
 
             if (isSwDecoder)
             {
@@ -5133,6 +5245,11 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 var outFormat = doOclTonemap ? "yuv420p10le" : "nv12";
+                if (doHdrPassthrough)
+                {
+                    outFormat = isVaapiEncoder ? "p010le" : "yuv420p10le";
+                }
+
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 if (isMjpegEncoder && !doOclTonemap)
                 {
@@ -5170,7 +5287,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add($"transpose_vaapi=dir={transposeDir}");
                 }
 
-                var outFormat = doTonemap ? (isRext ? "p010" : string.Empty) : "nv12";
+                var outFormat = doTonemap
+                    ? (isRext ? "p010" : string.Empty)
+                    : (doHdrPassthrough ? "p010" : "nv12");
                 var hwScaleFilter = GetHwScaleFilter("scale", "vaapi", outFormat, false, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
 
                 if (!string.IsNullOrEmpty(hwScaleFilter) && isMjpegEncoder)
@@ -5224,10 +5343,10 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 memoryOutput = true;
 
-                // OUTPUT nv12 surface(memory)
+                // OUTPUT nv12/p010le surface(memory)
                 // prefer hwmap to hwdownload on opencl/vaapi.
                 mainFilters.Add(isHwmapNotUsable ? "hwdownload" : "hwmap=mode=read");
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT nv12 surface(memory)
@@ -5332,6 +5451,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var isMjpegEncoder = vidEncoder.Contains("mjpeg", StringComparison.OrdinalIgnoreCase);
 
             var doVkTonemap = IsVulkanHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
             var doDeintH2645 = IsDeinterlaceAvailable(state);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
@@ -5351,7 +5471,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doVkTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doVkTonemap));
 
             if (isSwDecoder)
             {
@@ -5374,7 +5494,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     // sw scale
                     var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                     mainFilters.Add(swScaleFilter);
-                    mainFilters.Add("format=nv12");
+                    mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
                 }
             }
             else if (isVaapiDecoder)
@@ -5478,7 +5598,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (isSwEncoder && (doVkTonemap || isVaapiDecoder))
                 {
                     mainFilters.Add("hwdownload");
-                    mainFilters.Add("format=nv12");
+                    mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
                 }
 
                 if (isSwDecoder && isVaapiEncoder && !doVkTonemap)
@@ -5571,6 +5691,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doOclTonemap = IsHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
@@ -5584,7 +5705,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doOclTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doOclTonemap));
 
             var outFormat = string.Empty;
             if (isSwDecoder)
@@ -5597,7 +5718,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                outFormat = doOclTonemap ? "yuv420p10le" : "nv12";
+                outFormat = doOclTonemap ? "yuv420p10le" : (doHdrPassthrough ? "p010le" : "nv12");
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 if (isMjpegEncoder && !doOclTonemap)
                 {
@@ -5691,7 +5812,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 // OUTPUT nv12 surface(memory)
                 // prefer hwmap to hwdownload on opencl/vaapi.
                 mainFilters.Add(isHwmapNotUsable ? "hwdownload" : "hwmap");
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT nv12 surface(memory)
@@ -5803,6 +5924,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doVtTonemap = IsVideoToolboxTonemapAvailable(state, options);
             var doMetalTonemap = !doVtTonemap && IsHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
             var usingHwSurface = isVtDecoder && (_mediaEncoder.EncoderVersion >= _minFFmpegWorkingVtHwSurface);
 
             var rotation = state.VideoStream?.Rotation ?? 0;
@@ -5909,7 +6031,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (!isVtEncoder)
                 {
                     mainFilters.Add("hwdownload");
-                    mainFilters.Add("format=nv12");
+                    mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
                 }
 
                 return (mainFilters, subFilters, overlayFilters);
@@ -5929,7 +6051,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 if (!isVtEncoder)
                 {
                     mainFilters.Add("hwdownload");
-                    mainFilters.Add("format=nv12");
+                    mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
                 }
             }
 
@@ -6001,6 +6123,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var doDeintH2645 = IsDeinterlaceAvailable(state);
             var doOclTonemap = IsHwTonemapAvailable(state, options);
+            var doHdrPassthrough = IsHdrPassthroughAvailable(state, options);
 
             var hasSubs = state.SubtitleStream is not null && ShouldEncodeSubtitle(state);
             var hasTextSubs = hasSubs && state.SubtitleStream.IsTextSubtitleStream;
@@ -6021,7 +6144,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             /* Make main filters for video stream */
             var mainFilters = new List<string>();
 
-            mainFilters.Add(GetOverwriteColorPropertiesParam(state, doOclTonemap));
+            mainFilters.Add(GetOverwriteColorPropertiesParam(state, options, doOclTonemap));
 
             if (isSwDecoder)
             {
@@ -6033,7 +6156,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                     mainFilters.Add(swDeintFilter);
                 }
 
-                var outFormat = doOclTonemap ? "yuv420p10le" : (hasGraphicalSubs ? "yuv420p" : "nv12");
+                var outFormat = doOclTonemap ? "yuv420p10le" : (doHdrPassthrough ? "p010le" : (hasGraphicalSubs ? "yuv420p" : "nv12"));
                 var swScaleFilter = GetSwScaleFilter(state, options, vidEncoder, swpInW, swpInH, threeDFormat, reqW, reqH, reqMaxW, reqMaxH);
                 if (isMjpegEncoder && !doOclTonemap)
                 {
@@ -6064,7 +6187,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 var isFullAfbcPipeline = isEncoderSupportAfbc && isDrmInDrmOut && !doOclTonemap;
                 var swapOutputWandH = doRkVppTranspose && swapWAndH;
-                var outFormat = doOclTonemap ? "p010" : "nv12";
+                var outFormat = doOclTonemap || doHdrPassthrough ? "p010" : "nv12";
                 var hwScaleFilter = GetHwScaleFilter("vpp", "rkrga", outFormat, swapOutputWandH, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
                 var doScaling = !string.IsNullOrEmpty(GetHwScaleFilter("vpp", "rkrga", string.Empty, swapOutputWandH, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH));
 
@@ -6132,7 +6255,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 // OUTPUT nv12 surface(memory)
                 mainFilters.Add("hwdownload");
-                mainFilters.Add("format=nv12");
+                mainFilters.Add(doHdrPassthrough ? "format=p010le" : "format=nv12");
             }
 
             // OUTPUT nv12 surface(memory)
@@ -6343,9 +6466,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             return string.Empty;
         }
 
-        public string GetOverwriteColorPropertiesParam(EncodingJobInfo state, bool isTonemapAvailable)
+        public string GetOverwriteColorPropertiesParam(EncodingJobInfo state, EncodingOptions options, bool isTonemapAvailable)
         {
-            if (isTonemapAvailable)
+            // Tone mapping needs the source tagged so the filter knows what it converts from;
+            // passthrough needs the same tags because they end up in the output.
+            if (isTonemapAvailable || IsHdrPassthroughAvailable(state, options))
             {
                 return GetInputHdrParam(state.VideoStream?.ColorTransfer);
             }

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AsyncKeyedLock;
 using Jellyfin.Data;
+using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Common;
@@ -346,7 +347,16 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         {
             var audioCodec = state.ActualOutputAudioCodec;
             var videoCodec = state.ActualOutputVideoCodec;
-            var hardwareAccelerationType = _serverConfigurationManager.GetEncodingOptions().HardwareAccelerationType;
+            var encodingOptions = _serverConfigurationManager.GetEncodingOptions();
+            var hardwareAccelerationType = encodingOptions.HardwareAccelerationType;
+
+            // A copy keeps the source range; a re-encode is tone mapped to SDR unless passthrough
+            // carries it through.
+            var keepsSourceRange = EncodingHelper.IsCopyCodec(state.OutputVideoCodec)
+                                   || _encodingHelper.IsHdrPassthroughAvailable(state, encodingOptions);
+            var outputRangeType = keepsSourceRange
+                ? state.VideoStream?.VideoRangeType ?? VideoRangeType.Unknown
+                : VideoRangeType.SDR;
 
             _sessionManager.ReportTranscodingInfo(deviceId, new TranscodingInfo
             {
@@ -354,6 +364,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
                 AudioCodec = audioCodec,
                 VideoCodec = videoCodec,
                 Container = state.OutputContainer,
+                VideoRangeType = outputRangeType,
                 Framerate = framerate,
                 CompletionPercentage = percentComplete,
                 Width = state.OutputWidth,

--- a/MediaBrowser.Model/Configuration/EncodingOptions.cs
+++ b/MediaBrowser.Model/Configuration/EncodingOptions.cs
@@ -33,6 +33,7 @@ public class EncodingOptions
         EnableTonemapping = false;
         EnableVppTonemapping = false;
         EnableVideoToolboxTonemapping = false;
+        EnableHdrPassthrough = false;
         TonemappingAlgorithm = TonemappingAlgorithm.bt2390;
         TonemappingMode = TonemappingMode.auto;
         TonemappingRange = TonemappingRange.auto;
@@ -164,6 +165,14 @@ public class EncodingOptions
     /// Gets or sets a value indicating whether videotoolbox tonemapping is enabled.
     /// </summary>
     public bool EnableVideoToolboxTonemapping { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HDR is preserved when transcoding instead
+    /// of being tone mapped to SDR. Only applies when the source carries a static HDR10 or
+    /// HLG base layer, the output codec can hold 10-bit, and the client reports the matching
+    /// range as supported. Takes priority over tone mapping when all of those hold.
+    /// </summary>
+    public bool EnableHdrPassthrough { get; set; }
 
     /// <summary>
     /// Gets or sets the tone-mapping algorithm.

--- a/MediaBrowser.Model/Session/TranscodingInfo.cs
+++ b/MediaBrowser.Model/Session/TranscodingInfo.cs
@@ -1,5 +1,6 @@
 #nullable disable
 
+using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Entities;
 
 namespace MediaBrowser.Model.Session;
@@ -23,6 +24,12 @@ public class TranscodingInfo
     /// Gets or sets the thread count used for encoding.
     /// </summary>
     public string Container { get; set; }
+
+    /// <summary>
+    /// Gets or sets the video range type of the output, which is not necessarily that of the
+    /// source: HDR is tone mapped to SDR unless passthrough is carrying it.
+    /// </summary>
+    public VideoRangeType VideoRangeType { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the video is passed through.

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperHdrPassthroughTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperHdrPassthroughTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
+using Moq;
+using Xunit;
+
+using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding;
+
+/// <summary>
+/// Covers HDR passthrough, where a transcode keeps the BT.2020 primaries and the PQ or HLG
+/// transfer of the source instead of tone mapping the picture down to BT.709 SDR.
+/// </summary>
+public class EncodingHelperHdrPassthroughTests
+{
+    [Fact]
+    public void SwChain_PassthroughDisabled_TonemapsHdrToBt709()
+    {
+        var state = BuildHdr10State();
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: false), "hevc");
+
+        // setparams tags the source as PQ so tonemapx knows what it is converting from. The
+        // filter's own p/t/m arguments are what pin the result to BT.709, and the output
+        // format stays 8-bit.
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+        Assert.DoesNotContain("yuv420p10le", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_PassthroughEnabled_KeepsPqAndBt2020AndDropsTonemap()
+    {
+        var state = BuildHdr10State();
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.DoesNotContain("tonemap", filters, StringComparison.Ordinal);
+        Assert.Contains("color_trc=smpte2084", filters, StringComparison.Ordinal);
+        Assert.Contains("color_primaries=bt2020", filters, StringComparison.Ordinal);
+        Assert.Contains("colorspace=bt2020nc", filters, StringComparison.Ordinal);
+        Assert.DoesNotContain("bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_PassthroughEnabled_StaysTenBit()
+    {
+        var state = BuildHdr10State();
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        // Eight-bit output would quantise the HDR away even with the tags kept.
+        Assert.Contains("format=yuv420p10le", filters, StringComparison.Ordinal);
+        Assert.DoesNotContain("format=nv12", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_ClientDoesNotSupportHdr10_StillTonemaps()
+    {
+        // An SDR-only client must not be handed HDR, even with the option switched on.
+        var state = BuildHdr10State(clientRangeTypes: "SDR");
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_ClientDeclaresNothing_StillTonemaps()
+    {
+        // Unknown capabilities are not the same as HDR being safe to send.
+        var state = BuildHdr10State(clientRangeTypes: null);
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_H264Output_StillTonemaps()
+    {
+        // H.264 High 10 has no practical client support, so HDR cannot be delivered over it.
+        var state = BuildHdr10State(outputCodec: "h264");
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "h264");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_DolbyVisionProfile5_StillTonemaps()
+    {
+        // Profile 5 has no HDR10 base layer. Dropping the RPU would leave invalid colours,
+        // so tone mapping remains the only correct option.
+        var state = BuildDoviState(dvProfile: 5, dvBlCompatId: 0, hdr10Plus: false);
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Equal(VideoRangeType.DOVI, state.VideoStream.VideoRangeType);
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_DolbyVisionProfile8WithHdr10Plus_KeepsPq()
+    {
+        // Profile 8.1 with HDR10+ keeps a static HDR10 base layer, so it degrades to HDR10
+        // rather than breaking. This is the shape of a typical 4K WEB-DL.
+        var state = BuildDoviState(dvProfile: 8, dvBlCompatId: 1, hdr10Plus: true);
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Equal(VideoRangeType.DOVIWithHDR10Plus, state.VideoStream.VideoRangeType);
+        Assert.DoesNotContain("tonemap", filters, StringComparison.Ordinal);
+        Assert.Contains("color_trc=smpte2084", filters, StringComparison.Ordinal);
+        Assert.Contains("format=yuv420p10le", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_HlgSource_KeepsHlgTransfer()
+    {
+        var state = BuildHdr10State(colorTransfer: "arib-std-b67", clientRangeTypes: "HLG");
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Equal(VideoRangeType.HLG, state.VideoStream.VideoRangeType);
+        Assert.DoesNotContain("tonemap", filters, StringComparison.Ordinal);
+        Assert.Contains("color_trc=arib-std-b67", filters, StringComparison.Ordinal);
+        Assert.Contains("color_primaries=bt2020", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_HlgSourceButClientOnlyDeclaresHdr10_StillTonemaps()
+    {
+        // HLG and HDR10 are not interchangeable transfers.
+        var state = BuildHdr10State(colorTransfer: "arib-std-b67", clientRangeTypes: "HDR10");
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SwChain_SdrSource_IsUntouchedByThePassthroughOption()
+    {
+        var state = BuildHdr10State(colorTransfer: "bt709");
+        var filters = CreateHelper().GetVideoProcessingFilterParam(state, SwOptions(passthrough: true), "hevc");
+
+        Assert.Equal(VideoRange.SDR, state.VideoStream.VideoRange);
+        Assert.Contains("color_trc=bt709", filters, StringComparison.Ordinal);
+        Assert.DoesNotContain("yuv420p10le", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Nvenc_PassthroughEnabled_SurvivesTheSoftwareFallback()
+    {
+        // The NVENC dispatch drops to the software chain when the full CUDA pipeline is not
+        // available, which is what the mocked encoder reports. Passthrough has to survive that
+        // fallback rather than quietly reverting to SDR.
+        var options = SwOptions(passthrough: true);
+        options.HardwareAccelerationType = HardwareAccelerationType.nvenc;
+        var filters = CreateHelper().GetVideoProcessingFilterParam(BuildHdr10State(), options, "hevc");
+
+        Assert.DoesNotContain("tonemap", filters, StringComparison.Ordinal);
+        Assert.Contains("color_trc=smpte2084", filters, StringComparison.Ordinal);
+        Assert.Contains("format=yuv420p10le", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Vaapi_PassthroughEnabled_KeepsPqAndTenBit()
+    {
+        var options = SwOptions(passthrough: true);
+        options.HardwareAccelerationType = HardwareAccelerationType.vaapi;
+        var filters = CreateHelper().GetVideoProcessingFilterParam(BuildHdr10State(), options, "hevc");
+
+        Assert.DoesNotContain("tonemap", filters, StringComparison.Ordinal);
+        Assert.Contains("color_trc=smpte2084", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EncoderMissing_StillTonemaps()
+    {
+        // Hardware that has no 10-bit encoder cannot carry HDR, whatever the option says.
+        var options = SwOptions(passthrough: true);
+        options.HardwareAccelerationType = HardwareAccelerationType.vaapi;
+        var filters = CreateHelper(missingEncoder: "hevc_vaapi")
+            .GetVideoProcessingFilterParam(BuildHdr10State(), options, "hevc");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+        Assert.Contains("t=bt709:m=bt709:p=bt709", filters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void V4l2m2m_StillTonemaps()
+    {
+        // V4L2 M2M encoders are 8-bit only and have no 10-bit fallback.
+        var options = SwOptions(passthrough: true);
+        options.HardwareAccelerationType = HardwareAccelerationType.v4l2m2m;
+        var filters = CreateHelper().GetVideoProcessingFilterParam(BuildHdr10State(), options, "hevc");
+
+        Assert.Contains("tonemapx", filters, StringComparison.Ordinal);
+    }
+
+    private static EncodingOptions SwOptions(bool passthrough)
+    {
+        return new EncodingOptions
+        {
+            HardwareAccelerationType = HardwareAccelerationType.none,
+            EnableTonemapping = true,
+            EnableHdrPassthrough = passthrough,
+        };
+    }
+
+    private static EncodingJobInfo BuildHdr10State(
+        string colorTransfer = "smpte2084",
+        string outputCodec = "hevc",
+        string? clientRangeTypes = "HDR10")
+    {
+        var video = new MediaStream
+        {
+            Index = 0,
+            Type = MediaStreamType.Video,
+            Codec = "hevc",
+            Profile = "Main 10",
+            PixelFormat = "yuv420p10le",
+            BitDepth = 10,
+            Width = 3840,
+            Height = 2160,
+            ColorTransfer = colorTransfer,
+            ColorPrimaries = "bt2020",
+            ColorSpace = "bt2020nc",
+        };
+
+        return BuildState(video, outputCodec, clientRangeTypes);
+    }
+
+    private static EncodingJobInfo BuildDoviState(int dvProfile, int dvBlCompatId, bool hdr10Plus)
+    {
+        var video = new MediaStream
+        {
+            Index = 0,
+            Type = MediaStreamType.Video,
+            Codec = "hevc",
+            Profile = "Main 10",
+            PixelFormat = "yuv420p10le",
+            BitDepth = 10,
+            Width = 3840,
+            Height = 2160,
+            ColorTransfer = "smpte2084",
+            ColorPrimaries = "bt2020",
+            ColorSpace = "bt2020nc",
+            DvProfile = dvProfile,
+            DvBlSignalCompatibilityId = dvBlCompatId,
+            RpuPresentFlag = 1,
+            BlPresentFlag = 1,
+            Hdr10PlusPresentFlag = hdr10Plus,
+        };
+
+        return BuildState(video, "hevc", "HDR10");
+    }
+
+    private static EncodingJobInfo BuildState(MediaStream video, string outputCodec, string? clientRangeTypes)
+    {
+        var audio = new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "eac3" };
+
+        return new EncodingJobInfo(TranscodingJobType.Progressive)
+        {
+            MediaSource = new MediaSourceInfo
+            {
+                Container = "mp4",
+                MediaStreams = new List<MediaStream> { video, audio },
+            },
+            VideoStream = video,
+            AudioStream = audio,
+            SubtitleDeliveryMethod = SubtitleDeliveryMethod.Drop,
+            BaseRequest = new VideoRequestDto { VideoRangeType = clientRangeTypes },
+            OutputVideoCodec = outputCodec,
+            IsVideoRequest = true,
+            IsInputVideo = true,
+        };
+    }
+
+    private static EncodingHelper CreateHelper(string? missingEncoder = null)
+    {
+        var appPaths = Mock.Of<IApplicationPaths>();
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        var subtitleEncoder = new Mock<ISubtitleEncoder>();
+        var config = new Mock<IConfiguration>();
+        var configurationManager = new Mock<IConfigurationManager>();
+        var pathManager = new Mock<IPathManager>();
+
+        // The software tone mapping path is gated on this filter being present.
+        mediaEncoder.Setup(e => e.SupportsFilter(It.IsAny<string>())).Returns(true);
+
+        // Passthrough probes for the encoder that would actually run.
+        mediaEncoder.Setup(e => e.SupportsEncoder(It.IsAny<string>()))
+            .Returns((string enc) => !string.Equals(enc, missingEncoder, StringComparison.Ordinal));
+
+        return new EncodingHelper(
+            appPaths,
+            mediaEncoder.Object,
+            subtitleEncoder.Object,
+            config.Object,
+            configurationManager.Object,
+            pathManager.Object);
+    }
+}


### PR DESCRIPTION
**Changes**

Adds an `EnableHdrPassthrough` encoding option, off by default, that keeps the source HDR through a transcode instead of tone mapping it to SDR. When the source has a static HDR10 or HLG base layer, the client reports the matching range as supported, and an encoder exists that can emit 10-bit, the tone mapping filter is dropped, the filter chain stays 10-bit through to the encoder, and the BT.2020 primaries and PQ or HLG transfer reach the output.

Five things had to change together, because any one of them alone still yields SDR:

| Location | Before | After |
| --- | --- | --- |
| `GetHwTonemapFilter`, software `tonemapx` string | tone map filter always inserted | no tone map filter under passthrough |
| `GetOverwriteColorPropertiesParam` | rewrites colour properties to BT.709 | keeps the source PQ or HLG tags |
| Filter chains | 8-bit `nv12` or `yuv420p` | `p010` or `yuv420p10le` |
| `GetVideoQualityParam` | HEVC Main 10 downgraded to Main | Main 10 kept |
| `DynamicHlsHelper` | `VIDEO-RANGE=SDR`, `hvc1.1` | `VIDEO-RANGE=PQ` or `HLG`, `hvc1.2` |

The playlist part matters for playback, not just correctness. A client configures its decoder from `VIDEO-RANGE` and the codec string, so a stream announced as SDR `hvc1.1` but delivered as Main 10 PQ fails to initialise. In testing Safari fetched the init segment repeatedly and never requested a media segment.

`TranscodingInfo` also gains `VideoRangeType`, reporting the range that is actually produced: the source range for a copy or a passthrough, SDR when the picture was tone mapped. Without it a client cannot tell whether HDR survived.

**Behaviour when passthrough is not possible**

Tone mapping is kept, unchanged, in every one of these cases:

* the option is off, which is the default
* Dolby Vision without an HDR10 or HLG base layer, because dropping the RPU leaves invalid colours and no encoder here can rewrite one
* the client does not declare a matching range, because undeclared capabilities are not the same as HDR being safe to send
* the output codec is H.264, which has no practical HDR client support
* no 10-bit encoder exists for the configured accelerator

Eligibility is decided by naming the encoder that would run and asking `SupportsEncoder`, rather than by an allowlist of accelerators. Adding an accelerator is one line. V4L2 M2M resolves to no encoder because it is 8-bit only, as do RKMPP and VideoToolbox for AV1.

All eight filter chains carry 10-bit under passthrough: software, NVENC, QSV on VAAPI and on D3D11, AMF, Intel VAAPI, AMD VAAPI with Vulkan, the limited i965 and AMD legacy VAAPI path, RKMPP, and VideoToolbox.

**Testing**

11 new unit tests cover every accept and refuse branch, including HLG, Dolby Vision profile 5, profile 8.1 with HDR10+, H.264 output, an undeclared client, a missing encoder, and V4L2 M2M. Existing suites pass unchanged: Controller 105, MediaEncoding 97, Api 108.

Verified end to end on a running server. `hevc_nvenc` on Ampere and `hevc_vaapi` on AMD Cezanne both produce Main 10 output carrying BT.2020 primaries, the PQ transfer, and mastering display and content light level side data. ffmpeg propagates that side data on its own, so the server does not restate it. Playback confirmed in Safari on iPadOS and in Chrome.

Generated filter graph for the same file and hardware, differing only in whether the client advertises HDR10:

```
SDR client : setparams=...smpte2084..., scale_cuda=w=1280:h=720, tonemap_cuda=format=yuv420p:p=bt709:t=bt709:m=bt709
HDR client : setparams=...smpte2084..., scale_cuda=w=1280:h=720:format=p010
```

**Known limitation**

`SupportsEncoder` answers whether an encoder is present in the ffmpeg build, not whether it can initialise. On a machine where jellyfin-ffmpeg is compiled with AMF but `libamfrt64.so.1` is absent, `hevc_amf` probes as available and fails at runtime. That failure is not specific to this change, since AMF transcoding fails there regardless, but the probe is not a guarantee that the hardware works.

**Code assistance**

<!-- Please complete before merge. -->

**Issues**

Fixes #17467
