### PR TITLE
Improve Live TV DVR reliability: retry stream open, clean up failed captures

### DIFF
--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -51,6 +51,10 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     private readonly SeriesTimerManager _seriesTimerManager;
     private readonly RecordingsMetadataManager _recordingsMetadataManager;
 
+    private const int StreamOpenMaxAttempts = 3;
+    private static readonly TimeSpan StreamOpenInitialRetryDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan StreamOpenMaxRetryDelay = TimeSpan.FromSeconds(10);
+
     private readonly ConcurrentDictionary<string, ActiveRecordingInfo> _activeRecordings = new(StringComparer.OrdinalIgnoreCase);
     private readonly AsyncNonKeyedLocker _recordingDeleteSemaphore = new();
     private bool _disposed;
@@ -321,13 +325,21 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             IDirectStreamProvider? directStreamProvider = null;
             if (mediaStreamInfo.RequiresOpening)
             {
-                var liveStreamResponse = await _mediaSourceManager.OpenLiveStreamInternal(
-                    new LiveStreamRequest
-                    {
-                        ItemId = channel.Id,
-                        OpenToken = mediaStreamInfo.OpenToken
-                    },
-                    CancellationToken.None).ConfigureAwait(false);
+                // Retry the stream open with exponential backoff so a transient IPTV/tuner hiccup
+                // doesn't lose the whole recording before the recorder even starts.
+                var liveStreamResponse = await OpenWithRetryAsync(
+                    ct => _mediaSourceManager.OpenLiveStreamInternal(
+                        new LiveStreamRequest
+                        {
+                            ItemId = channel.Id,
+                            OpenToken = mediaStreamInfo.OpenToken
+                        },
+                        ct),
+                    StreamOpenMaxAttempts,
+                    StreamOpenInitialRetryDelay,
+                    StreamOpenMaxRetryDelay,
+                    _logger,
+                    recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
 
                 mediaStreamInfo = liveStreamResponse.Item1.MediaSource;
                 liveStreamId = mediaStreamInfo.LiveStreamId;
@@ -354,7 +366,6 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
                 timer.Status = RecordingStatus.InProgress;
                 _timerManager.AddOrUpdate(timer, false);
 
-                await _recordingsMetadataManager.SaveRecordingMetadata(timer, recordingPath, seriesPath).ConfigureAwait(false);
                 await CreateRecordingFolders().ConfigureAwait(false);
 
                 TriggerRefresh(recordingPath);
@@ -395,7 +406,9 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             }
         }
 
-        DeleteFileIfEmpty(recordingPath);
+        // Remove any empty/failed capture and its orphaned .nfo/folder so a recording that never
+        // produced video doesn't leave a metadata-only phantom item in the library.
+        DeleteOrphanedRecordingArtifacts(recordingPath, _logger);
         TriggerRefresh(recordingPath);
         _libraryMonitor.ReportFileSystemChangeComplete(recordingPath, false);
         _activeRecordings.TryRemove(timer.Id, out _);
@@ -411,11 +424,15 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             timer.RetryCount++;
             _timerManager.AddOrUpdate(timer);
         }
-        else if (File.Exists(recordingPath))
+        else if (HasUsableRecording(recordingPath))
         {
             timer.RecordingPath = recordingPath;
             timer.Status = RecordingStatus.Completed;
             _timerManager.AddOrUpdate(timer, false);
+
+            // Write the .nfo sidecar only now that a usable (non-empty) recording exists, so a
+            // failed/empty capture never leaves an orphaned metadata file behind.
+            await _recordingsMetadataManager.SaveRecordingMetadata(timer, recordingPath, seriesPath).ConfigureAwait(false);
             await PostProcessRecording(recordingPath).ConfigureAwait(false);
         }
         else
@@ -584,20 +601,127 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         return Path.Combine(recordingPath, recordingFileName);
     }
 
-    private void DeleteFileIfEmpty(string path)
+    /// <summary>
+    /// Removes a failed/empty recording capture and any artifacts it left behind (an empty video
+    /// file, an orphaned <c>.nfo</c> sidecar and the now-empty recording folder).
+    /// </summary>
+    /// <param name="recordingPath">The recording output path.</param>
+    /// <param name="logger">The logger.</param>
+    /// <returns><c>true</c> if the recording produced no usable video and artifacts were cleaned up; otherwise <c>false</c>.</returns>
+    internal static bool DeleteOrphanedRecordingArtifacts(string recordingPath, ILogger logger)
     {
-        var file = _fileSystem.GetFileInfo(path);
-
-        if (file.Exists && file.Length == 0)
+        if (HasUsableRecording(recordingPath))
         {
+            return false;
+        }
+
+        TryDeleteFile(recordingPath, logger);
+        TryDeleteFile(Path.ChangeExtension(recordingPath, ".nfo"), logger);
+
+        // A failed capture still created the series/movie subfolder for the output file. Remove it
+        // when empty so a recording that produced no video doesn't leave a phantom folder behind.
+        TryDeleteEmptyDirectory(Path.GetDirectoryName(recordingPath), logger);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether a recording output file exists and contains data. Used to gate metadata
+    /// writing and orphan cleanup so a failed/empty capture never persists a <c>.nfo</c> sidecar.
+    /// </summary>
+    /// <param name="recordingPath">The recording output path.</param>
+    /// <returns><c>true</c> if the file exists and is non-empty; otherwise <c>false</c>.</returns>
+    internal static bool HasUsableRecording(string recordingPath)
+        => File.Exists(recordingPath) && new FileInfo(recordingPath).Length > 0;
+
+    /// <summary>
+    /// Attempts an asynchronous open operation, retrying transient failures with exponential
+    /// backoff. Retries every exception except <see cref="OperationCanceledException"/> (which is
+    /// propagated immediately). The exception from the final attempt is re-thrown to the caller.
+    /// </summary>
+    /// <typeparam name="T">The result type of the open operation.</typeparam>
+    /// <param name="openAsync">The open operation to attempt.</param>
+    /// <param name="maxAttempts">The maximum number of attempts (must be at least 1).</param>
+    /// <param name="initialDelay">The delay before the first retry.</param>
+    /// <param name="maxDelay">The upper bound for the backoff delay.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result of the first successful attempt.</returns>
+    internal static async Task<T> OpenWithRetryAsync<T>(
+        Func<CancellationToken, Task<T>> openAsync,
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(openAsync);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxAttempts, 1);
+
+        var attempt = 0;
+        var delay = initialDelay;
+        while (true)
+        {
+            attempt++;
             try
             {
-                _fileSystem.DeleteFile(path);
+                return await openAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException && attempt < maxAttempts)
             {
-                _logger.LogError(ex, "Error deleting 0-byte failed recording file {Path}", path);
+                logger.LogWarning(
+                    ex,
+                    "Stream open attempt {Attempt}/{MaxAttempts} failed; retrying in {DelaySeconds}s",
+                    attempt,
+                    maxAttempts,
+                    delay.TotalSeconds);
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+                var nextDelayMs = Math.Min(delay.TotalMilliseconds * 2, maxDelay.TotalMilliseconds);
+                delay = TimeSpan.FromMilliseconds(nextDelayMs);
             }
+        }
+    }
+
+    /// <summary>
+    /// Deletes the given directory only when it exists and contains no entries. Used to remove the
+    /// leftover recording folder after a failed (empty) capture has been cleaned up.
+    /// </summary>
+    /// <param name="path">The directory to remove if empty.</param>
+    /// <param name="logger">The logger.</param>
+    private static void TryDeleteEmptyDirectory(string? path, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(path) && Directory.GetFileSystemEntries(path).Length == 0)
+            {
+                Directory.Delete(path, false);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error deleting empty recording folder {Path}", path);
+        }
+    }
+
+    private static void TryDeleteFile(string path, ILogger logger)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting orphaned recording artifact {Path}", path);
         }
     }
 

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerOrphanCleanupTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerOrphanCleanupTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using Jellyfin.LiveTv.Recordings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings
+{
+    public sealed class RecordingsManagerOrphanCleanupTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public RecordingsManagerOrphanCleanupTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "jf-rec-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_RemovesVideoAndNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(recordingPath));
+            Assert.False(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_MissingVideo_RemovesOrphanedNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_NonEmptyVideo_KeepsVideoAndNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.False(cleaned);
+            Assert.True(File.Exists(recordingPath));
+            Assert.True(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_RemovesEmptyRecordingFolder()
+        {
+            var folder = Path.Combine(_dir, "Scooby-Doo and Scrappy-Doo");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "episode.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(Directory.Exists(folder));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_NonEmptyVideo_KeepsRecordingFolder()
+        {
+            var folder = Path.Combine(_dir, "Some Show");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "episode.ts");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.False(cleaned);
+            Assert.True(Directory.Exists(folder));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_KeepsFolderWithOtherRecordings()
+        {
+            var folder = Path.Combine(_dir, "Series With Episodes");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "failed.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+            var goodEpisode = Path.Combine(folder, "good.ts");
+            File.WriteAllBytes(goodEpisode, new byte[] { 1, 2, 3, 4 });
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(recordingPath));
+            Assert.True(Directory.Exists(folder));
+            Assert.True(File.Exists(goodEpisode));
+        }
+
+        [Fact]
+        public void HasUsableRecording_NonEmptyFile_ReturnsTrue()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+
+            Assert.True(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        [Fact]
+        public void HasUsableRecording_EmptyFile_ReturnsFalse()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+
+            Assert.False(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        [Fact]
+        public void HasUsableRecording_MissingFile_ReturnsFalse()
+        {
+            var recordingPath = Path.Combine(_dir, "does-not-exist.ts");
+
+            Assert.False(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_dir, true);
+            }
+            catch (IOException)
+            {
+                // best effort cleanup
+            }
+        }
+    }
+}

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerRetryTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerRetryTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.LiveTv.Recordings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings
+{
+    public class RecordingsManagerRetryTests
+    {
+        private static readonly TimeSpan _fastDelay = TimeSpan.FromMilliseconds(1);
+
+        [Fact]
+        public async Task OpenWithRetryAsync_SucceedsFirstTry_CallsOnce()
+        {
+            var calls = 0;
+
+            var result = await RecordingsManager.OpenWithRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    return Task.FromResult(42);
+                },
+                maxAttempts: 3,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(42, result);
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_FailsThenSucceeds_RetriesUntilSuccess()
+        {
+            var calls = 0;
+
+            var result = await RecordingsManager.OpenWithRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    if (calls < 3)
+                    {
+                        throw new InvalidOperationException("transient open failure");
+                    }
+
+                    return Task.FromResult("ok");
+                },
+                maxAttempts: 3,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal("ok", result);
+            Assert.Equal(3, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_AlwaysFails_ThrowsAfterMaxAttempts()
+        {
+            var calls = 0;
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                RecordingsManager.OpenWithRetryAsync<int>(
+                    _ =>
+                    {
+                        calls++;
+                        throw new InvalidOperationException("always fails");
+                    },
+                    maxAttempts: 4,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    CancellationToken.None));
+
+            Assert.Equal("always fails", ex.Message);
+            Assert.Equal(4, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_Cancelled_DoesNotRetry()
+        {
+            var calls = 0;
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                RecordingsManager.OpenWithRetryAsync<int>(
+                    _ =>
+                    {
+                        calls++;
+                        throw new OperationCanceledException();
+                    },
+                    maxAttempts: 5,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    cts.Token));
+
+            Assert.Equal(1, calls);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two related DVR robustness fixes for flaky IPTV/M3U sources.

### Retry the stream open (D1)

`RecordStream` opened the live stream once, so a single transient hiccup lost the whole recording before the recorder even started. Wrap the open in `OpenWithRetryAsync` (3 attempts, exponential backoff 2s→10s):

```csharp
var liveStreamResponse = await OpenWithRetryAsync(
    ct => _mediaSourceManager.OpenLiveStreamInternal(
        new LiveStreamRequest { ItemId = channel.Id, OpenToken = mediaStreamInfo.OpenToken }, ct),
    StreamOpenMaxAttempts, StreamOpenInitialRetryDelay, StreamOpenMaxRetryDelay,
    _logger, recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
```

It retries every exception except `OperationCanceledException` (propagated immediately) and re-throws the final failure. The existing coarse 60s whole-recording retry still applies if all in-line attempts fail.

### Don't leave orphaned artifacts behind (D2)

The `.nfo` metadata sidecar was written from the recorder's `onStarted()` callback — i.e. **before any video bytes were confirmed** — so a capture that never delivered data left a metadata-only phantom item in the library (the recurring "I get a `.nfo` instead of the show" complaint). Now:

- the sidecar is written in finalize and **only when a usable (non-empty) recording exists**;
- the old 0-byte cleanup is replaced by `DeleteOrphanedRecordingArtifacts`, which removes the empty video, the orphaned `.nfo`, and the now-empty recording folder.

```csharp
internal static bool HasUsableRecording(string recordingPath)
    => File.Exists(recordingPath) && new FileInfo(recordingPath).Length > 0;

internal static bool DeleteOrphanedRecordingArtifacts(string recordingPath, ILogger logger)
{
    if (HasUsableRecording(recordingPath)) { return false; }
    TryDeleteFile(recordingPath, logger);
    TryDeleteFile(Path.ChangeExtension(recordingPath, ".nfo"), logger);
    TryDeleteEmptyDirectory(Path.GetDirectoryName(recordingPath), logger);
    return true;
}
```

Net effect: a failed capture leaves nothing behind, and the sidecar is only ever written for a real recording.

## Tests

- `OpenWithRetryAsync`: success-first-try, fail-then-succeed, exhausted-attempts, cancellation.
- Orphan cleanup / `HasUsableRecording`: empty/missing video is removed with its `.nfo`; a real recording keeps both.

## Notes

- Server-side; benefits every client/OS.
- A follow-up mid-recording reconnect/resume (so a dropped stream reconnects and finishes as one file) builds on this and will be a separate PR.
