### PR TITLE
Parse XMLTV guide once per refresh instead of once per channel

### DIFF
--- a/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
+++ b/src/Jellyfin.LiveTv/Listings/XmlTvListingsProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Jellyfin.Extensions;
 using Jellyfin.XmlTv;
 using Jellyfin.XmlTv.Entities;
@@ -31,6 +32,14 @@ namespace Jellyfin.LiveTv.Listings
         private readonly IServerConfigurationManager _config;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<XmlTvListingsProvider> _logger;
+
+        // Caches the last fully-parsed XMLTV file, grouped by channel id, so a guide refresh over
+        // thousands of channels parses the (potentially multi-GB) file once instead of once per
+        // channel. Keyed by file path + last-write-time so a freshly downloaded file rebuilds it.
+        private readonly object _programsCacheLock = new();
+        private string? _programsCacheFile;
+        private DateTime _programsCacheWriteTimeUtc;
+        private IReadOnlyDictionary<string, List<XmlTvProgram>>? _programsCache;
 
         public XmlTvListingsProvider(
             IServerConfigurationManager config,
@@ -58,7 +67,7 @@ namespace Jellyfin.LiveTv.Listings
 
         private async Task<string> GetXml(ListingsProviderInfo info, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("xmltv path: {Path}", info.Path);
+            _logger.LogDebug("xmltv path: {Path}", info.Path);
 
             string cacheFilename = info.Id + ".xml";
             string cacheDir = Path.Join(_config.ApplicationPaths.CachePath, "xmltv");
@@ -169,11 +178,116 @@ namespace Jellyfin.LiveTv.Listings
             _logger.LogDebug("Getting xmltv programs for channel {Id}", channelId);
 
             string path = await GetXml(info, cancellationToken).ConfigureAwait(false);
-            _logger.LogDebug("Opening XmlTvReader for {Path}", path);
-            var reader = new XmlTvReader(path, GetLanguage(info));
 
-            return reader.GetProgrammes(channelId, startDateUtc, endDateUtc, cancellationToken)
-                        .Select(p => GetProgramInfoWithEtag(p, info));
+            var programsByChannel = GetProgramsByChannel(path, GetLanguage(info), cancellationToken);
+            if (!programsByChannel.TryGetValue(channelId, out var channelPrograms))
+            {
+                return [];
+            }
+
+            var startOffset = new DateTimeOffset(DateTime.SpecifyKind(startDateUtc, DateTimeKind.Utc));
+            var endOffset = new DateTimeOffset(DateTime.SpecifyKind(endDateUtc, DateTimeKind.Utc));
+
+            // Materialize fresh ProgramInfo instances per call: callers mutate ProgramInfo (Id/ChannelId),
+            // so cached parsed XmlTvProgram entries must never be handed out directly.
+            return channelPrograms
+                .Where(p => p.EndDate >= startOffset && p.StartDate < endOffset)
+                .Select(p => GetProgramInfoWithEtag(p, info))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Parses the entire XMLTV file a single time and groups every programme by channel id, caching
+        /// the result until the underlying file changes. Without this, a guide refresh re-parses the whole
+        /// file once for every channel, which is unusable for providers exposing tens of thousands of channels.
+        /// </summary>
+        private IReadOnlyDictionary<string, List<XmlTvProgram>> GetProgramsByChannel(string path, string? language, CancellationToken cancellationToken)
+        {
+            var writeTimeUtc = File.GetLastWriteTimeUtc(path);
+
+            var cached = _programsCache;
+            if (cached is not null
+                && string.Equals(_programsCacheFile, path, StringComparison.Ordinal)
+                && _programsCacheWriteTimeUtc == writeTimeUtc)
+            {
+                return cached;
+            }
+
+            lock (_programsCacheLock)
+            {
+                cached = _programsCache;
+                if (cached is not null
+                    && string.Equals(_programsCacheFile, path, StringComparison.Ordinal)
+                    && _programsCacheWriteTimeUtc == writeTimeUtc)
+                {
+                    return cached;
+                }
+
+                _logger.LogDebug("Parsing XMLTV programmes for all channels from {Path}", path);
+
+                // Release any previously cached data before building the replacement.
+                _programsCache = null;
+                _programsCacheFile = null;
+
+                var parsed = ParseProgramsByChannel(path, language, cancellationToken);
+
+                _programsCacheFile = path;
+                _programsCacheWriteTimeUtc = writeTimeUtc;
+                _programsCache = parsed;
+
+                _logger.LogDebug("Parsed XMLTV programmes for {ChannelCount} channels from {Path}", parsed.Count, path);
+
+                return parsed;
+            }
+        }
+
+        private static IReadOnlyDictionary<string, List<XmlTvProgram>> ParseProgramsByChannel(string path, string? language, CancellationToken cancellationToken)
+        {
+            // Reuse the library's per-programme parser, but drive a single pass over the file ourselves
+            // so every channel's programmes are captured in one read instead of one read per channel.
+            var reader = new XmlTvReader(path, language);
+            var result = new Dictionary<string, List<XmlTvProgram>>(StringComparer.OrdinalIgnoreCase);
+
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Ignore,
+                CheckCharacters = false,
+                IgnoreProcessingInstructions = true,
+                IgnoreComments = true
+            };
+
+            using var xml = XmlReader.Create(path, settings);
+            if (xml.ReadToDescendant("tv") && xml.ReadToDescendant("programme"))
+            {
+                do
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var channelId = xml.GetAttribute("channel");
+                    if (string.IsNullOrEmpty(channelId))
+                    {
+                        continue;
+                    }
+
+                    // Capture the full date range; per-request date filtering happens against the cache.
+                    var programme = reader.GetProgramme(xml, channelId, DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+                    if (programme is null)
+                    {
+                        continue;
+                    }
+
+                    if (!result.TryGetValue(channelId, out var list))
+                    {
+                        list = [];
+                        result[channelId] = list;
+                    }
+
+                    list.Add(programme);
+                }
+                while (xml.ReadToFollowing("programme"));
+            }
+
+            return result;
         }
 
         private ProgramInfo GetProgramInfoWithEtag(XmlTvProgram program, ListingsProviderInfo info)

--- a/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Listings/XmlTvListingsProviderTests.cs
@@ -124,6 +124,61 @@ public class XmlTvListingsProviderTests
         Assert.Equal(original.Etag, equivalent.Etag);
     }
 
+    [Fact]
+    public async Task GetProgramsAsync_MultipleChannels_ReturnsOnlyRequestedChannel()
+    {
+        var info = new ListingsProviderInfo { Path = "Test Data/LiveTv/Listings/XmlTv/multichannel.xml" };
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
+
+        var channel1001 = (await _xmlTvListingsProvider
+            .GetProgramsAsync(info, "1001", startDate, startDate.AddDays(1), CancellationToken.None)).ToList();
+        var channel2002 = (await _xmlTvListingsProvider
+            .GetProgramsAsync(info, "2002", startDate, startDate.AddDays(1), CancellationToken.None)).ToList();
+
+        Assert.All(channel1001, p => Assert.Equal("1001", p.ChannelId));
+        Assert.All(channel2002, p => Assert.Equal("2002", p.ChannelId));
+
+        // Within a one-day window: 1001 has Program A + B (Program C is two days later), 2002 has A + B.
+        Assert.Equal(2, channel1001.Count);
+        Assert.Equal(2, channel2002.Count);
+    }
+
+    [Fact]
+    public async Task GetProgramsAsync_FiltersToRequestedWindow()
+    {
+        var info = new ListingsProviderInfo { Path = "Test Data/LiveTv/Listings/XmlTv/multichannel.xml" };
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
+
+        // A three-day window should also include Program C for channel 1001.
+        var wideWindow = (await _xmlTvListingsProvider
+            .GetProgramsAsync(info, "1001", startDate, startDate.AddDays(3), CancellationToken.None)).ToList();
+
+        Assert.Equal(3, wideWindow.Count);
+    }
+
+    [Fact]
+    public async Task GetProgramsAsync_RepeatedCalls_ReturnFreshObjects()
+    {
+        var info = new ListingsProviderInfo { Path = "Test Data/LiveTv/Listings/XmlTv/multichannel.xml" };
+        var startDate = new DateTime(2022, 11, 4, 0, 0, 0, DateTimeKind.Utc);
+
+        var first = (await _xmlTvListingsProvider
+            .GetProgramsAsync(info, "1001", startDate, startDate.AddDays(1), CancellationToken.None)).ToList();
+
+        // Callers mutate ProgramInfo (Id/ChannelId). Ensure the cached parse is not corrupted by it.
+        foreach (var program in first)
+        {
+            program.Id += "_mutated";
+            program.ChannelId = "mutated";
+        }
+
+        var second = (await _xmlTvListingsProvider
+            .GetProgramsAsync(info, "1001", startDate, startDate.AddDays(1), CancellationToken.None)).ToList();
+
+        Assert.All(second, p => Assert.Equal("1001", p.ChannelId));
+        Assert.All(second, p => Assert.DoesNotContain("_mutated", p.Id, StringComparison.Ordinal));
+    }
+
     private async Task<ProgramInfo> GetSingleProgramAsync(string path)
     {
         var info = new ListingsProviderInfo()

--- a/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/multichannel.xml
+++ b/tests/Jellyfin.LiveTv.Tests/Test Data/LiveTv/Listings/XmlTv/multichannel.xml
@@ -1,0 +1,22 @@
+<tv date="20221104">
+  <programme channel="1001" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Channel 1001 - Program A</title>
+    <desc lang="en">First program on 1001.</desc>
+  </programme>
+  <programme channel="2002" start="20221104130000 +0000" stop="20221104140000 +0000">
+    <title lang="en">Channel 2002 - Program A</title>
+    <desc lang="en">First program on 2002.</desc>
+  </programme>
+  <programme channel="1001" start="20221104140000 +0000" stop="20221104150000 +0000">
+    <title lang="en">Channel 1001 - Program B</title>
+    <desc lang="en">Second program on 1001.</desc>
+  </programme>
+  <programme channel="1001" start="20221106130000 +0000" stop="20221106140000 +0000">
+    <title lang="en">Channel 1001 - Program C (next-next day)</title>
+    <desc lang="en">Later program on 1001, outside a one-day window.</desc>
+  </programme>
+  <programme channel="2002" start="20221104150000 +0000" stop="20221104160000 +0000">
+    <title lang="en">Channel 2002 - Program B</title>
+    <desc lang="en">Second program on 2002.</desc>
+  </programme>
+</tv>


### PR DESCRIPTION
## Summary

`XmlTvListingsProvider.GetProgramsAsync` builds a new `XmlTvReader` and calls `GetProgrammes(channelId, ...)` on every call, and that streams and parses the **entire** XMLTV file to filter for a single channel. `GuideManager` calls this once per channel, so for *N* channels the whole file is parsed *N* times — **O(channels × filesize)**. With a large IPTV provider (tens of thousands of channels, multi-GB XMLTV) a guide refresh becomes pathologically slow.

## Fix

Parse the file a single time into a `channelId → programmes` dictionary, cached and keyed by path + last-write-time, then serve each channel from memory.

```csharp
var programsByChannel = GetProgramsByChannel(path, GetLanguage(info), cancellationToken);
if (!programsByChannel.TryGetValue(channelId, out var channelPrograms))
{
    return [];
}

return channelPrograms
    .Where(p => p.EndDate >= startOffset && p.StartDate < endOffset)
    .Select(p => GetProgramInfoWithEtag(p, info))
    .ToList();
```

Fresh `ProgramInfo` objects are still materialized per call because callers mutate them (`Id`/`ChannelId`), so only the lighter parsed entries are cached. The cache rebuilds automatically when a newer file is downloaded (write-time changes). This turns **O(channels × filesize)** into **O(filesize)**.

## Tests

Three new tests in `XmlTvListingsProviderTests` (+ a multi-channel XMLTV test data file): only the requested channel's programmes are returned; the date window is respected; repeated calls return fresh objects so caller mutation cannot corrupt the cache.

## Notes

- Parsing semantics are unchanged — only the number of file reads changes (N → 1).
- Server-side; benefits every client/OS.
