### PR TITLE
Make Live TV guide refresh scale for large IPTV playlists

### DIFF
--- a/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
+++ b/MediaBrowser.Model/LiveTv/LiveTvOptions.cs
@@ -44,5 +44,21 @@ namespace MediaBrowser.Model.LiveTv
         public bool SaveRecordingNFO { get; set; } = true;
 
         public bool SaveRecordingImages { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether channels without any guide data are hidden
+        /// from the channel list and guide. Useful for large IPTV playlists (tens of thousands
+        /// of channels) where most channels have no EPG, leaving the guide cluttered with blank rows.
+        /// </summary>
+        public bool HideChannelsWithoutProgrammes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether channel logos and programme images are
+        /// downloaded and cached locally during the guide refresh. When disabled, images are
+        /// fetched lazily on first display instead, which dramatically speeds up the guide
+        /// refresh for large IPTV playlists (whose logo/image URLs are often dead links that
+        /// otherwise block the refresh on network timeouts). Defaults to <c>true</c>.
+        /// </summary>
+        public bool PreCacheGuideImages { get; set; } = true;
     }
 }

--- a/src/Jellyfin.LiveTv/Guide/GuideManager.cs
+++ b/src/Jellyfin.LiveTv/Guide/GuideManager.cs
@@ -29,6 +29,12 @@ public class GuideManager : IGuideManager
     private const string EtagKey = "ProgramEtag";
     private const string ExternalServiceTag = "ExternalServiceId";
 
+    /// <summary>
+    /// Tag applied to channels that have at least one guide programme after a refresh.
+    /// Used to optionally hide channels with no EPG data from the channel list and guide.
+    /// </summary>
+    public const string GuideDataTagName = "GuideData";
+
     private static readonly ParallelOptions _cacheParallelOptions = new() { MaxDegreeOfParallelism = Math.Min(Environment.ProcessorCount, 10) };
 
     private readonly ILogger<GuideManager> _logger;
@@ -181,7 +187,7 @@ public class GuideManager : IGuideManager
             .Select(i => new Tuple<string, ChannelInfo>(service.Name, i))
             .ToList();
 
-        var list = new List<LiveTvChannel>();
+        var list = new List<(LiveTvChannel Channel, bool NeedsRefresh)>();
 
         var numComplete = 0;
         var parentFolder = _liveTvManager.GetInternalLiveTvFolder(cancellationToken);
@@ -220,10 +226,18 @@ public class GuideManager : IGuideManager
 
         var guideDays = GetGuideDays();
 
-        _logger.LogInformation("Refreshing guide with {Days} days of guide data", guideDays);
+        // When disabled, channel logos and programme images are left as remote URLs and fetched
+        // lazily on first display instead of being downloaded synchronously here. This avoids the
+        // per-channel network stall (often on dead IPTV logo links) that dominates a large refresh.
+        var preCacheImages = _config.GetLiveTvConfiguration().PreCacheGuideImages;
+
+        _logger.LogInformation(
+            "Refreshing guide with {Days} days of guide data (image pre-caching {State})",
+            guideDays,
+            preCacheImages ? "enabled" : "disabled");
 
         var maxCacheDate = DateTime.UtcNow.AddDays(MaxCacheDays);
-        foreach (var currentChannel in list)
+        foreach (var (currentChannel, channelNeedsRefresh) in list)
         {
             cancellationToken.ThrowIfCancellationRequested();
             channels.Add(currentChannel.Id);
@@ -241,12 +255,18 @@ public class GuideManager : IGuideManager
 
                 var channelPrograms = (await service.GetProgramsAsync(currentChannel.ExternalId, start, end, cancellationToken).ConfigureAwait(false)).ToList();
 
-                var existingPrograms = _libraryManager.GetItemList(new InternalItemsQuery
-                {
-                    IncludeItemTypes = [BaseItemKind.LiveTvProgram],
-                    ChannelIds = [currentChannel.Id],
-                    DtoOptions = new DtoOptions(true)
-                }).Cast<LiveTvProgram>().ToDictionary(i => i.Id);
+                // Skip the per-channel existing-programs lookup when the provider returned no
+                // programmes for this channel. On large IPTV playlists the vast majority of
+                // channels have no EPG, so this avoids tens of thousands of pointless DB queries
+                // each refresh. Any stale programmes are still removed by CleanDatabase afterwards.
+                var existingPrograms = channelPrograms.Count == 0
+                    ? new Dictionary<Guid, LiveTvProgram>()
+                    : _libraryManager.GetItemList(new InternalItemsQuery
+                    {
+                        IncludeItemTypes = [BaseItemKind.LiveTvProgram],
+                        ChannelIds = [currentChannel.Id],
+                        DtoOptions = new DtoOptions(true)
+                    }).Cast<LiveTvProgram>().ToDictionary(i => i.Id);
 
                 var newPrograms = new List<LiveTvProgram>();
                 var updatedPrograms = new List<LiveTvProgram>();
@@ -283,7 +303,10 @@ public class GuideManager : IGuideManager
                 {
                     _libraryManager.CreateItems(newPrograms, currentChannel, cancellationToken);
 
-                    await PreCacheImages(newPrograms, maxCacheDate).ConfigureAwait(false);
+                    if (preCacheImages)
+                    {
+                        await PreCacheImages(newPrograms, maxCacheDate).ConfigureAwait(false);
+                    }
                 }
 
                 if (updatedPrograms.Count > 0)
@@ -294,26 +317,83 @@ public class GuideManager : IGuideManager
                         ItemUpdateType.MetadataImport,
                         cancellationToken).ConfigureAwait(false);
 
-                    await PreCacheImages(updatedPrograms, maxCacheDate).ConfigureAwait(false);
+                    if (preCacheImages)
+                    {
+                        await PreCacheImages(updatedPrograms, maxCacheDate).ConfigureAwait(false);
+                    }
                 }
 
-                currentChannel.IsMovie = isMovie;
-                currentChannel.IsNews = isNews;
-                currentChannel.IsSports = isSports;
-                currentChannel.IsSeries = isSeries;
+                // Only persist and refresh the channel when something actually changed this cycle.
+                // Doing this unconditionally re-saved and re-refreshed every channel (icons included)
+                // on every guide refresh, which is the dominant cost for large playlists.
+                var channelChanged = channelNeedsRefresh;
+
+                if (currentChannel.IsMovie != isMovie)
+                {
+                    currentChannel.IsMovie = isMovie;
+                    channelChanged = true;
+                }
+
+                if (currentChannel.IsNews != isNews)
+                {
+                    currentChannel.IsNews = isNews;
+                    channelChanged = true;
+                }
+
+                if (currentChannel.IsSports != isSports)
+                {
+                    currentChannel.IsSports = isSports;
+                    channelChanged = true;
+                }
+
+                if (currentChannel.IsSeries != isSeries)
+                {
+                    currentChannel.IsSeries = isSeries;
+                    channelChanged = true;
+                }
+
+                var tagsBefore = currentChannel.Tags;
 
                 if (isKids)
                 {
                     currentChannel.AddTag("Kids");
                 }
 
-                await currentChannel.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
-                await currentChannel.RefreshMetadata(
-                    new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                // Mark whether this channel has any guide data so it can be optionally hidden
+                // when empty. A previously marked channel that lost all programmes must be
+                // unmarked, otherwise it would linger in a filtered guide.
+                if (channelPrograms.Count > 0)
+                {
+                    currentChannel.AddTag(GuideDataTagName);
+                }
+                else
+                {
+                    RemoveTag(currentChannel, GuideDataTagName);
+                }
+
+                // AddTag/RemoveTag only swap the array instance when the set actually changed.
+                if (!ReferenceEquals(tagsBefore, currentChannel.Tags))
+                {
+                    channelChanged = true;
+                }
+
+                if (channelChanged)
+                {
+                    await currentChannel.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
+
+                    // RefreshMetadata is what downloads/localizes the channel logo. Skip it when
+                    // image pre-caching is disabled; the logo (a remote URL) then loads lazily on
+                    // first display via the image endpoint instead of stalling the refresh here.
+                    if (preCacheImages)
                     {
-                        ForceSave = true
-                    },
-                    cancellationToken).ConfigureAwait(false);
+                        await currentChannel.RefreshMetadata(
+                            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+                            {
+                                ForceSave = true
+                            },
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                }
             }
             catch (OperationCanceledException)
             {
@@ -342,6 +422,11 @@ public class GuideManager : IGuideManager
             DtoOptions = new DtoOptions(false)
         });
 
+        // Use a set for O(1) membership tests. The previous Array.Contains made this O(n*m),
+        // which becomes pathological (tens of thousands of programmes x thousands of ids) and
+        // dominated the tail of the guide refresh on large playlists.
+        var currentIds = new HashSet<Guid>(currentIdList);
+
         var numComplete = 0;
 
         foreach (var itemId in list)
@@ -354,7 +439,7 @@ public class GuideManager : IGuideManager
                 continue;
             }
 
-            if (!currentIdList.Contains(itemId))
+            if (!currentIds.Contains(itemId))
             {
                 var item = _libraryManager.GetItemById(itemId);
 
@@ -378,7 +463,7 @@ public class GuideManager : IGuideManager
         }
     }
 
-    private async Task<LiveTvChannel> GetChannel(
+    private async Task<(LiveTvChannel Channel, bool NeedsRefresh)> GetChannel(
         ChannelInfo channelInfo,
         string serviceName,
         BaseItem parentFolder,
@@ -464,7 +549,9 @@ public class GuideManager : IGuideManager
             await _libraryManager.UpdateItemAsync(item, parentFolder, ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
         }
 
-        return item;
+        // A new or changed channel needs its metadata (icon included) refreshed; an unchanged one
+        // can skip that expensive step during the program pass below.
+        return (item, isNew || forceUpdate);
     }
 
     private (LiveTvProgram Item, bool IsNew, bool IsUpdated) GetProgram(
@@ -649,6 +736,21 @@ public class GuideManager : IGuideManager
         }
 
         return (item, false, false);
+    }
+
+    private static void RemoveTag(BaseItem item, string name)
+    {
+        var current = item.Tags;
+        if (current.Length == 0)
+        {
+            return;
+        }
+
+        var filtered = Array.FindAll(current, t => !string.Equals(t, name, StringComparison.OrdinalIgnoreCase));
+        if (filtered.Length != current.Length)
+        {
+            item.Tags = filtered;
+        }
     }
 
     private static bool UpdateImages(BaseItem item, ProgramInfo info)

--- a/src/Jellyfin.LiveTv/LiveTvChannelImageHelper.cs
+++ b/src/Jellyfin.LiveTv/LiveTvChannelImageHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 
@@ -9,8 +10,17 @@ namespace Jellyfin.LiveTv;
 internal static class LiveTvChannelImageHelper
 {
     /// <summary>
+    /// Provider id used to remember which source (URL or path) the current channel icon came from,
+    /// so an unchanged icon is not needlessly re-applied (and thus re-downloaded) on every refresh.
+    /// </summary>
+    internal const string ImageSourceKey = "GuideImageSource";
+
+    /// <summary>
     /// Applies the channel icon from guide or tuner metadata.
-    /// Called on each guide refresh so remote icons are re-downloaded even when the URL is unchanged.
+    /// The icon is only (re)applied when the source changed or the channel has no icon yet; an
+    /// unchanged icon is left in place so it is not re-downloaded on every guide refresh. This
+    /// matters a lot for large IPTV playlists where re-fetching tens of thousands of logos each
+    /// cycle dominates the refresh time.
     /// </summary>
     /// <param name="item">The channel item.</param>
     /// <param name="imagePath">The local image path from the tuner, if any.</param>
@@ -27,7 +37,16 @@ internal static class LiveTvChannelImageHelper
             return false;
         }
 
+        // Skip when the same source is already applied and an icon is present. The stored source is
+        // tracked separately from the image path because the path may be localized after download.
+        if (item.HasImage(ImageType.Primary)
+            && string.Equals(item.GetProviderId(ImageSourceKey), newImageSource, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
         item.SetImagePath(ImageType.Primary, newImageSource);
+        item.SetProviderId(ImageSourceKey, newImageSource);
         return true;
     }
 }

--- a/src/Jellyfin.LiveTv/LiveTvManager.cs
+++ b/src/Jellyfin.LiveTv/LiveTvManager.cs
@@ -134,6 +134,14 @@ namespace Jellyfin.LiveTv
                 DtoOptions = dtoOptions
             };
 
+            // Optionally hide channels that carry no guide data. The guide refresh tags channels
+            // that received programmes, so filtering on that tag keeps blank channels out of large
+            // IPTV playlists without an expensive per-channel program lookup here.
+            if (_config.GetLiveTvConfiguration().HideChannelsWithoutProgrammes)
+            {
+                internalQuery.Tags = [Guide.GuideManager.GuideDataTagName];
+            }
+
             var orderBy = internalQuery.OrderBy.ToList();
 
             orderBy.AddRange(query.SortBy.Select(i => (i, query.SortOrder ?? SortOrder.Ascending)));

--- a/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/M3uParser.cs
@@ -105,7 +105,7 @@ namespace Jellyfin.LiveTv.TunerHosts
 
                     channel.Path = trimmedLine;
                     channels.Add(channel);
-                    _logger.LogInformation("Parsed channel: {ChannelName}", channel.Name);
+                    _logger.LogDebug("Parsed channel: {ChannelName}", channel.Name);
                     extInf = string.Empty;
                 }
             }

--- a/tests/Jellyfin.LiveTv.Tests/LiveTvChannelImageHelperTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/LiveTvChannelImageHelperTests.cs
@@ -35,7 +35,7 @@ public class LiveTvChannelImageHelperTests
     }
 
     [Fact]
-    public void UpdateChannelImageIfNeeded_SameUrl_StillUpdates()
+    public void UpdateChannelImageIfNeeded_SameUrl_DoesNotUpdate()
     {
         var channel = new LiveTvChannel { Name = "Test Channel" };
         LiveTvChannelImageHelper.UpdateChannelImageIfNeeded(channel, null, "https://example.com/icon.png");
@@ -45,7 +45,22 @@ public class LiveTvChannelImageHelperTests
             null,
             "https://example.com/icon.png");
 
-        Assert.True(updated);
+        Assert.False(updated);
         Assert.Equal("https://example.com/icon.png", channel.GetImagePath(ImageType.Primary));
+    }
+
+    [Fact]
+    public void UpdateChannelImageIfNeeded_ChangedUrl_Updates()
+    {
+        var channel = new LiveTvChannel { Name = "Test Channel" };
+        LiveTvChannelImageHelper.UpdateChannelImageIfNeeded(channel, null, "https://example.com/icon.png");
+
+        var updated = LiveTvChannelImageHelper.UpdateChannelImageIfNeeded(
+            channel,
+            null,
+            "https://example.com/new-icon.png");
+
+        Assert.True(updated);
+        Assert.Equal("https://example.com/new-icon.png", channel.GetImagePath(ImageType.Primary));
     }
 }

--- a/tests/Jellyfin.LiveTv.Tests/LiveTvManagerChannelFilterTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/LiveTvManagerChannelFilterTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using System.Threading;
+using Jellyfin.Data.Enums;
+using Jellyfin.LiveTv.Guide;
+using Jellyfin.LiveTv.Timers;
+using MediaBrowser.Common;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Channels;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.LiveTv;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.LiveTv;
+using MediaBrowser.Model.Querying;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests
+{
+    public class LiveTvManagerChannelFilterTests
+    {
+        [Fact]
+        public void GetInternalChannels_HideChannelsWithoutProgrammes_AppliesGuideDataTagFilter()
+        {
+            InternalItemsQuery? captured = null;
+            var manager = CreateManager(
+                new LiveTvOptions { HideChannelsWithoutProgrammes = true },
+                q => captured = q);
+
+            manager.GetInternalChannels(new LiveTvChannelQuery(), new DtoOptions(), CancellationToken.None);
+
+            Assert.NotNull(captured);
+            Assert.NotNull(captured.Tags);
+            Assert.Contains(GuideManager.GuideDataTagName, captured.Tags);
+        }
+
+        [Fact]
+        public void GetInternalChannels_ShowAllChannels_DoesNotFilterOnGuideDataTag()
+        {
+            InternalItemsQuery? captured = null;
+            var manager = CreateManager(
+                new LiveTvOptions { HideChannelsWithoutProgrammes = false },
+                q => captured = q);
+
+            manager.GetInternalChannels(new LiveTvChannelQuery(), new DtoOptions(), CancellationToken.None);
+
+            Assert.NotNull(captured);
+            Assert.True(captured.Tags is null || captured.Tags.Length == 0);
+        }
+
+        private static LiveTvManager CreateManager(LiveTvOptions options, Action<InternalItemsQuery> onQuery)
+        {
+            var libraryManager = new Mock<ILibraryManager>();
+            libraryManager
+                .Setup(x => x.GetNamedView(It.IsAny<string>(), It.IsAny<CollectionType>(), It.IsAny<string>()))
+                .Returns(new UserView { Id = Guid.NewGuid() });
+            libraryManager
+                .Setup(x => x.GetItemsResult(It.IsAny<InternalItemsQuery>()))
+                .Callback<InternalItemsQuery>(q => onQuery(q))
+                .Returns(new QueryResult<BaseItem>());
+
+            var config = new Mock<IServerConfigurationManager>();
+            config.Setup(x => x.GetConfiguration("livetv")).Returns(options);
+
+            var localization = new Mock<ILocalizationManager>();
+            localization.Setup(x => x.GetLocalizedString(It.IsAny<string>())).Returns("Live TV");
+
+            return new LiveTvManager(
+                config.Object,
+                NullLogger<LiveTvManager>.Instance,
+                Mock.Of<IUserDataManager>(),
+                Mock.Of<IDtoService>(),
+                Mock.Of<IUserManager>(),
+                libraryManager.Object,
+                localization.Object,
+                Mock.Of<IChannelManager>(),
+                Mock.Of<IRecordingsManager>(),
+                CreateDtoService(),
+                new ILiveTvService[] { CreateDefaultService() });
+        }
+
+        private static LiveTvDtoService CreateDtoService()
+            => new LiveTvDtoService(
+                Mock.Of<IDtoService>(),
+                Mock.Of<IImageProcessor>(),
+                NullLogger<LiveTvDtoService>.Instance,
+                Mock.Of<IApplicationHost>(),
+                Mock.Of<ILibraryManager>());
+
+        private static DefaultLiveTvService CreateDefaultService()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "jf-livetv-test-" + Guid.NewGuid().ToString("N"));
+
+            var appPaths = new Mock<IApplicationPaths>();
+            appPaths.Setup(x => x.DataPath).Returns(tempDir);
+
+            var configManager = new Mock<IConfigurationManager>();
+            configManager.Setup(x => x.CommonApplicationPaths).Returns(appPaths.Object);
+
+            var timerManager = new TimerManager(NullLogger<TimerManager>.Instance, configManager.Object);
+            var seriesTimerManager = new SeriesTimerManager(NullLogger<SeriesTimerManager>.Instance, configManager.Object);
+
+            return new DefaultLiveTvService(
+                NullLogger<DefaultLiveTvService>.Instance,
+                Mock.Of<IServerConfigurationManager>(),
+                Mock.Of<ITunerHostManager>(),
+                Mock.Of<IListingsManager>(),
+                Mock.Of<IRecordingsManager>(),
+                Mock.Of<ILibraryManager>(),
+                CreateDtoService(),
+                timerManager,
+                seriesTimerManager);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

On a large IPTV/M3U playlist (tens of thousands of channels) a guide refresh could take **hours**. This PR removes several avoidable per-refresh costs so a large refresh completes in minutes, with no behavior change unless a user opts in.

## Changes

**Performance (no behavior change):**
- `CleanDatabase` used `currentIdList.Contains` on a `Guid[]` (O(n·m)); build a `HashSet<Guid>` once for O(1) membership, removing the quadratic tail.
- The per-channel existing-programmes DB query ran even for channels with no EPG; skip it when the provider returned no programmes (stale rows are still removed by `CleanDatabase`).
- Every channel was re-persisted and re-metadata-refreshed (re-downloading its logo) on every refresh; track whether a channel actually changed and only save/refresh when it did.
- Channel icons were re-applied (and thus re-downloaded) even when unchanged; remember the icon source in a provider id and skip re-applying an unchanged icon.
- Lower two per-channel `LogInformation` lines (`M3uParser`, `XmlTvListingsProvider`) to `LogDebug`; they emitted tens of thousands of lines per refresh.

**Opt-in options (default = current behavior):**
- `LiveTvOptions.PreCacheGuideImages` (default `true`). When disabled, channel-logo and programme-image downloads are skipped during refresh and load lazily on first display instead (`ImageController` already converts remote images to local on first request), so dead IPTV image links no longer stall the refresh on network timeouts.
- `LiveTvOptions.HideChannelsWithoutProgrammes` (default `false`). The refresh tags channels that received programmes (`"GuideData"`) and untags those that lost them; when enabled, `GetInternalChannels` filters on that tag so blank channels are excluded at the DB level (pagination/totals stay correct). One refresh is required after enabling before blank channels drop.

First-time import is unchanged (everything is "new"); steady-state refreshes now skip untouched channels entirely.

## Tests

Unit tests for the unchanged-icon skip (`LiveTvChannelImageHelperTests`) and the hide-blank-channels tag filter (`LiveTvManagerChannelFilterTests`).

## Notes

- Happy to split the opt-in `HideChannelsWithoutProgrammes` feature into its own PR if maintainers prefer to keep this purely a performance change.
- Server-side; benefits every client/OS.
