### PR TITLE
Add Referer and custom HTTP headers for M3U tuners

### DIFF
--- a/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
+++ b/MediaBrowser.Model/LiveTv/TunerHostInfo.cs
@@ -1,6 +1,9 @@
 #nullable disable
 #pragma warning disable CS1591
 
+using System;
+using MediaBrowser.Model.Dto;
+
 namespace MediaBrowser.Model.LiveTv
 {
     public class TunerHostInfo
@@ -13,6 +16,7 @@ namespace MediaBrowser.Model.LiveTv
             AllowStreamSharing = true;
             AllowFmp4TranscodingContainer = false;
             FallbackMaxStreamingBitrate = 30000000;
+            CustomHttpHeaders = Array.Empty<NameValuePair>();
         }
 
         public string Id { get; set; }
@@ -42,6 +46,19 @@ namespace MediaBrowser.Model.LiveTv
         public int TunerCount { get; set; }
 
         public string UserAgent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Referer header sent with HTTP requests for this tuner. Some IPTV
+        /// providers reject requests (HTTP 406/403) unless a matching Referer is present.
+        /// </summary>
+        public string Referer { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional custom HTTP headers sent with requests for this tuner.
+        /// Applied on top of the User-Agent and Referer headers. Stored as name/value pairs
+        /// so the value survives XML configuration serialization.
+        /// </summary>
+        public NameValuePair[] CustomHttpHeaders { get; set; }
 
         public bool IgnoreDts { get; set; }
 

--- a/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3UTunerHost.cs
@@ -164,6 +164,24 @@ namespace Jellyfin.LiveTv.TunerHosts
                 httpHeaders[HeaderNames.UserAgent] = string.IsNullOrWhiteSpace(info.UserAgent) ?
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36" :
                     info.UserAgent;
+
+                // Some IPTV providers reject requests (HTTP 406/403) without a matching Referer.
+                if (!string.IsNullOrWhiteSpace(info.Referer))
+                {
+                    httpHeaders[HeaderNames.Referer] = info.Referer;
+                }
+
+                // Apply any additional provider-specific headers configured for this tuner.
+                if (info.CustomHttpHeaders is not null)
+                {
+                    foreach (var header in info.CustomHttpHeaders)
+                    {
+                        if (!string.IsNullOrWhiteSpace(header.Name) && !string.IsNullOrWhiteSpace(header.Value))
+                        {
+                            httpHeaders[header.Name] = header.Value;
+                        }
+                    }
+                }
             }
 
             var mediaSource = new MediaSourceInfo

--- a/tests/Jellyfin.LiveTv.Tests/M3UTunerHostTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/M3UTunerHostTests.cs
@@ -1,0 +1,106 @@
+using Jellyfin.LiveTv.TunerHosts;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.LiveTv;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests
+{
+    public class M3UTunerHostTests
+    {
+        [Fact]
+        public void CreateMediaSourceInfo_DefaultsUserAgent_WhenNoneConfigured()
+        {
+            var host = CreateHost();
+            var info = new TunerHostInfo { Url = "http://example.com/list.m3u" };
+            var channel = new ChannelInfo { Path = "http://example.com/stream" };
+
+            var mediaSource = host.CreateMediaSourceInfoPublic(info, channel);
+
+            Assert.True(mediaSource.RequiredHttpHeaders.ContainsKey(HeaderNames.UserAgent));
+            Assert.False(mediaSource.RequiredHttpHeaders.ContainsKey(HeaderNames.Referer));
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_AddsReferer_WhenConfigured()
+        {
+            var host = CreateHost();
+            var info = new TunerHostInfo
+            {
+                Url = "http://example.com/list.m3u",
+                Referer = "http://provider.example/portal"
+            };
+            var channel = new ChannelInfo { Path = "http://example.com/stream" };
+
+            var mediaSource = host.CreateMediaSourceInfoPublic(info, channel);
+
+            Assert.Equal("http://provider.example/portal", mediaSource.RequiredHttpHeaders[HeaderNames.Referer]);
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_AddsCustomHeaders_WhenConfigured()
+        {
+            var host = CreateHost();
+            var info = new TunerHostInfo
+            {
+                Url = "http://example.com/list.m3u",
+                CustomHttpHeaders =
+                [
+                    new NameValuePair("Origin", "http://provider.example"),
+                    new NameValuePair("X-Provider-Token", "abc123")
+                ]
+            };
+            var channel = new ChannelInfo { Path = "http://example.com/stream" };
+
+            var mediaSource = host.CreateMediaSourceInfoPublic(info, channel);
+
+            Assert.Equal("http://provider.example", mediaSource.RequiredHttpHeaders["Origin"]);
+            Assert.Equal("abc123", mediaSource.RequiredHttpHeaders["X-Provider-Token"]);
+        }
+
+        private static TestableM3UTunerHost CreateHost()
+        {
+            var mediaSourceManager = new Mock<IMediaSourceManager>();
+            mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>())).Returns(MediaProtocol.Http);
+
+            return new TestableM3UTunerHost(
+                Mock.Of<IServerConfigurationManager>(),
+                mediaSourceManager.Object,
+                NullLogger<M3UTunerHost>.Instance,
+                Mock.Of<IFileSystem>(),
+                Mock.Of<System.Net.Http.IHttpClientFactory>(),
+                Mock.Of<IServerApplicationHost>(),
+                Mock.Of<INetworkManager>(),
+                Mock.Of<IStreamHelper>());
+        }
+
+        private sealed class TestableM3UTunerHost : M3UTunerHost
+        {
+            public TestableM3UTunerHost(
+                IServerConfigurationManager config,
+                IMediaSourceManager mediaSourceManager,
+                ILogger<M3UTunerHost> logger,
+                IFileSystem fileSystem,
+                System.Net.Http.IHttpClientFactory httpClientFactory,
+                IServerApplicationHost appHost,
+                INetworkManager networkManager,
+                IStreamHelper streamHelper)
+                : base(config, mediaSourceManager, logger, fileSystem, httpClientFactory, appHost, networkManager, streamHelper)
+            {
+            }
+
+            public MediaSourceInfo CreateMediaSourceInfoPublic(TunerHostInfo info, ChannelInfo channel)
+                => CreateMediaSourceInfo(info, channel);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

For M3U tuner sources, `M3UTunerHost.CreateMediaSourceInfo` only ever set a **User-Agent** on the outgoing request. Many IPTV providers return **HTTP 406/403** unless a `Referer` (or another provider-specific header) is present, so those channels fail in Jellyfin while playing fine in VLC/ffmpeg where such headers can be supplied. This also affects DVR, which opens the stream through the same tuner host.

## Fix

Add optional `Referer` and `CustomHttpHeaders` to `TunerHostInfo` and populate `mediaSource.RequiredHttpHeaders` from them alongside the existing User-Agent.

```csharp
if (!string.IsNullOrWhiteSpace(info.Referer))
{
    httpHeaders[HeaderNames.Referer] = info.Referer;
}

if (info.CustomHttpHeaders is not null)
{
    foreach (var header in info.CustomHttpHeaders)
    {
        if (!string.IsNullOrWhiteSpace(header.Name) && !string.IsNullOrWhiteSpace(header.Value))
        {
            httpHeaders[header.Name] = header.Value;
        }
    }
}
```

**Important:** `CustomHttpHeaders` is a `NameValuePair[]`, **not** a `Dictionary<string,string>`. `LiveTvOptions` is persisted via `XmlSerializer`, which throws `NotSupportedException` on `IDictionary` members and would break *all* tuner saves. This mirrors the `NameValuePair[]` pattern already used by `ListingsProviderInfo.ChannelMappings`.

## Tests

`M3UTunerHostTests` (3 tests): the default User-Agent is still applied; a configured `Referer` lands in `RequiredHttpHeaders`; custom headers are applied.

## Notes

- Fully backward-compatible: existing configs with none of the new fields behave exactly as before.
- A matching `jellyfin-web` config UI (inputs for Referer + custom headers) can follow as a separate web PR.
