### PR TITLE
Allow local image providers to be disabled per library

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -898,6 +898,16 @@ public class LibraryController : BaseJellyfinApiController
             .DistinctBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
+        result.LocalImageProviders = plugins
+            .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.LocalImageProvider))
+            .Select(i => new LibraryOptionInfoDto
+            {
+                Name = i.Name,
+                DefaultEnabled = true
+            })
+            .DistinctBy(i => i.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
         result.SubtitleFetchers = plugins
             .SelectMany(i => i.Plugins.Where(p => p.Type == MetadataPluginType.SubtitleFetcher))
             .Select(i => new LibraryOptionInfoDto

--- a/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
+++ b/Jellyfin.Api/Models/LibraryDtos/LibraryOptionsResultDto.cs
@@ -19,6 +19,11 @@ public class LibraryOptionsResultDto
     public IReadOnlyList<LibraryOptionInfoDto> MetadataReaders { get; set; } = Array.Empty<LibraryOptionInfoDto>();
 
     /// <summary>
+    /// Gets or sets the local image providers.
+    /// </summary>
+    public IReadOnlyList<LibraryOptionInfoDto> LocalImageProviders { get; set; } = Array.Empty<LibraryOptionInfoDto>();
+
+    /// <summary>
     /// Gets or sets the subtitle fetchers.
     /// </summary>
     public IReadOnlyList<LibraryOptionInfoDto> SubtitleFetchers { get; set; } = Array.Empty<LibraryOptionInfoDto>();

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -18,6 +18,7 @@ namespace MediaBrowser.Model.Configuration
             MediaSegmentProviderOrder = Array.Empty<string>();
             SubtitleFetcherOrder = Array.Empty<string>();
             DisabledLocalMetadataReaders = Array.Empty<string>();
+            DisabledLocalImageProviders = Array.Empty<string>();
             DisabledLyricFetchers = Array.Empty<string>();
             LyricFetcherOrder = Array.Empty<string>();
 
@@ -92,6 +93,16 @@ namespace MediaBrowser.Model.Configuration
         public string[] DisabledLocalMetadataReaders { get; set; }
 
         public string[]? LocalMetadataReaderOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the names of local image providers that are disabled for this library.
+        /// </summary>
+        /// <remarks>
+        /// Empty by default, which preserves the historical behaviour of always applying every
+        /// local image provider. Note that "Internal Images" reads the internal metadata folder,
+        /// which is where artwork uploaded through the API or the web client is stored.
+        /// </remarks>
+        public string[] DisabledLocalImageProviders { get; set; }
 
         public string[] DisabledSubtitleFetchers { get; set; }
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -10,8 +10,6 @@ namespace MediaBrowser.Model.Configuration
     {
         private static readonly string[] _defaultTagDelimiters = ["/", "|", ";", "\\"];
 
-        private string[] _disabledLocalImageProviders = Array.Empty<string>();
-
         public LibraryOptions()
         {
             TypeOptions = Array.Empty<TypeOptions>();
@@ -96,21 +94,7 @@ namespace MediaBrowser.Model.Configuration
 
         public string[]? LocalMetadataReaderOrder { get; set; }
 
-        /// <summary>
-        /// Gets or sets the names of local image providers that are disabled for this library.
-        /// </summary>
-        /// <remarks>
-        /// Empty by default, which preserves the historical behaviour of always applying every
-        /// local image provider. Assigning null stores an empty array, so options deserialized
-        /// from a client request with the property set to null cannot break image refreshes.
-        /// Note that "Internal Images" reads the internal metadata folder,
-        /// which is where artwork uploaded through the API or the web client is stored.
-        /// </remarks>
-        public string[] DisabledLocalImageProviders
-        {
-            get => _disabledLocalImageProviders;
-            set => _disabledLocalImageProviders = value ?? Array.Empty<string>();
-        }
+        public string[] DisabledLocalImageProviders { get; set; }
 
         public string[] DisabledSubtitleFetchers { get; set; }
 

--- a/MediaBrowser.Model/Configuration/LibraryOptions.cs
+++ b/MediaBrowser.Model/Configuration/LibraryOptions.cs
@@ -10,6 +10,8 @@ namespace MediaBrowser.Model.Configuration
     {
         private static readonly string[] _defaultTagDelimiters = ["/", "|", ";", "\\"];
 
+        private string[] _disabledLocalImageProviders = Array.Empty<string>();
+
         public LibraryOptions()
         {
             TypeOptions = Array.Empty<TypeOptions>();
@@ -99,10 +101,16 @@ namespace MediaBrowser.Model.Configuration
         /// </summary>
         /// <remarks>
         /// Empty by default, which preserves the historical behaviour of always applying every
-        /// local image provider. Note that "Internal Images" reads the internal metadata folder,
+        /// local image provider. Assigning null stores an empty array, so options deserialized
+        /// from a client request with the property set to null cannot break image refreshes.
+        /// Note that "Internal Images" reads the internal metadata folder,
         /// which is where artwork uploaded through the API or the web client is stored.
         /// </remarks>
-        public string[] DisabledLocalImageProviders { get; set; }
+        public string[] DisabledLocalImageProviders
+        {
+            get => _disabledLocalImageProviders;
+            set => _disabledLocalImageProviders = value ?? Array.Empty<string>();
+        }
 
         public string[] DisabledSubtitleFetchers { get; set; }
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -432,11 +432,11 @@ namespace MediaBrowser.Providers.Manager
                 return true;
             }
 
-            // Local image providers are not part of the image fetcher list; they are opted out of
-            // per library instead, and are enabled unless explicitly disabled.
+            // Local image providers are not part of the image fetcher list and are enabled
+            // unless the library opts out of them.
             if (provider is ILocalImageProvider)
             {
-                return !libraryOptions.DisabledLocalImageProviders.Contains(provider.Name, StringComparison.OrdinalIgnoreCase);
+                return libraryOptions.DisabledLocalImageProviders?.Contains(provider.Name, StringComparison.OrdinalIgnoreCase) != true;
             }
 
             if (item.IsLocked && refreshOptions.ImageRefreshMode != MetadataRefreshMode.FullRefresh)

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -401,7 +401,7 @@ namespace MediaBrowser.Providers.Manager
             var typeOptions = libraryOptions.GetTypeOptions(item.GetType().Name);
             var fetcherOrder = typeOptions?.ImageFetcherOrder ?? options.ImageFetcherOrder;
 
-            return _imageProviders.Where(i => CanRefreshImages(i, item, typeOptions, refreshOptions, includeDisabled))
+            return _imageProviders.Where(i => CanRefreshImages(i, item, libraryOptions, typeOptions, refreshOptions, includeDisabled))
                 .OrderBy(i => GetConfiguredOrder(fetcherOrder, i.Name))
                 .ThenBy(GetDefaultOrder);
         }
@@ -409,6 +409,7 @@ namespace MediaBrowser.Providers.Manager
         private bool CanRefreshImages(
             IImageProvider provider,
             BaseItem item,
+            LibraryOptions libraryOptions,
             TypeOptions? libraryTypeOptions,
             ImageRefreshOptions refreshOptions,
             bool includeDisabled)
@@ -426,9 +427,16 @@ namespace MediaBrowser.Providers.Manager
                 return false;
             }
 
-            if (includeDisabled || provider is ILocalImageProvider)
+            if (includeDisabled)
             {
                 return true;
+            }
+
+            // Local image providers are not part of the image fetcher list; they are opted out of
+            // per library instead, and are enabled unless explicitly disabled.
+            if (provider is ILocalImageProvider)
+            {
+                return !libraryOptions.DisabledLocalImageProviders.Contains(provider.Name, StringComparison.OrdinalIgnoreCase);
             }
 
             if (item.IsLocked && refreshOptions.ImageRefreshMode != MetadataRefreshMode.FullRefresh)

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -198,6 +198,33 @@ namespace Jellyfin.Providers.Tests.Manager
             GetImageProviders_CanRefreshImages_Tester(providerType, true, expected, baseItemEnabled: enabled);
         }
 
+        [Theory]
+        [InlineData(nameof(ILocalImageProvider), false, true)]
+        [InlineData(nameof(ILocalImageProvider), true, false)]
+        // the opt-out list must only apply to local providers
+        [InlineData(nameof(IRemoteImageProvider), true, true)]
+        [InlineData(nameof(IDynamicImageProvider), true, true)]
+        public void GetImageProviders_CanRefreshImagesLocalDisabled_WhenNotOptedOut(string providerType, bool disableLocal, bool expected)
+        {
+            GetImageProviders_CanRefreshImages_Tester(
+                providerType,
+                true,
+                expected,
+                disabledLocalImageProviders: disableLocal ? new[] { "provider" } : null);
+        }
+
+        [Theory]
+        [InlineData(nameof(ILocalImageProvider), true)]
+        [InlineData(nameof(IRemoteImageProvider), true)]
+        public void GetImageProviders_CanRefreshImagesLocalDisabled_IsCaseInsensitive(string providerType, bool disableLocal)
+        {
+            GetImageProviders_CanRefreshImages_Tester(
+                providerType,
+                true,
+                providerType != nameof(ILocalImageProvider),
+                disabledLocalImageProviders: disableLocal ? new[] { "PROVIDER" } : null);
+        }
+
         private static void GetImageProviders_CanRefreshImages_Tester(
             string providerType,
             bool supports,
@@ -205,7 +232,8 @@ namespace Jellyfin.Providers.Tests.Manager
             bool errorOnSupported = false,
             bool itemLocked = false,
             bool fullRefresh = false,
-            bool baseItemEnabled = true)
+            bool baseItemEnabled = true,
+            string[]? disabledLocalImageProviders = null)
         {
             var item = new Movie
             {
@@ -231,7 +259,12 @@ namespace Jellyfin.Providers.Tests.Manager
             baseItemManager.Setup(i => i.IsImageFetcherEnabled(item, It.IsAny<TypeOptions>(), providerName))
                 .Returns(baseItemEnabled);
 
-            using var providerManager = GetProviderManager(baseItemManager: baseItemManager.Object);
+            var libraryOptions = new LibraryOptions
+            {
+                DisabledLocalImageProviders = disabledLocalImageProviders ?? Array.Empty<string>()
+            };
+
+            using var providerManager = GetProviderManager(libraryOptions: libraryOptions, baseItemManager: baseItemManager.Object);
             AddParts(providerManager, imageProviders: new[] { provider });
 
             var actualProviders = providerManager.GetImageProviders(item, refreshOptions).ToArray();

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -213,16 +213,26 @@ namespace Jellyfin.Providers.Tests.Manager
                 disabledLocalImageProviders: disableLocal ? new[] { "provider" } : null);
         }
 
-        [Theory]
-        [InlineData(nameof(ILocalImageProvider), true)]
-        [InlineData(nameof(IRemoteImageProvider), true)]
-        public void GetImageProviders_CanRefreshImagesLocalDisabled_IsCaseInsensitive(string providerType, bool disableLocal)
+        [Fact]
+        public void GetImageProviders_CanRefreshImagesLocalDisabled_IsCaseInsensitive()
         {
             GetImageProviders_CanRefreshImages_Tester(
-                providerType,
+                nameof(ILocalImageProvider),
                 true,
-                providerType != nameof(ILocalImageProvider),
-                disabledLocalImageProviders: disableLocal ? new[] { "PROVIDER" } : null);
+                false,
+                disabledLocalImageProviders: new[] { "PROVIDER" });
+        }
+
+        [Fact]
+        public void GetImageProviders_CanRefreshImagesLocalDisabledNull_TreatedAsEmpty()
+        {
+            // Clients can update library options with the property set to null; the setter
+            // stores an empty array so local providers stay enabled instead of throwing.
+            GetImageProviders_CanRefreshImages_Tester(
+                nameof(ILocalImageProvider),
+                true,
+                true,
+                disabledLocalImageProviders: null);
         }
 
         private static void GetImageProviders_CanRefreshImages_Tester(
@@ -261,7 +271,8 @@ namespace Jellyfin.Providers.Tests.Manager
 
             var libraryOptions = new LibraryOptions
             {
-                DisabledLocalImageProviders = disabledLocalImageProviders ?? Array.Empty<string>()
+                // Null is assigned as-is to verify that the property setter coalesces it.
+                DisabledLocalImageProviders = disabledLocalImageProviders!
             };
 
             using var providerManager = GetProviderManager(libraryOptions: libraryOptions, baseItemManager: baseItemManager.Object);

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -223,18 +223,6 @@ namespace Jellyfin.Providers.Tests.Manager
                 disabledLocalImageProviders: new[] { "PROVIDER" });
         }
 
-        [Fact]
-        public void GetImageProviders_CanRefreshImagesLocalDisabledNull_TreatedAsEmpty()
-        {
-            // Clients can update library options with the property set to null; the setter
-            // stores an empty array so local providers stay enabled instead of throwing.
-            GetImageProviders_CanRefreshImages_Tester(
-                nameof(ILocalImageProvider),
-                true,
-                true,
-                disabledLocalImageProviders: null);
-        }
-
         private static void GetImageProviders_CanRefreshImages_Tester(
             string providerType,
             bool supports,
@@ -269,11 +257,11 @@ namespace Jellyfin.Providers.Tests.Manager
             baseItemManager.Setup(i => i.IsImageFetcherEnabled(item, It.IsAny<TypeOptions>(), providerName))
                 .Returns(baseItemEnabled);
 
-            var libraryOptions = new LibraryOptions
+            var libraryOptions = new LibraryOptions();
+            if (disabledLocalImageProviders is not null)
             {
-                // Null is assigned as-is to verify that the property setter coalesces it.
-                DisabledLocalImageProviders = disabledLocalImageProviders!
-            };
+                libraryOptions.DisabledLocalImageProviders = disabledLocalImageProviders;
+            }
 
             using var providerManager = GetProviderManager(libraryOptions: libraryOptions, baseItemManager: baseItemManager.Object);
             AddParts(providerManager, imageProviders: new[] { provider });


### PR DESCRIPTION
Local image providers bypass the image fetcher configuration entirely. `CanRefreshImages` returns true for any `ILocalImageProvider` before the enabled check runs, so a `poster.jpg` next to the media always beats artwork from a metadata provider or artwork uploaded through the API, with no way to opt out.

**Changes**
* Add `DisabledLocalImageProviders` to `LibraryOptions`, declared like the existing `DisabledLocalMetadataReaders`
* Replace that short circuit in `CanRefreshImages` with a check against the list, still after the `includeDisabled` branch so a disabled provider stays listed and can be turned back on
* Return the available local image providers from `Libraries/AvailableOptions`
* Tests for the opt out, remote and dynamic providers being unaffected, and case insensitive matching

Empty by default. On a movie library the list is `Local Images` (the `poster.jpg` / `folder.jpg` / `cover.jpg` sidecars) and `Internal Images` (uploaded artwork). I left the latter in rather than filtering it out, happy to hide it if you would rather.

Two things worth knowing: `EpisodeLocalImageProvider` is also named `Local Images`, so on TV libraries the two are disabled together, and disabling a provider stops new sidecars being adopted without dropping one that already was.

**Code assistance**

Claude Code to locate the code paths and write the tests

**Issues**

Relates to #14449 and #13256. Client side is jellyfin/jellyfin-web#8274.
