### PR TITLE
Fix InvalidOperationException when guide requests an unmatched channel

### DIFF
--- a/src/Jellyfin.LiveTv/DefaultLiveTvService.cs
+++ b/src/Jellyfin.LiveTv/DefaultLiveTvService.cs
@@ -448,7 +448,12 @@ namespace Jellyfin.LiveTv
         public async Task<IEnumerable<ProgramInfo>> GetProgramsAsync(string channelId, DateTime startDateUtc, DateTime endDateUtc, CancellationToken cancellationToken)
         {
             var channels = await GetChannelsAsync(true, cancellationToken).ConfigureAwait(false);
-            var channel = channels.First(i => string.Equals(i.Id, channelId, StringComparison.OrdinalIgnoreCase));
+            var channel = channels.FirstOrDefault(i => string.Equals(i.Id, channelId, StringComparison.OrdinalIgnoreCase));
+            if (channel is null)
+            {
+                _logger.LogDebug("No channel found matching id {ChannelId}; returning no programs", channelId);
+                return [];
+            }
 
             return await _listingsManager.GetProgramsAsync(channel, startDateUtc, endDateUtc, cancellationToken)
                 .ConfigureAwait(false);

--- a/tests/Jellyfin.LiveTv.Tests/DefaultLiveTvServiceTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/DefaultLiveTvServiceTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.LiveTv.Timers;
+using MediaBrowser.Common;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests
+{
+    public class DefaultLiveTvServiceTests
+    {
+        private static DefaultLiveTvService CreateService(ITunerHostManager tunerHostManager)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jf-livetv-test-" + Guid.NewGuid().ToString("N"));
+
+            var appPaths = new Mock<IApplicationPaths>();
+            appPaths.Setup(x => x.DataPath).Returns(tempDir);
+
+            var configManager = new Mock<IConfigurationManager>();
+            configManager.Setup(x => x.CommonApplicationPaths).Returns(appPaths.Object);
+
+            var timerManager = new TimerManager(NullLogger<TimerManager>.Instance, configManager.Object);
+            var seriesTimerManager = new SeriesTimerManager(NullLogger<SeriesTimerManager>.Instance, configManager.Object);
+
+            var dtoService = new LiveTvDtoService(
+                Mock.Of<IDtoService>(),
+                Mock.Of<IImageProcessor>(),
+                NullLogger<LiveTvDtoService>.Instance,
+                Mock.Of<IApplicationHost>(),
+                Mock.Of<ILibraryManager>());
+
+            return new DefaultLiveTvService(
+                NullLogger<DefaultLiveTvService>.Instance,
+                Mock.Of<IServerConfigurationManager>(),
+                tunerHostManager,
+                Mock.Of<IListingsManager>(),
+                Mock.Of<IRecordingsManager>(),
+                Mock.Of<ILibraryManager>(),
+                dtoService,
+                timerManager,
+                seriesTimerManager);
+        }
+
+        [Fact]
+        public async Task GetProgramsAsync_UnmatchedChannelId_ReturnsEmpty()
+        {
+            var tunerHostManager = new Mock<ITunerHostManager>();
+            tunerHostManager.Setup(x => x.TunerHosts).Returns(Array.Empty<ITunerHost>());
+
+            var service = CreateService(tunerHostManager.Object);
+
+            var result = await service.GetProgramsAsync(
+                "channel-that-does-not-exist",
+                DateTime.UtcNow,
+                DateTime.UtcNow.AddHours(1),
+                CancellationToken.None);
+
+            Assert.Empty(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`DefaultLiveTvService.GetProgramsAsync` used `.First(...)` to locate a channel by id, which throws `InvalidOperationException: "Sequence contains no matching element"` when no channel matches. `GuideManager` catches this per channel and logs it at **ERROR**, which spams the log and can leave guides empty. A channel with no matching EPG entry is a **normal** condition, not an error.

## Fix

Use `.FirstOrDefault(...)` and return an empty result (logged at Debug) when there is no match.

```csharp
var channel = channels.FirstOrDefault(i => string.Equals(i.Id, channelId, StringComparison.OrdinalIgnoreCase));
if (channel is null)
{
    _logger.LogDebug("No channel found matching id {ChannelId}; returning no programs", channelId);
    return [];
}
```

## Tests

Adds `DefaultLiveTvServiceTests.GetProgramsAsync_UnmatchedChannelId_ReturnsEmpty`: against `master` it fails with the exception above; with this change it returns empty and the suite stays green.

## Notes

- Small, backward-compatible, server-side change (benefits every client/OS).
