### PR TITLE
Route all FFmpeg execution through a single supervised runner

### DIFF
--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -71,6 +71,8 @@ using MediaBrowser.Controller.LibraryTaskScheduler;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Lyrics;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.Controller.MediaSegments;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Persistence;
@@ -415,7 +417,7 @@ namespace Emby.Server.Implementations
         /// Runs the startup tasks.
         /// </summary>
         /// <returns><see cref="Task" />.</returns>
-        public Task RunStartupTasksAsync()
+        public async Task RunStartupTasksAsync()
         {
             Logger.LogInformation("Running startup tasks");
 
@@ -426,7 +428,7 @@ namespace Emby.Server.Implementations
             ConfigurationManager.ConfigurationUpdated += OnConfigurationUpdated;
             ConfigurationManager.NamedConfigurationUpdated += OnConfigurationUpdated;
 
-            var ffmpegValid = Resolve<IMediaEncoder>().SetFFmpegPath();
+            var ffmpegValid = await Resolve<IMediaEncoder>().SetFFmpegPathAsync().ConfigureAwait(false);
 
             if (!ffmpegValid)
             {
@@ -436,8 +438,6 @@ namespace Emby.Server.Implementations
             Logger.LogInformation("ServerId: {ServerId}", SystemId);
             Logger.LogInformation("Core startup complete");
             CoreStartupHasCompleted = true;
-
-            return Task.CompletedTask;
         }
 
         private void EnsureStartupWizardIntegrity()
@@ -564,7 +564,9 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<IKeyframeRepository, KeyframeRepository>();
             serviceCollection.AddSingleton<IItemTypeLookup, ItemTypeLookup>();
 
+            serviceCollection.AddSingleton<IFFPaths, MediaBrowser.MediaEncoding.FFProcessing.FFPaths>();
             serviceCollection.AddSingleton<IMediaEncoder, MediaBrowser.MediaEncoding.Encoder.MediaEncoder>();
+            serviceCollection.AddSingleton<IFFRunner, MediaBrowser.MediaEncoding.FFProcessing.FFRunner>();
             serviceCollection.AddSingleton<EncodingHelper>();
             serviceCollection.AddSingleton<IPathManager, PathManager>();
             serviceCollection.AddSingleton<IExternalDataManager, ExternalDataManager>();

--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/AudioNormalizationTask.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +13,8 @@ using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Tasks;
@@ -29,7 +29,7 @@ public partial class AudioNormalizationTask : IScheduledTask
 {
     private readonly IItemPersistenceService _persistenceService;
     private readonly ILibraryManager _libraryManager;
-    private readonly IMediaEncoder _mediaEncoder;
+    private readonly IFFRunner _ffRunner;
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILocalizationManager _localization;
     private readonly ILogger<AudioNormalizationTask> _logger;
@@ -41,24 +41,24 @@ public partial class AudioNormalizationTask : IScheduledTask
     /// </summary>
     /// <param name="persistenceService">Instance of the <see cref="IItemPersistenceService"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
-    /// <param name="mediaEncoder">Instance of the <see cref="IMediaEncoder"/> interface.</param>
     /// <param name="applicationPaths">Instance of the <see cref="IApplicationPaths"/> interface.</param>
     /// <param name="localizationManager">Instance of the <see cref="ILocalizationManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{AudioNormalizationTask}"/> interface.</param>
+    /// <param name="ffRunner">Instance of the <see cref="IFFRunner"/> interface.</param>
     public AudioNormalizationTask(
         IItemPersistenceService persistenceService,
         ILibraryManager libraryManager,
-        IMediaEncoder mediaEncoder,
         IApplicationPaths applicationPaths,
         ILocalizationManager localizationManager,
-        ILogger<AudioNormalizationTask> logger)
+        ILogger<AudioNormalizationTask> logger,
+        IFFRunner ffRunner)
     {
         _persistenceService = persistenceService;
         _libraryManager = libraryManager;
-        _mediaEncoder = mediaEncoder;
         _applicationPaths = applicationPaths;
         _localization = localizationManager;
         _logger = logger;
+        _ffRunner = ffRunner;
     }
 
     /// <inheritdoc />
@@ -116,8 +116,7 @@ public partial class AudioNormalizationTask : IScheduledTask
                         try
                         {
                             a.LUFS = await CalculateLUFSAsync(
-                                string.Format(CultureInfo.InvariantCulture, "-f concat -safe 0 -i \"{0}\"", tempFile),
-                                OperatingSystem.IsWindows(), // Wait for process to exit on Windows before we try deleting the concat file
+                                new LoudnessRequest { Path = tempFile, IsConcatPlaylist = true },
                                 cancellationToken).ConfigureAwait(false);
                             toSaveDbItems.Add(a);
                         }
@@ -174,8 +173,7 @@ public partial class AudioNormalizationTask : IScheduledTask
                 if (!t.NormalizationGain.HasValue && !t.LUFS.HasValue && t.IsFileProtocol)
                 {
                     t.LUFS = await CalculateLUFSAsync(
-                        string.Format(CultureInfo.InvariantCulture, "-i \"{0}\"", t.Path.Replace("\"", "\\\"", StringComparison.Ordinal)),
-                        false,
+                        new LoudnessRequest { Path = t.Path.Replace("\"", "\\\"", StringComparison.Ordinal) },
                         cancellationToken).ConfigureAwait(false);
                     toSaveDbItems.Add(t);
                 }
@@ -225,72 +223,24 @@ public partial class AudioNormalizationTask : IScheduledTask
         };
     }
 
-    private async Task<float?> CalculateLUFSAsync(string inputArgs, bool waitForExit, CancellationToken cancellationToken)
+    private async Task<float?> CalculateLUFSAsync(LoudnessRequest request, CancellationToken cancellationToken)
     {
-        var args = $"-hide_banner {inputArgs} -af ebur128=framelog=verbose -f null -";
+        // ebur128 reports the summary on stderr at the end of the run, so it survives the runner's
+        // bounded tail however long the input is.
+        var result = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
 
-        using (var process = new Process()
+        if (!result.Succeeded)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = _mediaEncoder.EncoderPath,
-                Arguments = args,
-                StandardErrorEncoding = Encoding.UTF8,
-                RedirectStandardError = true
-            },
-        })
-        {
-            _logger.LogDebug("Starting ffmpeg with arguments: {Arguments}", args);
-            try
-            {
-                process.Start();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error starting ffmpeg with arguments: {Arguments}", args);
-                return null;
-            }
-
-            try
-            {
-                process.PriorityClass = ProcessPriorityClass.BelowNormal;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error setting ffmpeg process priority");
-            }
-
-            using var reader = process.StandardError;
-            float? lufs = null;
-            var foundLufs = false;
-            await foreach (var line in reader.ReadAllLinesAsync(cancellationToken).ConfigureAwait(false))
-            {
-                if (foundLufs)
-                {
-                    continue;
-                }
-
-                Match match = LUFSRegex().Match(line);
-                if (!match.Success)
-                {
-                    continue;
-                }
-
-                lufs = float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
-                foundLufs = true;
-            }
-
-            if (lufs is null)
-            {
-                _logger.LogError("Failed to find LUFS value in output");
-            }
-
-            if (waitForExit)
-            {
-                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            return lufs;
+            return null;
         }
+
+        var match = LUFSRegex().Match(result.Stderr);
+        if (!match.Success)
+        {
+            _logger.LogError("Failed to find LUFS value for {Path}", request.Path);
+            return null;
+        }
+
+        return float.Parse(match.Groups[1].ValueSpan, CultureInfo.InvariantCulture.NumberFormat);
     }
 }

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1420,7 +1420,7 @@ public class DynamicHlsController : BaseJellyfinApiController
             "hls1/main/",
             Request.QueryString.ToString(),
             EncodingHelper.IsCopyCodec(state.OutputVideoCodec));
-        var playlist = _dynamicHlsPlaylistGenerator.CreateMainPlaylist(request);
+        var playlist = await _dynamicHlsPlaylistGenerator.CreateMainPlaylistAsync(request, cancellationTokenSource.Token).ConfigureAwait(false);
 
         return new FileContentResult(Encoding.UTF8.GetBytes(playlist), MimeTypes.GetMimeType("playlist.m3u8"));
     }
@@ -1633,9 +1633,34 @@ public class DynamicHlsController : BaseJellyfinApiController
                 Path.GetFileNameWithoutExtension(outputPath));
         }
 
+        // Assembled in FFmpeg's required order: input options, the input, then everything describing
+        // the output. Reading the placeholders left to right —
+        //
+        //   {0} {1}            input options and the input itself, which must precede everything else
+        //   -map_metadata -1   drop the source's container metadata and chapters rather than copying
+        //   -map_chapters -1     them into every segment; the client has them from the API already
+        //   -threads {2}       encoder thread count
+        //   {3} {4} {5}        stream selection, then the video and audio encoding decisions
+        //   -copyts            keep the source's timestamps instead of rebasing them to zero, and
+        //   -avoid_negative_ts   suppress the shift FFmpeg would otherwise apply to avoid negatives
+        //     disabled
+        //   -max_muxing_queue_size {6}
+        //   -f hls             the HLS muxer; everything below configures it
+        //   -max_delay 5000000 500ms of muxer reordering slack, in microseconds
+        //   -hls_time {7}      target segment duration
+        //   -hls_segment_type {8}          mpegts or fmp4, plus the fmp4 header filename
+        //   -start_number {9}  the segment index this process begins at
+        //   {10}               -hls_base_url, event playlists only
+        //   -hls_segment_filename "{11}"   the numbered segment pattern
+        //   {12}               playlist type, list size, and the fmp4 discontinuity flag
+        //   "{13}"             the .m3u8 playlist, which is what the runner waits to appear
+        //
+        // Seeking restarts FFmpeg at an arbitrary -start_number rather than from the beginning, so a
+        // restarted process has to land segment N on the same point in the source timeline the
+        // original would have.
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
+            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} \"{13}\"",
             inputModifier,
             _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer),
             threads,

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7663,9 +7663,23 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var inputModifier = GetInputModifier(state, encodingOptions, null);
 
+            // One continuous file rather than segments, so there is no muxer configuration block —
+            // the shape is input, mapping, encoding decisions, output. Left to right:
+            //
+            //   {0} {1}            input options and the input, which must precede everything else
+            //   {2}                keyframe placement, only when the container needs it
+            //   {3}                stream selection
+            //   {4}                video encoding decisions
+            //   -map_metadata -1   drop the source's container metadata and chapters; the client has
+            //   -map_chapters -1     them from the API already
+            //   -threads {5}       encoder thread count
+            //   {6}                audio encoding decisions
+            //   {7}                burned-in or embedded subtitles
+            //   {8}                the fragmented-mp4 muxer flags set above, when the output is mp4
+            //   "{9}"              the output file, which is what the runner waits to appear
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0} {1}{2} {3} {4} -map_metadata -1 -map_chapters -1 -threads {5} {6}{7}{8} -y \"{9}\"",
+                "{0} {1}{2} {3} {4} -map_metadata -1 -map_chapters -1 -threads {5} {6}{7}{8} \"{9}\"",
                 inputModifier,
                 GetInputArgument(state, encodingOptions, null),
                 keyFrame,
@@ -7907,18 +7921,23 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var inputModifier = GetInputModifier(state, encodingOptions, null);
 
+            // Audio only, so there is no mapping or video block at all. Left to right as it renders:
+            //
+            //   {0} {1}            input options and the input, which must precede everything else
+            //   -threads {2}       decoder thread count
+            //   -vn                drop any video stream the source carries
+            //   {3}                the audio encoding decisions built above
+            //   -id3v2_version 3   write ID3v2.3 rather than the 2.4 FFmpeg defaults to, and add an
+            //   -write_id3v1 1     ID3v1 tag as well, for players that read neither of the others
+            //   "{4}"              the output file, which is what the runner waits to appear
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0} {1}{7}{8} -threads {2}{3} {4} -id3v2_version 3 -write_id3v1 1{6} -y \"{5}\"",
+                "{0} {1} -threads {2} -vn {3} -id3v2_version 3 -write_id3v1 1 \"{4}\"",
                 inputModifier,
                 GetInputArgument(state, encodingOptions, null),
                 threads,
-                " -vn",
                 string.Join(' ', audioTranscodeParams),
-                outputPath,
-                string.Empty,
-                string.Empty,
-                string.Empty).Trim();
+                outputPath).Trim();
         }
 
         public static int FindIndex(IReadOnlyList<MediaStream> mediaStreams, MediaStream streamToFind)

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFAction.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFAction.cs
@@ -1,0 +1,54 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// The operations this server performs with FFmpeg. The action determines which binary runs, the
+/// clobber policy, the stdin disposition, the deadlines and the priority.
+/// </summary>
+public enum FFAction
+{
+    /// <summary>Container and stream metadata, as JSON.</summary>
+    Probe,
+
+    /// <summary>Keyframe packet timings, as CSV.</summary>
+    ScanKeyframes,
+
+    /// <summary>
+    /// Version check of a candidate binary, run before that path is accepted. Uniquely, it names
+    /// the executable to launch rather than using the resolved one, because deciding whether a
+    /// path is usable is precisely what it exists to do.
+    /// </summary>
+    ValidateBinary,
+
+    /// <summary>Interrogation of the binary's own feature support.</summary>
+    Capabilities,
+
+    /// <summary>
+    /// Test of whether the encoder responds to runtime keys. Steerable by definition: it cannot
+    /// run with <c>-nostdin</c>, which would disable what it is testing.
+    /// </summary>
+    ProbeRuntimeKeys,
+
+    /// <summary>EBU R128 loudness measurement, reported on stderr.</summary>
+    MeasureLoudness,
+
+    /// <summary>Embedded attachments dumped to disk.</summary>
+    ExtractAttachment,
+
+    /// <summary>An embedded subtitle track written to a sidecar file.</summary>
+    ExtractSubtitle,
+
+    /// <summary>A single decoded frame written as a still image.</summary>
+    ExtractImage,
+
+    /// <summary>Frames decoded at a fixed interval for trickplay tiles.</summary>
+    GenerateTrickplay,
+
+    /// <summary>A live stream recorded to a file.</summary>
+    Record,
+
+    /// <summary>
+    /// Media delivered to a client, for as long as that client keeps watching. Steerable, since
+    /// the throttler pauses and resumes it and playback ending has to stop it.
+    /// </summary>
+    Stream
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFActionPolicy.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFActionPolicy.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Diagnostics;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// The process policy an <see cref="FFAction"/> carries.
+/// </summary>
+/// <param name="ProbeOnly">Whether the action runs ffprobe rather than ffmpeg.</param>
+/// <param name="Overwrite">
+/// Whether existing output may be replaced. Always emitted, because with neither <c>-y</c> nor
+/// <c>-n</c> and non-interactive stdin FFmpeg fatals with "File ... already exists. Exiting".
+/// ffprobe registers neither option.
+/// </param>
+/// <param name="Stdin">Whether the process is steerable through runtime keys.</param>
+/// <param name="Timeout">The wall-clock deadline when the request does not supply one.</param>
+/// <param name="IdleTimeout">
+/// How long the process may report no progress before it is killed. Only applies when the request
+/// supplies a progress signal; CPU time is not used as one, since work blocked on a slow network
+/// read accrues none.
+/// </param>
+/// <param name="GracefulStopTimeout">
+/// How long a steerable process is given to exit after being sent <c>q</c>, before it is killed.
+/// </param>
+/// <param name="Priority">The scheduling priority when the request does not supply one.</param>
+/// <param name="RequiresProgressStats">
+/// Whether the action needs FFmpeg's periodic status line. That line is suppressed below
+/// <c>info</c> unless <c>-stats</c> is asked for explicitly, so an action parsing it for progress
+/// gets nothing at the level a default logger derives.
+/// </param>
+/// <param name="StderrIsPayload">
+/// Whether the action reads its own standard error as the answer rather than as a diagnostic. Such
+/// an action needs a log level high enough for the answer to be emitted at all, and needs the whole
+/// of it retained rather than a trailing window.
+/// </param>
+public readonly record struct FFActionPolicy(
+    bool ProbeOnly,
+    bool Overwrite,
+    FFStdinMode Stdin,
+    TimeSpan Timeout,
+    TimeSpan IdleTimeout,
+    TimeSpan GracefulStopTimeout,
+    ProcessPriorityClass Priority,
+    bool RequiresProgressStats,
+    bool StderrIsPayload)
+{
+    /// <summary>
+    /// Fallback when <c>ServerConfiguration.ImageExtractionTimeoutMs</c> is unset. Matches
+    /// <c>MediaEncoder.DefaultHdrImageExtractionTimeout</c>; SDR callers pass the shorter 10s.
+    /// </summary>
+    public static readonly TimeSpan DefaultImageExtraction = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// Fallback when <c>EncodingOptions.SubtitleExtractionTimeoutMinutes</c> is unset, matching
+    /// that setting's own default.
+    /// </summary>
+    public static readonly TimeSpan DefaultSubtitleExtraction = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// Grace after <c>q</c>, matching the wait in <c>EncodedRecorder.Stop</c>.
+    /// </summary>
+    public static readonly TimeSpan RecordingStopGrace = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Grace after <c>q</c> for a delivery stream, matching the wait in <c>TranscodingJob.Stop</c>.
+    /// Shorter than a recording's: nobody is watching any more, and the segments already written
+    /// stay valid.
+    /// </summary>
+    public static readonly TimeSpan StreamStopGrace = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Deadline for reading metadata out of a container. Generous because the read may cross a
+    /// slow network mount, and it is the only bound these actions have.
+    /// </summary>
+    public static readonly TimeSpan MetadataRead = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// Deadline for reading an entire file through. The work is I/O bound, so the real cost is size
+    /// divided by link speed: a 90 GB remux is a quarter of an hour on gigabit but over two hours on
+    /// a slow share. Loose enough that only a hung or badly degraded process reaches it.
+    /// </summary>
+    public static readonly TimeSpan FullFileScan = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// Deadline for decoding an entire audio stream, which runs many times faster than realtime
+    /// even across a whole album.
+    /// </summary>
+    public static readonly TimeSpan FullAudioScan = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Deadline for a startup interrogation. The work is trivial, so slow here means something is wrong.
+    /// </summary>
+    public static readonly TimeSpan StartupInterrogation = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// What almost every action wants: run FFmpeg, replace whatever output is already there, never
+    /// speak to it once started, bound it by the wall clock alone, and run it below the priority of
+    /// whatever the user is actually watching.
+    /// </summary>
+    private static readonly FFActionPolicy Background = new(
+        ProbeOnly: false,
+        Overwrite: true,
+        Stdin: FFStdinMode.FireAndForget,
+        Timeout: MetadataRead,
+        IdleTimeout: FFDefaults.Unbounded,
+        GracefulStopTimeout: TimeSpan.Zero,
+        Priority: ProcessPriorityClass.BelowNormal,
+        RequiresProgressStats: false,
+        StderrIsPayload: false);
+
+    /// <summary>
+    /// Gets the policy for an action. Each arm states only what makes that action unusual; the rest
+    /// comes from <see cref="Background"/>.
+    /// <para>
+    /// Two rules run across the whole table. The idle watchdog is only armed where the request
+    /// supplies a real progress signal, so every action but one is bounded by the wall clock alone.
+    /// And <c>StderrIsPayload</c> means the action reads its own standard error as the answer, which
+    /// both floors the log level and retains all of it rather than a trailing window.
+    /// </para>
+    /// <para>
+    /// <c>FFActionPolicyTests</c> pins the distinctive values per action, so an arm that silently
+    /// loses one fails the build rather than shipping.
+    /// </para>
+    /// </summary>
+    /// <param name="action">The action.</param>
+    /// <returns>Its policy.</returns>
+    public static FFActionPolicy For(FFAction action) => action switch
+    {
+        FFAction.Probe => Background with
+        {
+            ProbeOnly = true,
+            Overwrite = false
+        },
+
+        FFAction.ScanKeyframes => Background with
+        {
+            ProbeOnly = true,
+            Overwrite = false,
+            Timeout = FullFileScan
+        },
+
+        // Runs an executable the administrator nominated, which has not been shown to behave, so it
+        // is the interrogation most likely to hang. Bounding it is the whole point.
+        FFAction.ValidateBinary => Background with
+        {
+            Overwrite = false,
+            Timeout = StartupInterrogation,
+            Priority = FFDefaults.InheritPriority
+        },
+
+        // The device probes answer by scraping their own stderr. Those needing more than info ask
+        // for it in their own arguments, which land after the level the payload floor sets.
+        FFAction.Capabilities => Background with
+        {
+            Overwrite = false,
+            Timeout = StartupInterrogation,
+            Priority = FFDefaults.InheritPriority,
+            StderrIsPayload = true
+        },
+
+        // Steerable because the probe writes a key to stdin and reads the reply off stderr; a
+        // process told not to read stdin cannot answer the question being asked of it.
+        FFAction.ProbeRuntimeKeys => Background with
+        {
+            Overwrite = false,
+            Stdin = FFStdinMode.ControlChannel,
+            Timeout = StartupInterrogation,
+            Priority = FFDefaults.InheritPriority,
+            StderrIsPayload = true
+        },
+
+        // ebur128 writes its loudness summary to stderr at info, so the result vanishes entirely
+        // under a quieter level.
+        FFAction.MeasureLoudness => Background with
+        {
+            Overwrite = false,
+            Timeout = FullAudioScan,
+            StderrIsPayload = true
+        },
+
+        FFAction.ExtractAttachment => Background,
+
+        FFAction.ExtractSubtitle => Background with
+        {
+            Timeout = DefaultSubtitleExtraction
+        },
+
+        FFAction.ExtractImage => Background with
+        {
+            Timeout = DefaultImageExtraction
+        },
+
+        // Runs as long as the media is long, so no wall clock can bound it. The one action with a
+        // progress signal — each new tile — so the idle watchdog does the bounding instead.
+        FFAction.GenerateTrickplay => Background with
+        {
+            Timeout = FFDefaults.Unbounded,
+            IdleTimeout = DefaultImageExtraction
+        },
+
+        // Bounded by the recording's own duration rather than a deadline, and stopped by asking
+        // rather than killing, so the container is finalised and the file stays playable.
+        FFAction.Record => Background with
+        {
+            Stdin = FFStdinMode.ControlChannel,
+            Timeout = FFDefaults.Unbounded,
+            GracefulStopTimeout = RecordingStopGrace,
+            Priority = ProcessPriorityClass.Normal
+        },
+
+        // Lives as long as the viewer watches. Stopped by asking, so an HLS segment in flight is
+        // finished rather than truncated. Normal priority because someone is waiting on it, and
+        // -stats because JobLogSink parses that line for progress and throttling.
+        // Overwrite is stated rather than inherited, and StreamRequest pins it on regardless of what
+        // is written here. Delivery routinely writes over what an abandoned session left behind, and
+        // FFmpeg refusing to overwrite still exits 0, so turning this off would silently disable
+        // playback. See the remarks on StreamRequest.
+        FFAction.Stream => Background with
+        {
+            Overwrite = true,
+            Stdin = FFStdinMode.ControlChannel,
+            Timeout = FFDefaults.Unbounded,
+            GracefulStopTimeout = StreamStopGrace,
+            Priority = ProcessPriorityClass.Normal,
+            RequiresProgressStats = true
+        },
+
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, "No policy defined.")
+    };
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFActionPolicy.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFActionPolicy.cs
@@ -12,7 +12,10 @@ namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
 /// <c>-n</c> and non-interactive stdin FFmpeg fatals with "File ... already exists. Exiting".
 /// ffprobe registers neither option.
 /// </param>
-/// <param name="Stdin">Whether the process is steerable through runtime keys.</param>
+/// <param name="Stdin">
+/// What becomes of the process's standard input, which decides both whether <c>-nostdin</c> is
+/// emitted and whether the process can be asked to quit rather than killed.
+/// </param>
 /// <param name="Timeout">The wall-clock deadline when the request does not supply one.</param>
 /// <param name="IdleTimeout">
 /// How long the process may report no progress before it is killed. Only applies when the request
@@ -21,6 +24,8 @@ namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
 /// </param>
 /// <param name="GracefulStopTimeout">
 /// How long a steerable process is given to exit after being sent <c>q</c>, before it is killed.
+/// Zero for everything that is not a <see cref="FFStdinMode.ControlChannel"/>, which is killed
+/// outright because there is nowhere to send the key.
 /// </param>
 /// <param name="Priority">The scheduling priority when the request does not supply one.</param>
 /// <param name="RequiresProgressStats">
@@ -158,12 +163,13 @@ public readonly record struct FFActionPolicy(
             StderrIsPayload = true
         },
 
-        // Steerable because the probe writes a key to stdin and reads the reply off stderr; a
-        // process told not to read stdin cannot answer the question being asked of it.
+        // Writes a key to stdin and reads the reply off stderr so it must not be run with -nostdin.
+        // It closes stdin once the key is written, so unlike a genuine control channel there
+        // is no way to ask it to quit afterwards.
         FFAction.ProbeRuntimeKeys => Background with
         {
             Overwrite = false,
-            Stdin = FFStdinMode.ControlChannel,
+            Stdin = FFStdinMode.WriteThenClose,
             Timeout = StartupInterrogation,
             Priority = FFDefaults.InheritPriority,
             StderrIsPayload = true
@@ -227,4 +233,56 @@ public readonly record struct FFActionPolicy(
 
         _ => throw new ArgumentOutOfRangeException(nameof(action), action, "No policy defined.")
     };
+
+    /// <summary>
+    /// Throws if this policy asks for a combination that cannot work.
+    /// <para>
+    /// Validation done here rather than in the constructor because every arm of <see cref="For"/>
+    /// is built with a <c>with</c> expression, which copies the struct and assigns properties.
+    /// The runner calls this at the single point where a resolved policy becomes operative, which
+    /// is also the only place the request's own contribution is visible.
+    /// </para>
+    /// </summary>
+    /// <param name="action">The action this policy came from, named in the message.</param>
+    /// <param name="hasProgressSignal">
+    /// Whether the request supplies a liveness probe. The idle watchdog does nothing without one, so
+    /// a policy leaning on it is only bounded if the request cooperates.
+    /// </param>
+    /// <exception cref="InvalidOperationException">The combination cannot work.</exception>
+    public void EnsureCoherent(FFAction action, bool hasProgressSignal)
+    {
+        // The grace is the wait after writing "q". Anything else has nowhere to write it, so the
+        // grace would be spent waiting on a message that was never sent.
+        if (GracefulStopTimeout > TimeSpan.Zero && Stdin != FFStdinMode.ControlChannel)
+        {
+            throw new InvalidOperationException(
+                $"{action}: a stop grace needs {nameof(FFStdinMode.ControlChannel)}, not {Stdin}.");
+        }
+
+        if (ProbeOnly)
+        {
+            // ffprobe has no runtime keys to steer with and no encode whose progress it could report.
+            if (Stdin != FFStdinMode.FireAndForget)
+            {
+                throw new InvalidOperationException($"{action}: ffprobe cannot be steered through stdin.");
+            }
+
+            if (RequiresProgressStats)
+            {
+                throw new InvalidOperationException($"{action}: ffprobe has no progress to report.");
+            }
+        }
+
+        // Something has to be able to end the process. Dropping the wall clock is allowed, but only
+        // in exchange for a watchdog that will actually arm or a channel to ask it to stop through.
+        // A watchdog with no probe behind it counts for nothing, and that half lives on the request,
+        // so this is the only place the two can be weighed together.
+        if (Timeout == FFDefaults.Unbounded
+            && Stdin != FFStdinMode.ControlChannel
+            && !(IdleTimeout != FFDefaults.Unbounded && hasProgressSignal))
+        {
+            throw new InvalidOperationException(
+                $"{action}: no wall clock, no armed idle watchdog and no way to ask it to stop.");
+        }
+    }
 }

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFDefaults.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFDefaults.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Shared defaults for <see cref="FFRequest"/>.
+/// </summary>
+public static class FFDefaults
+{
+    /// <summary>
+    /// Gets the "use the action's priority" value. <see cref="ProcessPriorityClass"/> has no zero
+    /// member, so zero cannot collide with a real priority.
+    /// </summary>
+    public const ProcessPriorityClass InheritPriority = 0;
+
+    /// <summary>Gets a progress probe that contributes no liveness signal.</summary>
+    public static Func<long> NoProgressProbe { get; } = static () => 0;
+
+    /// <summary>
+    /// Gets the "no deadline" value, which
+    /// <see cref="System.Threading.CancellationTokenSource.CancelAfter(TimeSpan)"/> treats as never
+    /// firing.
+    /// </summary>
+    public static TimeSpan Unbounded => System.Threading.Timeout.InfiniteTimeSpan;
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFDelivery.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFDelivery.cs
@@ -1,0 +1,14 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// How a stream reaches the client. Orthogonal to <see cref="StreamMode"/>: either delivery can
+/// carry any amount of re-encoding.
+/// </summary>
+public enum FFDelivery
+{
+    /// <summary>A single continuous output the client reads as one response.</summary>
+    Progressive,
+
+    /// <summary>A playlist of segment files the client fetches individually.</summary>
+    Hls
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFLogLevel.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFLogLevel.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Derives FFmpeg's <c>-loglevel</c> argument from the server's own log level.
+/// </summary>
+public static class FFLogLevel
+{
+    /// <summary>
+    /// Maps a logger's level, but never below <c>info</c>. FFmpeg reports filter results — the
+    /// ebur128 loudness summary, for one — at info, so an action that reads its own standard error
+    /// as the answer gets nothing at all under a quieter level.
+    /// </summary>
+    /// <param name="logger">The logger to inspect.</param>
+    /// <returns>The value for <c>-loglevel</c>.</returns>
+    public static string ForPayload(ILogger logger)
+    {
+        var level = For(logger);
+
+        return level is "debug" or "verbose" ? level : "info";
+    }
+
+    /// <summary>
+    /// Maps a logger's effective level onto an FFmpeg log level.
+    /// </summary>
+    /// <param name="logger">The logger to inspect.</param>
+    /// <returns>The value for <c>-loglevel</c>.</returns>
+    public static string For(ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            return "debug";
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            return "verbose";
+        }
+
+        if (logger.IsEnabled(LogLevel.Warning))
+        {
+            return "warning";
+        }
+
+        return logger.IsEnabled(LogLevel.Error) ? "error" : "fatal";
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFOutputSink.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFOutputSink.cs
@@ -23,6 +23,13 @@ public abstract class FFOutputSink
     public const int DefaultRetainedLines = 200;
 
     /// <summary>
+    /// Gets a value indicating whether nothing written here is ever dropped. The runner checks this
+    /// for an action whose stderr is its answer rather than a diagnostic, since a sink that keeps a
+    /// trailing window would silently truncate that answer.
+    /// </summary>
+    public virtual bool RetainsEverything => false;
+
+    /// <summary>
     /// Gets a sink for output that only ever explains a failure. Keeps the last
     /// <see cref="DefaultRetainedLines"/> lines; everything earlier is dropped.
     /// </summary>
@@ -86,6 +93,8 @@ public abstract class FFOutputSink
     private sealed class CompleteSink : FFOutputSink
     {
         private readonly StringBuilder _builder = new();
+
+        public override bool RetainsEverything => true;
 
         public override ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
         {

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFOutputSink.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFOutputSink.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Where a process's captured output goes as it arrives. The runner always drains the pipe — a
+/// full one would block the child — so the choice here is only what happens to the bytes.
+/// </summary>
+public abstract class FFOutputSink
+{
+    /// <summary>
+    /// How many trailing lines <see cref="Diagnostic"/> retains. Measured against jellyfin-ffmpeg
+    /// 7.1.4: a failure emits three to six lines at <c>warning</c>, and the stream and format dump
+    /// that precedes one runs to 42 lines at <c>info</c> and 97 at <c>verbose</c>. This is roughly
+    /// double the largest of those, so the useful context survives at any log level the server
+    /// actually sets.
+    /// </summary>
+    public const int DefaultRetainedLines = 200;
+
+    /// <summary>
+    /// Gets a sink for output that only ever explains a failure. Keeps the last
+    /// <see cref="DefaultRetainedLines"/> lines; everything earlier is dropped.
+    /// </summary>
+    /// <returns>A bounded in-memory sink.</returns>
+    public static FFOutputSink Diagnostic() => new BoundedSink(DefaultRetainedLines);
+
+    /// <summary>
+    /// Gets a sink for output that <em>is</em> the answer, such as a filter's measurements. Keeps
+    /// all of it, since the part that matters could be anywhere.
+    /// </summary>
+    /// <returns>An unbounded in-memory sink.</returns>
+    public static FFOutputSink Complete() => new CompleteSink();
+
+    /// <summary>
+    /// Gets a sink that writes through to <paramref name="destination"/> as each line arrives, so a
+    /// long-running process can be followed rather than read once it has finished. Nothing is
+    /// retained in memory, so <see cref="FFResult.Stderr"/> stays empty.
+    /// </summary>
+    /// <param name="destination">The stream to write to. The caller owns closing it.</param>
+    /// <returns>A pass-through sink.</returns>
+    public static FFOutputSink ToStream(Stream destination) => new StreamSink(destination);
+
+    /// <summary>
+    /// Accepts one line of output.
+    /// </summary>
+    /// <param name="line">The line, without its terminator.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the write.</returns>
+    public abstract ValueTask WriteLineAsync(string line, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns whatever was retained, which is empty for sinks that wrote through.
+    /// </summary>
+    /// <returns>The retained text.</returns>
+    public abstract string GetRetainedText();
+
+    private sealed class BoundedSink : FFOutputSink
+    {
+        private readonly int _maxLines;
+        private readonly Queue<string> _lines = new();
+
+        public BoundedSink(int maxLines) => _maxLines = maxLines;
+
+        public override ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
+        {
+            _lines.Enqueue(line);
+
+            // Evicting whole lines keeps the retained text readable and cannot strand half of a
+            // UTF-16 surrogate pair, which cutting at a character offset can.
+            while (_lines.Count > _maxLines)
+            {
+                _lines.Dequeue();
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public override string GetRetainedText() => string.Join(Environment.NewLine, _lines);
+    }
+
+    private sealed class CompleteSink : FFOutputSink
+    {
+        private readonly StringBuilder _builder = new();
+
+        public override ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
+        {
+            if (_builder.Length > 0)
+            {
+                _builder.Append(Environment.NewLine);
+            }
+
+            _builder.Append(line);
+
+            return ValueTask.CompletedTask;
+        }
+
+        public override string GetRetainedText() => _builder.ToString();
+    }
+
+    private sealed class StreamSink : FFOutputSink
+    {
+        private readonly Stream _destination;
+
+        public StreamSink(Stream destination) => _destination = destination;
+
+        public override async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
+        {
+            await _destination.WriteAsync(Encoding.UTF8.GetBytes(line + Environment.NewLine), cancellationToken).ConfigureAwait(false);
+
+            // Flush per line: the point of this sink is that the file is readable while the
+            // process is still running.
+            await _destination.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public override string GetRetainedText() => string.Empty;
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFRequest.cs
@@ -73,8 +73,8 @@ public abstract record FFRequest
     public FFOutputSink Stderr { get; init; } = FFOutputSink.Diagnostic();
 
     /// <summary>
-    /// Gets an optional liveness counter, such as files produced so far. The watchdog also tracks
-    /// the child's CPU time; either advancing counts as alive.
+    /// Gets an optional liveness counter, such as files produced so far. When supplied, the
+    /// runner's idle watchdog uses this to detect stalled work.
     /// </summary>
     public Func<long> ProgressProbe { get; init; } = FFDefaults.NoProgressProbe;
 

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFRequest.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Base for every FFmpeg operation. Concrete requests carry their own parameters; this base holds
+/// only what applies to every operation.
+/// </summary>
+public abstract record FFRequest
+{
+    /// <summary>
+    /// Gets the executable to launch, when the operation names one rather than using the resolved
+    /// encoder or prober. Empty for everything except validating a candidate path, which runs
+    /// before any path has been accepted.
+    /// </summary>
+    public virtual string BinaryPathOverride => string.Empty;
+
+    /// <summary>Gets the operation this request performs.</summary>
+    public abstract FFAction Action { get; }
+
+    /// <summary>
+    /// Gets the wall-clock deadline. <see cref="TimeSpan.Zero"/> means the action's own deadline.
+    /// Set this only where the timeout is user-configurable.
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets the idle watchdog window. <see cref="TimeSpan.Zero"/> means the action's own; a zero
+    /// window would kill the process before it could report progress. Only meaningful alongside
+    /// <see cref="ProgressProbe"/>.
+    /// </summary>
+    public TimeSpan IdleTimeout { get; init; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets the scheduling priority. <see cref="FFDefaults.InheritPriority"/> means the action's
+    /// own.
+    /// </summary>
+    public ProcessPriorityClass Priority { get; init; } = FFDefaults.InheritPriority;
+
+    /// <summary>
+    /// Gets the working directory. Empty means inherit, which is
+    /// <see cref="ProcessStartInfo.WorkingDirectory"/>'s contract.
+    /// </summary>
+    public string WorkingDirectory { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a reader that drains standard output and discards it. Draining is not optional even
+    /// when the bytes are unwanted: an unread pipe fills, which blocks the child, which then
+    /// never exits.
+    /// </summary>
+    public static Func<Stream, CancellationToken, Task> DiscardStdout { get; }
+        = static (stdout, cancellationToken) => stdout.CopyToAsync(Stream.Null, cancellationToken);
+
+    /// <summary>
+    /// Gets the reader for standard output. Defaults to <see cref="DiscardStdout"/>; supply one to
+    /// parse the output, as the probe and keyframe scans do. It receives the <em>caller's</em>
+    /// cancellation token rather than the wall-clock deadline, since a consumer still parsing after
+    /// the process has exited is not overrunning anything.
+    /// </summary>
+    public Func<Stream, CancellationToken, Task> Stdout { get; init; } = DiscardStdout;
+
+    /// <summary>
+    /// Gets where standard error goes. Defaults to a bounded in-memory buffer surfaced on
+    /// <see cref="FFResult.Stderr"/>; use <see cref="FFOutputSink.Complete"/> when the output is
+    /// the answer rather than a diagnostic, or <see cref="FFOutputSink.ToStream"/> to follow a
+    /// long-running process live.
+    /// </summary>
+    public FFOutputSink Stderr { get; init; } = FFOutputSink.Diagnostic();
+
+    /// <summary>
+    /// Gets an optional liveness counter, such as files produced so far. The watchdog also tracks
+    /// the child's CPU time; either advancing counts as alive.
+    /// </summary>
+    public Func<long> ProgressProbe { get; init; } = FFDefaults.NoProgressProbe;
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="ProgressProbe"/> reports real progress. Without
+    /// one there is nothing to watch, so the idle watchdog does not run and the wall clock is the
+    /// only bound.
+    /// </summary>
+    public bool HasProgressSignal => !ReferenceEquals(ProgressProbe, FFDefaults.NoProgressProbe);
+
+    /// <summary>
+    /// Resolves the process policy for this request: the action's policy, with this request's
+    /// deadline and priority applied where it supplied them.
+    /// </summary>
+    /// <returns>The effective policy.</returns>
+    public virtual FFActionPolicy ResolvePolicy()
+    {
+        var policy = FFActionPolicy.For(Action);
+
+        if (Timeout != TimeSpan.Zero)
+        {
+            policy = policy with { Timeout = Timeout };
+        }
+
+        if (IdleTimeout != TimeSpan.Zero)
+        {
+            policy = policy with { IdleTimeout = IdleTimeout };
+        }
+
+        if (Priority != FFDefaults.InheritPriority)
+        {
+            policy = policy with { Priority = Priority };
+        }
+
+        return policy;
+    }
+
+    /// <summary>
+    /// Appends this operation's arguments to <paramref name="builder"/>. The global flags implied
+    /// by <see cref="FFAction"/> and the server log level have already been written, this appends
+    /// a fragment for the action for the rest of the command line.
+    /// </summary>
+    /// <param name="builder">The buffer to append to.</param>
+    public abstract void BuildArguments(StringBuilder builder);
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFResult.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFResult.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// The outcome of a completed FFmpeg or ffprobe run.
+/// </summary>
+/// <param name="ExitCode">The exit code, or <c>-1</c> if the process was killed.</param>
+/// <param name="Stderr">The retained tail of standard error.</param>
+/// <param name="Elapsed">Wall-clock duration from start to exit.</param>
+/// <param name="StopReason">Why the process stopped.</param>
+public readonly record struct FFResult(
+    int ExitCode,
+    string Stderr,
+    TimeSpan Elapsed,
+    FFStopReason StopReason)
+{
+    /// <summary>
+    /// Gets a value indicating whether the process ran to completion and reported success.
+    /// </summary>
+    public bool Succeeded => StopReason == FFStopReason.Exited && ExitCode == 0;
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStdinMode.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStdinMode.cs
@@ -1,0 +1,19 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Whether an FFmpeg process is q-for-quittable. Sets both the <c>-nostdin</c> argument and the
+/// disposition of the stdin handle. Derived from the action.
+/// </summary>
+public enum FFStdinMode
+{
+    /// <summary>
+    /// Stdin is redirected and closed immediately, and <c>-nostdin</c> is emitted for the encoder.
+    /// </summary>
+    FireAndForget,
+
+    /// <summary>
+    /// Stdin stays open for FFmpeg's runtime keys. <c>-nostdin</c> is suppressed, since it would
+    /// disable them.
+    /// </summary>
+    ControlChannel
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStdinMode.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStdinMode.cs
@@ -15,5 +15,16 @@ public enum FFStdinMode
     /// Stdin stays open for FFmpeg's runtime keys. <c>-nostdin</c> is suppressed, since it would
     /// disable them.
     /// </summary>
-    ControlChannel
+    ControlChannel,
+
+    /// <summary>
+    /// Stdin is written once at startup and closed immediately after, so the process is not
+    /// steerable thereafter. <c>-nostdin</c> is suppressed, since the write has to land.
+    /// <para>
+    /// Only the runtime-key probe, which asks its question by writing a key and then has nothing
+    /// further to say. Distinguished from <see cref="ControlChannel"/> because a process whose stdin
+    /// is gone cannot be asked to quit: terminating one has to go straight to the kill.
+    /// </para>
+    /// </summary>
+    WriteThenClose
 }

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStopReason.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStopReason.cs
@@ -1,0 +1,27 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Why a process stopped.
+/// </summary>
+public enum FFStopReason
+{
+    /// <summary>
+    /// Not a settled outcome.
+    /// </summary>
+    Unknown,
+
+    /// <summary>The process exited on its own. Consult the exit code.</summary>
+    Exited,
+
+    /// <summary>The caller's cancellation token fired; the process was killed.</summary>
+    Cancelled,
+
+    /// <summary>The wall-clock deadline elapsed; the process was killed.</summary>
+    TimedOut,
+
+    /// <summary>
+    /// The process was alive but made no forward progress within the idle window, measured by its
+    /// own CPU time and by the action's optional domain probe. It was killed.
+    /// </summary>
+    Stalled
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStopReason.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/FFStopReason.cs
@@ -20,8 +20,8 @@ public enum FFStopReason
     TimedOut,
 
     /// <summary>
-    /// The process was alive but made no forward progress within the idle window, measured by its
-    /// own CPU time and by the action's optional domain probe. It was killed.
+    /// The process was alive but made no forward progress within the idle window, measured by
+    /// the action's optional probe, so it was terminated.
     /// </summary>
     Stalled
 }

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFPaths.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFPaths.cs
@@ -1,0 +1,29 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Holds the resolved locations of the FFmpeg and FFprobe binaries.
+/// <para>
+/// This exists as its own service so that the process runner does not have to depend on the media
+/// encoder, which would be a cycle: the encoder is what runs the operations, and the runner is what
+/// the encoder runs them through.
+/// </para>
+/// </summary>
+public interface IFFPaths
+{
+    /// <summary>
+    /// Gets the FFmpeg binary path, or empty when none has been resolved.
+    /// </summary>
+    string EncoderPath { get; }
+
+    /// <summary>
+    /// Gets the FFprobe binary path, derived from <see cref="EncoderPath"/>.
+    /// </summary>
+    string ProbePath { get; }
+
+    /// <summary>
+    /// Records the resolved encoder location and derives the prober's from it. FFprobe is never
+    /// configured separately.
+    /// </summary>
+    /// <param name="encoderPath">The FFmpeg binary path, or empty to clear both.</param>
+    void SetEncoderPath(string encoderPath);
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFRunner.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFRunner.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Spawns ffmpeg and ffprobe. Every run redirects all three pipes, drains stdout and stderr,
+/// bounds itself with a wall clock and an idle watchdog, and kills the process tree on
+/// cancellation.
+/// </summary>
+public interface IFFRunner
+{
+    /// <summary>
+    /// Runs an operation and waits for it to finish. Equivalent to <see cref="StartAsync"/>
+    /// followed by awaiting <see cref="IFFSession.Completion"/>, and implemented that way, so the
+    /// two entry points cannot drift apart.
+    /// </summary>
+    /// <param name="request">The operation and its parameters.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The outcome.</returns>
+    Task<FFResult> RunAsync(FFRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Starts an operation and returns once the process is running, leaving the caller to decide
+    /// when to stop it. For work that outlives the call — recordings and transcodes — where
+    /// <see cref="RunAsync(FFRequest, CancellationToken)"/> would block until exit.
+    /// <para>
+    /// Pair with <see cref="FFOutputSink.ToStream"/> so the log is readable while the process runs.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The operation and its parameters.</param>
+    /// <param name="cancellationToken">Cancels the start, and thereafter stops the process.</param>
+    /// <returns>A handle on the running process.</returns>
+    Task<IFFSession> StartAsync(FFRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Renders the command line this request would run, binary included, without running anything.
+    /// <para>
+    /// For callers that write the command into a user-facing log. Since the runner supplies the
+    /// global flags — <c>-hide_banner</c>, the derived <c>-loglevel</c>, <c>-stats</c> and the
+    /// overwrite flag — a caller logging only its own <c>Arguments</c> records something that does
+    /// not reproduce when pasted into a shell. Ask for this instead.
+    /// </para>
+    /// </summary>
+    /// <param name="request">The operation and its parameters.</param>
+    /// <returns>The full command line, exactly as <see cref="StartAsync"/> would launch it.</returns>
+    string GetCommandLine(FFRequest request);
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFSession.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/IFFSession.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// A running FFmpeg process the caller holds onto, for operations that outlive the call that
+/// started them. Obtained from <see cref="IFFRunner.StartAsync"/>, which returns once the process
+/// is running rather than once it has finished.
+/// </summary>
+public interface IFFSession : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets the process id, for correlating with external logs.
+    /// </summary>
+    int ProcessId { get; }
+
+    /// <summary>
+    /// Gets a task that completes when the process has exited and its output has been drained.
+    /// Carries the same outcome <see cref="IFFRunner.RunAsync(FFRequest, CancellationToken)"/>
+    /// would have returned.
+    /// </summary>
+    Task<FFResult> Completion { get; }
+
+    /// <summary>
+    /// Sends one of FFmpeg's runtime keys, such as pause or resume. Requires the action to use
+    /// <see cref="FFStdinMode.ControlChannel"/>. Do not send the quit key here — use
+    /// <see cref="StopAsync"/>, which also handles the escalation to a kill.
+    /// </summary>
+    /// <param name="key">The key to write.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the write.</returns>
+    Task SendKeyAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Asks the process to stop, escalating to a kill of the whole tree if it does not exit within
+    /// the action's grace period.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The outcome, once it has stopped.</returns>
+    Task<FFResult> StopAsync(CancellationToken cancellationToken);
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/AttachmentRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/AttachmentRequest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Dumps embedded attachments such as subtitle fonts to disk, either by stream index or all at
+/// once under their embedded filenames.
+/// </summary>
+public sealed record AttachmentRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ExtractAttachment;
+
+    /// <summary>Gets the input target, already formed and quoted by the caller.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>
+    /// Gets the attachments to extract by stream index. When empty, every attachment is dumped
+    /// into <see cref="FFRequest.WorkingDirectory"/> using its embedded filename.
+    /// </summary>
+    public IReadOnlyList<AttachmentTarget> Targets { get; init; } = [];
+
+    /// <summary>Gets a value indicating whether the input is a concat playlist.</summary>
+    public bool IsConcatPlaylist { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (Targets.Count == 0)
+        {
+            // dump every attachment to the working directory using its embedded filename
+            builder.Append("-dump_attachment:t \"\" ");
+        }
+        else
+        {
+            foreach (var target in Targets)
+            {
+                builder.AppendFormat(
+                    CultureInfo.InvariantCulture,
+                    "-dump_attachment:{0} \"{1}\" ",
+                    target.StreamIndex,
+                    target.OutputPath);
+            }
+        }
+
+        if (IsConcatPlaylist)
+        {
+            // use the concat demuxer to read the playlist emitting the attachments in the order listed
+            // and allow absolute paths in the playlist to allow dumping to arbitrary locations.
+            builder.Append("-f concat -safe 0 ");
+        }
+
+        // Map the attachments themselves so the null muxer always has a stream to write, whatever
+        // the source contains. The ? makes the map optional; without it a source carrying no
+        // attachments fails with "Stream map '' matches no streams".
+        // -t 0 stops after zero media frames, so this only dumps and exits.
+        builder.Append("-i ").Append(Input).Append(" -map 0:t? -t 0 -f null null");
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/AttachmentTarget.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/AttachmentTarget.cs
@@ -1,0 +1,8 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// One attachment to extract.
+/// </summary>
+/// <param name="StreamIndex">The attachment's stream index within the container.</param>
+/// <param name="OutputPath">Where to write it, already normalised by the caller.</param>
+public readonly record struct AttachmentTarget(int StreamIndex, string OutputPath);

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/CapabilitiesRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/CapabilitiesRequest.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Interrogates the binary's own capabilities at startup: version, codec and filter lists, and
+/// feature tests. These arguments are literal interrogations of FFmpeg rather than media
+/// operations, so arguments are passed verbatim.
+/// </summary>
+public sealed record CapabilitiesRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.Capabilities;
+
+    /// <summary>Gets the interrogation arguments.</summary>
+    public required string Arguments { get; init; }
+
+    /// <summary>Gets a value indicating whether this interrogates ffprobe rather than ffmpeg.</summary>
+    public bool ProbeOnly { get; init; }
+
+    /// <inheritdoc />
+    public override FFActionPolicy ResolvePolicy() => base.ResolvePolicy() with { ProbeOnly = ProbeOnly };
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Append(Arguments);
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ImageRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ImageRequest.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Model.Drawing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Decodes a single frame and writes it as a still image.
+/// </summary>
+public sealed record ImageRequest : FFRequest
+{
+    /// <summary>Value for <see cref="StreamIndex"/> meaning "let FFmpeg pick the stream".</summary>
+    public const int AutoStreamIndex = -1;
+
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ExtractImage;
+
+    /// <summary>Gets the input target, already formed and quoted by the caller.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>Gets the file to write, already normalised by the caller.</summary>
+    public required string OutputPath { get; init; }
+
+    /// <summary>Gets the filter chain, without the <c>-vf</c> prefix.</summary>
+    public required string Filters { get; init; }
+
+    /// <summary>Gets the FFmpeg version, which decides how frame sync is spelled.</summary>
+    public required Version EncoderVersion { get; init; }
+
+    /// <summary>Gets the demuxer to force, when the container needs one. Empty to let FFmpeg decide.</summary>
+    public string InputFormat { get; init; } = string.Empty;
+
+    /// <summary>Gets the position to seek to. Zero takes the frame from the start.</summary>
+    public TimeSpan SeekTo { get; init; }
+
+    /// <summary>
+    /// Gets the stream to take the image from. <see cref="AutoStreamIndex"/> lets FFmpeg pick.
+    /// </summary>
+    public int StreamIndex { get; init; } = AutoStreamIndex;
+
+    /// <summary>
+    /// Gets the requested output size. <see cref="ImageResolution.MatchSource"/> keeps the source
+    /// size and emits no scaling flag.
+    /// </summary>
+    public ImageResolution Resolution { get; init; } = ImageResolution.MatchSource;
+
+    /// <summary>
+    /// Gets a value indicating whether decoding should discard non-keyframes. Faster, but on
+    /// containers that cannot seek to a keyframe the frame may be corrupt.
+    /// </summary>
+    public bool KeyFrameOnly { get; init; }
+
+    /// <summary>Gets the decoder thread count. Zero means auto and omits the flag.</summary>
+    public int Threads { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (InputFormat.Length > 0)
+        {
+            // force the demuxer; FFmpeg's probe cannot always name the container from its bytes
+            builder.Append("-f ").Append(InputFormat).Append(' ');
+        }
+
+        if (KeyFrameOnly)
+        {
+            // discard non-keyframes in the decoder, so the seek lands cheaply
+            builder.Append("-skip_frame nokey ");
+        }
+
+        if (SeekTo > TimeSpan.Zero)
+        {
+            // before -i, so the demuxer seeks rather than the decoder discarding frames up to here
+            builder.Append("-ss ").Append(FormatSeek(SeekTo)).Append(' ');
+        }
+
+        builder.Append("-i ").Append(Input);
+
+        if (StreamIndex != AutoStreamIndex)
+        {
+            // pick the embedded image out of the container by index rather than by heuristic
+            builder.Append(" -map 0:").Append(StreamIndex.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (Threads > 0)
+        {
+            builder.Append(" -threads ").Append(Threads.ToString(CultureInfo.InvariantCulture));
+        }
+
+        // -vframes 1: stop after a single decoded frame
+        builder.Append(" -vframes 1 -vf ").Append(Filters);
+
+        var size = ResolveSize(Resolution);
+        if (size.Length > 0)
+        {
+            builder.Append(" -s ").Append(size);
+        }
+
+        // -1 lets FFmpeg decide the fps mode, which is all a single frame needs
+        builder.Append(EncodingHelper.GetVideoSyncOption("-1", EncoderVersion));
+
+        // image2 writes the single frame as a standalone file
+        builder.Append(" -f image2 \"").Append(OutputPath).Append('"');
+    }
+
+    /// <summary>
+    /// FFmpeg wants a duration, not a clock time, but accepts this spelling and it stays readable
+    /// in the logs.
+    /// </summary>
+    private static string FormatSeek(TimeSpan offset)
+        => offset.ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// FFmpeg's <c>-s</c> takes explicit dimensions, so the configured rung has to be expanded to
+    /// a concrete 16:9 frame size.
+    /// </summary>
+    private static string ResolveSize(ImageResolution resolution) => resolution switch
+    {
+        ImageResolution.P144 => "256x144",
+        ImageResolution.P240 => "426x240",
+        ImageResolution.P360 => "640x360",
+        ImageResolution.P480 => "854x480",
+        ImageResolution.P720 => "1280x720",
+        ImageResolution.P1080 => "1920x1080",
+        ImageResolution.P1440 => "2560x1440",
+        ImageResolution.P2160 => "3840x2160",
+        _ => string.Empty
+    };
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/KeyframeScanRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/KeyframeScanRequest.cs
@@ -24,9 +24,9 @@ public sealed record KeyframeScanRequest : FFRequest
         // empty pts_time fields, and a keyframe with no timestamp tells a segmenter nothing.
         builder.Append("-fflags +genpts ")
 
-            // Inert for this query, and kept only so the scan asks for exactly what it always has.
-            // -skip_frame is a decoder option, but -show_entries packet= reads the demuxer's packet
-            // headers and decodes nothing, so there are no frames to skip.
+            // Inert for this query: -skip_frame is a decoder option, but -show_entries packet= reads
+            // the demuxer's packet headers and decodes nothing, so there are no frames to skip. Kept
+            // because dropping it would change what the scan asks ffprobe for to no benefit.
             .Append("-skip_frame nokey ")
 
             // Ask for both durations because either can be missing. The parser prefers the stream's

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/KeyframeScanRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/KeyframeScanRequest.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Reads keyframe packet timings so that HLS segmenting can align to them.
+/// </summary>
+public sealed record KeyframeScanRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ScanKeyframes;
+
+    /// <summary>Gets the file to scan.</summary>
+    public required string FilePath { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Synthesise timestamps for a container that carries none. Without it such a source reports
+        // empty pts_time fields, and a keyframe with no timestamp tells a segmenter nothing.
+        builder.Append("-fflags +genpts ")
+
+            // Inert for this query, and kept only so the scan asks for exactly what it always has.
+            // -skip_frame is a decoder option, but -show_entries packet= reads the demuxer's packet
+            // headers and decodes nothing, so there are no frames to skip.
+            .Append("-skip_frame nokey ")
+
+            // Ask for both durations because either can be missing. The parser prefers the stream's
+            // and falls back to the container's. These arrive as single-field rows after the packets.
+            .Append("-show_entries format=duration ")
+            .Append("-show_entries stream=duration ")
+
+            // The payload: one row per video packet, as "packet,<pts_time>,<flags>". The field order
+            // is important as the parser splits the row positionally, so pts_time must be named
+            // before flags. A keyframe is a row whose flags field begins with K.
+            //
+            // Note this emits *every* packet, not just keyframes; roughly 30 rows a second, so a
+            // feature-length file yields a couple of hundred thousand. Selecting the keyframes out
+            // of them is the parser's job.
+            .Append("-show_entries packet=pts_time,flags ")
+
+            // Video only. Nothing in a row identifies which stream it came from, so an audio track's
+            // packets would be indistinguishable from the video's and read as extra keyframes.
+            .Append("-select_streams v ")
+
+            // csv rather than json, because of the row count above.
+            //
+            // This relies on ffprobe's default of prefixing each row with its section name, which is
+            // the only thing that distinguishes a "packet" row from the trailing "stream" and
+            // "format" ones so the parser dispatches on it. Adding the usual =p=0 to strip that prefix
+            // would leave the output unparseable.
+            .Append("-of csv \"")
+            .Append(FilePath)
+            .Append('"');
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/LoudnessRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/LoudnessRequest.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Measures EBU R128 loudness. The measurement is reported on stderr rather than written to a
+/// file, so the caller reads it out of <see cref="FFResult.Stderr"/>.
+/// </summary>
+public sealed record LoudnessRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.MeasureLoudness;
+
+    /// <summary>Gets the path to measure, or to a concat playlist listing several.</summary>
+    public required string Path { get; init; }
+
+    /// <summary>Gets a value indicating whether <see cref="Path"/> is a concat playlist.</summary>
+    public bool IsConcatPlaylist { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (IsConcatPlaylist)
+        {
+            // Read the playlist as one continuous program so an album measures as a whole rather
+            // than track by track. -safe 0 permits the absolute paths the playlist is written with.
+            builder.Append("-f concat -safe 0 ");
+        }
+
+        // ebur128 reports through the log rather than the output stream, so the run is uses
+        // FFActionPolicy.StderrIsPayload. That is what ensures -loglevel is at least info and keeps
+        // the whole stderr instead of a trailing window. Do not assume the flag is decorative: measured
+        // against jellyfin-ffmpeg 7.1.4, the "Summary:" block is emitted at info and verbose and at
+        // nothing below them, so at the default server log level of warning this run would exit 0
+        // having printed no measurement at all, and the caller's regex would match nothing.
+        //
+        // framelog=verbose additionally logs each frame's loudness. The caller only reads the
+        // summary, but the per-frame lines are what let a truncated or stalled measurement be told
+        // apart from one that simply found nothing.
+        //
+        // -f null discards the decoded audio; the analysis is the entire point of the run.
+        builder.AppendFormat(CultureInfo.InvariantCulture, "-i \"{0}\" ", Path)
+            .Append("-af ebur128=framelog=verbose -f null -");
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ProbeRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ProbeRequest.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Reads container and stream metadata as JSON.
+/// </summary>
+public sealed record ProbeRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.Probe;
+
+    /// <summary>Gets the input target, already formed and quoted by the caller.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>
+    /// Gets the per-source tuning arguments: <c>-analyzeduration</c>, <c>-probesize</c>,
+    /// <c>-user_agent</c> and the RTSP transport flags. These are properties of the media source
+    /// rather than of the process, so they are the caller's responsibility.
+    /// </summary>
+    public string SourceTuning { get; init; } = string.Empty;
+
+    /// <summary>Gets a value indicating whether chapter markers should be reported.</summary>
+    public bool IncludeChapters { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether only the first video frame should be reported, which the
+    /// prober must have been verified to support.
+    /// </summary>
+    public bool FirstVideoFrameOnly { get; init; }
+
+    /// <summary>Gets the decoder thread count. Zero means auto and omits the command-line flag.</summary>
+    public int Threads { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Must precede -i. These are input options (how long to sniff for, how many bytes to read,
+        // which RTSP transport to negotiate) and FFmpeg binds an input option to the next input
+        // named after it.
+        if (SourceTuning.Length > 0)
+        {
+            builder.Append(SourceTuning.Trim()).Append(' ');
+        }
+
+        builder.Append("-i ").Append(Input);
+
+        // Position preserved from the original command: -show_streams reports what the headers
+        // already say and decodes almost nothing, so there is very little here for extra
+        // threads to do.
+        if (Threads > 0)
+        {
+            builder.Append(" -threads ").Append(Threads);
+        }
+
+        builder.Append(" -print_format json -show_streams");
+
+        if (IncludeChapters)
+        {
+            builder.Append(" -show_chapters");
+        }
+
+        // -only_first_vframe stops after the first video frame, which is all the caller wants and
+        // avoids reporting every frame in the file. Unlike everything else here it is not present in
+        // every ffprobe build, so it is only ever set once startup has confirmed the running prober
+        // accepts it (CheckSupportedProberOptionAsync); on a build without it the whole run fails.
+        if (FirstVideoFrameOnly)
+        {
+            builder.Append(" -show_frames -only_first_vframe");
+        }
+
+        // Container-level metadata: duration, bitrate, format name and tags.
+        builder.Append(" -show_format");
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/RecordRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/RecordRequest.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Records a live stream to a file, copying the streams rather than re-encoding them.
+/// </summary>
+public sealed record RecordRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.Record;
+
+    /// <summary>Gets the source to record, already quoted by the caller.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>Gets the file to write, already quoted and escaped by the caller.</summary>
+    public required string OutputPath { get; init; }
+
+    /// <summary>
+    /// Gets the FFmpeg version, which decides whether the read-rate catch-up limit is understood.
+    /// </summary>
+    public required Version EncoderVersion { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether decode timestamps are ignored. Some broadcast sources emit
+    /// ones that move backwards, which stalls muxing.
+    /// </summary>
+    public bool IgnoreDts { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the container index is ignored, for sources whose index is
+    /// absent or wrong.
+    /// </summary>
+    public bool IgnoreIndex { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether presentation timestamps are generated. Live sources often
+    /// arrive with none, and a recording without them is unseekable.
+    /// </summary>
+    public bool GeneratePts { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the source is read at its native frame rate rather than as
+    /// fast as it arrives, which is what makes a recording track wall-clock time.
+    /// </summary>
+    public bool ReadAtNativeFramerate { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the source is looped and reconnected on failure, for
+    /// sources that end or drop out mid-recording.
+    /// </summary>
+    public bool RequiresLooping { get; init; }
+
+    /// <summary>
+    /// Gets how long FFmpeg may spend examining the source before deciding its stream layout.
+    /// Live sources need longer than files, since the opening moments may carry no keyframe.
+    /// </summary>
+    public TimeSpan AnalyzeDuration { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets a value indicating whether subtitle streams are copied. When false they are dropped,
+    /// since a live source's subtitles are frequently unmuxable into the target container.
+    /// </summary>
+    public bool CopySubtitles { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Correct minor audio drift by stretching or squeezing rather than dropping samples.
+        builder.Append("-async 1");
+
+        if (IgnoreDts || IgnoreIndex || GeneratePts)
+        {
+            // -fflags tells the demuxer how much of the source's own timing metadata to believe.
+            builder.Append(" -fflags ");
+
+            if (IgnoreDts)
+            {
+                // ignore decode timestamps and let the decoder order frames itself
+                builder.Append("+igndts");
+            }
+
+            if (IgnoreIndex)
+            {
+                // ignore the container index and find the streams by scanning instead
+                builder.Append("+ignidx");
+            }
+
+            if (GeneratePts)
+            {
+                // synthesise presentation timestamps from frame order where the source carries none
+                builder.Append("+genpts");
+            }
+        }
+
+        if (ReadAtNativeFramerate)
+        {
+            // -re paces reading to the source's own frame rate instead of consuming it as fast as
+            // it arrives, so an hour of broadcast takes an hour rather than filling the disk.
+            builder.Append(" -re");
+
+            // FFmpeg 8 tightened how far -re may run ahead, which stalls a remux. Restoring the
+            // older allowance keeps recordings from stuttering.
+            if (EncoderVersion >= new Version(8, 0))
+            {
+                builder.Append(" -readrate_catchup 100");
+            }
+        }
+
+        if (RequiresLooping)
+        {
+            // -stream_loop -1 restarts the source indefinitely, and the reconnect options let a
+            // dropped network source resume rather than ending the recording. The delay caps how
+            // long to wait between attempts.
+            builder.Append(" -stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2");
+        }
+
+        // How long to examine the source before deciding its stream layout. In microseconds.
+        builder.Append(" -analyzeduration ")
+            .Append(((long)AnalyzeDuration.TotalMicroseconds).ToString(CultureInfo.InvariantCulture));
+
+        builder.Append(" -i ").Append(Input);
+
+        // Copy both streams: a recording re-encodes nothing, it only changes container. The second
+        // +genpts applies to the output, where live sources routinely arrive with no usable
+        // presentation timestamps and a recording carrying none of its own is unseekable.
+        builder.Append(" -codec:v:0 copy -fflags +genpts -codec:a:0 copy");
+
+        // -sn drops subtitles entirely; a live source's are often unmuxable into the target.
+        builder.Append(CopySubtitles ? " -codec:s copy" : " -sn");
+
+        // Drop source metadata: it describes the live stream, not the recording.
+        builder.Append(" -map_metadata -1 ").Append(OutputPath);
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/RuntimeKeyProbeRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/RuntimeKeyProbeRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Tests whether the encoder responds to runtime keys. The runner writes the query key to stdin;
+/// the answer is whatever the encoder prints to stderr in response.
+/// </summary>
+public sealed record RuntimeKeyProbeRequest : FFRequest
+{
+    /// <summary>The key written to stdin. FFmpeg's "list runtime keys" query.</summary>
+    public const string QueryKey = "?";
+
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ProbeRuntimeKeys;
+
+    /// <summary>Gets the interrogation arguments.</summary>
+    public required string Arguments { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Append(Arguments);
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/StreamRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/StreamRequest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Delivers media to a client, either as one continuous response or as HLS segments.
+/// <para>
+/// Unlike the other requests this carries its arguments already assembled. Building them needs the
+/// whole of <c>EncodingHelper</c> — hardware pipelines, filter graphs, bitrate and profile
+/// negotiation — which is a far larger body of logic than any single request should absorb.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three builders are the only ones that produce the string:
+/// <c>DynamicHlsController.GetCommandLineArguments</c> for segmented delivery, and
+/// <c>EncodingHelper</c>'s progressive video and audio builders, reached through
+/// <c>FileStreamResponseHelpers</c>. All three emit the same shape — input options, <c>-i</c>,
+/// stream selection and mapping, codec and filter arguments, muxer arguments, and finally
+/// <c>"&lt;output&gt;"</c>. The output target lives inside the string; the runner never supplies one.
+/// </para>
+/// <para>
+/// What they must <em>not</em> emit is any flag the runner already owns: <c>-hide_banner</c>, the
+/// <c>-loglevel</c> derived from the server's logger, <c>-stats</c>, and the <c>-y</c> / <c>-n</c>
+/// overwrite flag. Those are written first and this string is appended after them, so a repeat
+/// here is the last word on the command line.
+/// </para>
+/// </remarks>
+public sealed record StreamRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.Stream;
+
+    /// <summary>Gets how the output reaches the client.</summary>
+    public required FFDelivery Delivery { get; init; }
+
+    /// <summary>
+    /// Gets how much re-encoding the delivery actually involves. Not used to build the arguments —
+    /// they already reflect it — but it decides how the run is supervised and reported, since a
+    /// remux and a full transcode cost wildly different amounts.
+    /// </summary>
+    public required StreamMode Mode { get; init; }
+
+    /// <summary>
+    /// Gets the assembled arguments, including the input and output terms.
+    /// </summary>
+    public required string Arguments { get; init; }
+
+    /// <summary>
+    /// Resolves the action's policy and then pins <c>Overwrite</c> on. Delivery routinely writes over
+    /// output a previous run left behind — a stale segment, or a progressive file from an abandoned
+    /// session.
+    /// </summary>
+    /// <returns>The effective policy, always with <c>Overwrite</c> set.</returns>
+    public override FFActionPolicy ResolvePolicy() => base.ResolvePolicy() with { Overwrite = true };
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Verbatim, and appended after the runner's own global flags. Nothing is validated or
+        // rewritten here: the caller owns the whole command line from the input options onwards,
+        // which is the point of this request type.
+        builder.Append(Arguments);
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleConvertRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleConvertRequest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Rewrites a standalone subtitle file as SubRip, optionally reinterpreting its character
+/// encoding. Unlike <see cref="SubtitleExtractRequest"/> there is no container to select from, so
+/// the whole file is converted.
+/// </summary>
+public sealed record SubtitleConvertRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ExtractSubtitle;
+
+    /// <summary>Gets the file to read.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>Gets the file to write.</summary>
+    public required string OutputPath { get; init; }
+
+    /// <summary>
+    /// Gets the character encoding to read the source as. Empty lets FFmpeg decide, which is
+    /// correct when the source is already UTF-8 or the encoding could not be detected. It is also
+    /// ignored where FFmpeg refuses it — see <see cref="SpecifiesCharacterEncoding"/>.
+    /// </summary>
+    public string SourceCharacterEncoding { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether <c>-sub_charenc</c> is actually emitted.
+    /// <para>
+    /// FFmpeg recodes UTF-16 SAMI on its own and then rejects being told the encoding as well,
+    /// failing with "do not specify a character encoding" and "Unable to recode subtitle event".
+    /// </para>
+    /// </summary>
+    public bool SpecifiesCharacterEncoding
+        => SourceCharacterEncoding.Length > 0 && !(IsSami && IsUtf16);
+
+    private bool IsSami
+        => Input.EndsWith(".smi", StringComparison.OrdinalIgnoreCase)
+           || Input.EndsWith(".sami", StringComparison.OrdinalIgnoreCase);
+
+    private bool IsUtf16
+        => SourceCharacterEncoding.Equals("UTF-16BE", StringComparison.OrdinalIgnoreCase)
+           || SourceCharacterEncoding.Equals("UTF-16LE", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (SpecifiesCharacterEncoding)
+        {
+            // before -i, so the demuxer decodes the bytes as this charset rather than guessing
+            builder.Append("-sub_charenc ").Append(SourceCharacterEncoding).Append(' ');
+        }
+
+        builder.Append("-i \"").Append(Input).Append('"');
+
+        // -c:s srt re-encodes the cues as SubRip rather than copying them, which is what actually
+        // performs the conversion. There is no -map: the file holds one subtitle stream and
+        // nothing else, so FFmpeg's default selection already picks it.
+        builder.Append(" -c:s srt \"").Append(OutputPath).Append('"');
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleExtractRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleExtractRequest.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Writes one or more embedded subtitle streams out of a container as sidecar files. A single run
+/// serves every target, so a container with many subtitle tracks is demuxed once rather than once
+/// per track.
+/// </summary>
+public sealed record SubtitleExtractRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ExtractSubtitle;
+
+    /// <summary>Gets the input target, already formed and quoted by the caller.</summary>
+    public required string Input { get; init; }
+
+    /// <summary>Gets the streams to write. Each becomes its own output file.</summary>
+    public required IReadOnlyList<SubtitleTarget> Targets { get; init; }
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Append("-i ").Append(Input);
+
+        foreach (var target in Targets)
+        {
+            // -an -vn: this output carries the one subtitle stream and nothing else
+            builder.Append(" -map 0:")
+                .Append(target.StreamIndex.ToString(CultureInfo.InvariantCulture))
+                .Append(" -an -vn -c:s ")
+                .Append(target.CopyStream ? "copy" : "srt");
+
+            if (target.IsVobSub)
+            {
+                // FFmpeg has no .idx/.sub muxer, so VobSub has to be wrapped in Matroska
+                builder.Append(" -f matroska");
+            }
+
+            // write through rather than buffering, so a reader can open the file before the run ends
+            builder.Append(" -flush_packets 1");
+
+            builder.Append(" \"").Append(target.OutputPath).Append('"');
+        }
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleTarget.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/SubtitleTarget.cs
@@ -1,0 +1,20 @@
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// One subtitle stream to write out of a container.
+/// </summary>
+/// <param name="StreamIndex">The stream's index within the container.</param>
+/// <param name="OutputPath">Where to write it, already normalised by the caller.</param>
+/// <param name="CopyStream">
+/// Whether the stream can be written as-is. When false it is converted to SubRip, which is the
+/// only text format worth normalising to.
+/// </param>
+/// <param name="IsVobSub">
+/// Whether the stream is VobSub. FFmpeg has no .idx/.sub muxer, so these have to be wrapped in
+/// Matroska instead.
+/// </param>
+public readonly record struct SubtitleTarget(
+    int StreamIndex,
+    string OutputPath,
+    bool CopyStream,
+    bool IsVobSub);

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/TrickplayRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/TrickplayRequest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Globalization;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Decodes frames at a fixed interval and writes them as numbered stills for trickplay tiles.
+/// </summary>
+public sealed record TrickplayRequest : FFRequest
+{
+    /// <summary>The qscale used when the caller has no configured value.</summary>
+    public const int DefaultQualityScale = 4;
+
+    /// <summary>Best quality FFmpeg accepts for qscale.</summary>
+    public const int BestQualityScale = 1;
+
+    /// <summary>Worst quality FFmpeg accepts for qscale.</summary>
+    public const int WorstQualityScale = 31;
+
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.GenerateTrickplay;
+
+    /// <summary>
+    /// Gets the hardware-acceleration setup and input target as one string. Built by
+    /// <c>EncodingHelper</c>, which owns the decoder selection and its thread clamps.
+    /// </summary>
+    public required string Input { get; init; }
+
+    /// <summary>
+    /// Gets the filter chain including the <c>-vf</c> flag, built by <c>EncodingHelper</c> which
+    /// owns the hardware-dependent graph: which scaler, which tone-map, and which surface the
+    /// frames live on all vary by decoder.
+    /// </summary>
+    public required string FilterChain { get; init; }
+
+    /// <summary>
+    /// Gets the source frame rate to rebuild timestamps at, or zero to leave them alone.
+    /// <para>
+    /// Some containers report timestamps that do not advance monotonically. Selecting frames by
+    /// interval from those lands tiles at the wrong instants, so the presentation clock is
+    /// recomputed from the frame number first. Keyframe-only extraction does not need this,
+    /// because it takes whatever keyframes exist rather than sampling a timeline.
+    /// </para>
+    /// </summary>
+    public double NormalizeTimestampsAtFrameRate { get; init; }
+
+    /// <summary>Gets the numbered output pattern, such as <c>%08d.jpg</c>.</summary>
+    public required string OutputPath { get; init; }
+
+    /// <summary>
+    /// Gets the mjpeg encoder to use. It also decides how quality is expressed and whether a
+    /// software fallback has to be offered.
+    /// </summary>
+    public required string VideoEncoder { get; init; }
+
+    /// <summary>
+    /// Gets the FFmpeg version, which decides how frame sync is spelled.
+    /// </summary>
+    public required Version EncoderVersion { get; init; }
+
+    /// <summary>
+    /// Gets the requested quality on FFmpeg's qscale scale, where <see cref="BestQualityScale"/> is
+    /// best and <see cref="WorstQualityScale"/> is worst. Translated to whatever
+    /// <see cref="VideoEncoder"/> actually understands.
+    /// </summary>
+    public int QualityScale { get; init; } = DefaultQualityScale;
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // -an -sn: tiles come from video only, so never decode audio or subtitles.
+        builder.Append(Input).Append(" -an -sn ").Append(RenderFilterChain()).Append(' ');
+
+        // No encoder thread count: mjpeg stills at tile resolution are trivial to encode, and the
+        // encoder is fed by a decoder already pinned to one or two threads, so there is nothing to
+        // parallelise. The decoder's count is set on the input side instead.
+        builder.Append("-c:v ").Append(VideoEncoder).Append(' ');
+
+        var (qualityFlag, qualityValue) = ResolveQuality();
+        builder.Append(qualityFlag).Append(qualityValue.ToString(CultureInfo.InvariantCulture)).Append(' ');
+
+        if (VideoEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase))
+        {
+            // let VideoToolbox fall back to its software encoder; some Intel Macs have no hardware mjpeg
+            builder.Append("-allow_sw 1 ");
+        }
+
+        // pass source timestamps through unchanged so tile N maps to a known instant
+        builder.Append(EncodingHelper.GetVideoSyncOption("0", EncoderVersion).Trim()).Append(' ');
+
+        // image2 writes one file per frame, numbered by the pattern
+        builder.Append("-f image2 \"").Append(OutputPath).Append('"');
+    }
+
+    /// <summary>
+    /// Inserts the timestamp rebuild ahead of the interval selection, since <c>setpts</c> has to
+    /// rewrite the clock before <c>fps</c> samples against it.
+    /// </summary>
+    private string RenderFilterChain()
+    {
+        if (NormalizeTimestampsAtFrameRate <= 0)
+        {
+            return FilterChain;
+        }
+
+        var fpsFilter = FilterChain.IndexOf("fps=", StringComparison.Ordinal);
+        if (fpsFilter < 0)
+        {
+            throw new InvalidOperationException(
+                "Timestamp normalisation was requested but the filter chain selects no frame rate: " + FilterChain);
+        }
+
+        return FilterChain.Insert(
+            fpsFilter,
+            string.Create(CultureInfo.InvariantCulture, $"setpts=N/{NormalizeTimestampsAtFrameRate:F3}/TB,"));
+    }
+
+    /// <summary>
+    /// Translates <see cref="QualityScale"/> into the flag and value <see cref="VideoEncoder"/>
+    /// understands. FFmpeg's qscale runs 1 (best) to 31 (worst); the hardware mjpeg encoders
+    /// instead take a jpeg quality where higher is better, over differing ranges, so the scale has
+    /// to be inverted per encoder rather than passed through.
+    /// </summary>
+    private (string Flag, int Value) ResolveQuality()
+    {
+        var quality = Math.Clamp(QualityScale, BestQualityScale, WorstQualityScale);
+
+        if (VideoEncoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase)
+            || VideoEncoder.Contains("qsv", StringComparison.OrdinalIgnoreCase))
+        {
+            // jpeg quality, 0-100
+            return ("-global_quality:v ", 100 - ((quality - 1) * (100 / 30)));
+        }
+
+        if (VideoEncoder.Contains("rkmpp", StringComparison.OrdinalIgnoreCase))
+        {
+            // jpeg quality, but rkmpp caps at 99 rather than 100
+            return ("-qp_init:v ", 99 - ((quality - 1) * (99 / 30)));
+        }
+
+        if (VideoEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase))
+        {
+            // jpeg quality scaled to QP2LAMBDA, still spelled as qscale
+            return ("-qscale:v ", 118 - ((quality - 1) * (118 / 30)));
+        }
+
+        return ("-qscale:v ", quality);
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ValidateBinaryRequest.cs
+++ b/MediaBrowser.Controller/MediaEncoding/FFProcessing/Requests/ValidateBinaryRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+
+/// <summary>
+/// Asks a candidate executable to report its version, so the answer can decide whether that path
+/// is accepted. The version banner is written to standard output.
+/// </summary>
+public sealed record ValidateBinaryRequest : FFRequest
+{
+    /// <inheritdoc />
+    public override FFAction Action => FFAction.ValidateBinary;
+
+    /// <summary>Gets the executable to run. Not yet accepted, hence not resolvable from IFFPaths.</summary>
+    public required string BinaryPath { get; init; }
+
+    /// <inheritdoc />
+    public override string BinaryPathOverride => BinaryPath;
+
+    /// <inheritdoc />
+    public override void BuildArguments(StringBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        builder.Append("-version");
+    }
+}

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -243,7 +243,19 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// Sets the path to find FFmpeg.
         /// </summary>
         /// <returns>bool indicates whether a valid ffmpeg is found.</returns>
-        bool SetFFmpegPath();
+        Task<bool> SetFFmpegPathAsync();
+
+        /// <summary>
+        /// Run at startup to validate ffmpeg.
+        /// </summary>
+        /// <returns><c>true</c> if a valid ffmpeg is found.</returns>
+        /// <remarks>
+        /// Blocks the calling thread until validation completes. Retained so existing callers keep
+        /// working; the cost is bounded because this runs once at startup and the capability
+        /// interrogations take a couple of seconds, but prefer <see cref="SetFFmpegPathAsync"/>.
+        /// </remarks>
+        [Obsolete("Blocks the calling thread. Use SetFFmpegPathAsync instead.")]
+        bool SetFFmpegPath() => SetFFmpegPathAsync().GetAwaiter().GetResult();
 
         /// <summary>
         /// Gets the primary playlist of .vob files.

--- a/MediaBrowser.Controller/MediaEncoding/JobLogSink.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogSink.cs
@@ -15,7 +15,6 @@ namespace MediaBrowser.Controller.MediaEncoding;
 /// </summary>
 public sealed class JobLogSink : FFOutputSink
 {
-    private readonly JobLogger _jobLogger;
     private readonly EncodingJobInfo _state;
     private readonly Stream _target;
 
@@ -27,7 +26,6 @@ public sealed class JobLogSink : FFOutputSink
     /// <param name="target">The log file to write to. Owned by the caller.</param>
     public JobLogSink(ILogger logger, EncodingJobInfo state, Stream target)
     {
-        _jobLogger = new JobLogger(logger);
         _state = state;
         _target = target;
     }
@@ -46,7 +44,7 @@ public sealed class JobLogSink : FFOutputSink
     /// <returns>A task representing the write.</returns>
     public override async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
     {
-        _jobLogger.ParseLogLine(line, _state);
+        JobLogger.ParseLogLine(line, _state);
 
         await _target.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine + line), cancellationToken).ConfigureAwait(false);
 

--- a/MediaBrowser.Controller/MediaEncoding/JobLogSink.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogSink.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// Writes a delivery job's FFmpeg output to its log file and reports playback progress from the
+/// same lines. FFmpeg's status line carries the position and bitrate, so the log and the progress
+/// feed are one stream read once.
+/// </summary>
+public sealed class JobLogSink : FFOutputSink
+{
+    private readonly JobLogger _jobLogger;
+    private readonly EncodingJobInfo _state;
+    private readonly Stream _target;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JobLogSink"/> class.
+    /// </summary>
+    /// <param name="logger">The logger backing progress reporting.</param>
+    /// <param name="state">The job whose progress is updated.</param>
+    /// <param name="target">The log file to write to. Owned by the caller.</param>
+    public JobLogSink(ILogger logger, EncodingJobInfo state, Stream target)
+    {
+        _jobLogger = new JobLogger(logger);
+        _state = state;
+        _target = target;
+    }
+
+    /// <summary>
+    /// Records one line of FFmpeg output.
+    /// <para>
+    /// No guard against the target being closed underneath this: the runner awaits the drain before
+    /// completing the session, and the log stream is only disposed once that completes, so this
+    /// cannot run concurrently with disposal. If the runner ever stops awaiting the drain first,
+    /// that stops being true.
+    /// </para>
+    /// </summary>
+    /// <param name="line">The line, without its terminator.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the write.</returns>
+    public override async ValueTask WriteLineAsync(string line, CancellationToken cancellationToken)
+    {
+        _jobLogger.ParseLogLine(line, _state);
+
+        await _target.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine + line), cancellationToken).ConfigureAwait(false);
+
+        // Flush per line so the log is readable while the transcode is still running.
+        await _target.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override string GetRetainedText() => string.Empty;
+}

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -4,23 +4,12 @@
 
 using System;
 using System.Globalization;
-using System.IO;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.Controller.MediaEncoding
 {
     public class JobLogger
     {
-        private readonly ILogger _logger;
-
-        public JobLogger(ILogger logger)
-        {
-            _logger = logger;
-        }
-
-        public void ParseLogLine(string line, EncodingJobInfo state)
+        public static void ParseLogLine(string line, EncodingJobInfo state)
         {
             float? framerate = null;
             double? percent = null;

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -20,46 +20,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             _logger = logger;
         }
 
-        public async Task StartStreamingLog(EncodingJobInfo state, StreamReader reader, Stream target)
-        {
-            try
-            {
-                using (target)
-                using (reader)
-                {
-                    string line = await reader.ReadLineAsync().ConfigureAwait(false);
-                    while (line is not null && reader.BaseStream.CanRead)
-                    {
-                        ParseLogLine(line, state);
-
-                        var bytes = Encoding.UTF8.GetBytes(Environment.NewLine + line);
-
-                        // If ffmpeg process is closed, the state is disposed, so don't write to target in that case
-                        if (!target.CanWrite)
-                        {
-                            break;
-                        }
-
-                        await target.WriteAsync(bytes).ConfigureAwait(false);
-
-                        // Check again, the stream could have been closed
-                        if (!target.CanWrite)
-                        {
-                            break;
-                        }
-
-                        await target.FlushAsync().ConfigureAwait(false);
-                        line = await reader.ReadLineAsync().ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error reading ffmpeg log");
-            }
-        }
-
-        private void ParseLogLine(string line, EncodingJobInfo state)
+        public void ParseLogLine(string line, EncodingJobInfo state)
         {
             float? framerate = null;
             double? percent = null;

--- a/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
+++ b/MediaBrowser.Controller/MediaEncoding/JobLogger.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 
 namespace MediaBrowser.Controller.MediaEncoding
 {
-    public class JobLogger
+    public static class JobLogger
     {
         public static void ParseLogLine(string line, EncodingJobInfo state)
         {

--- a/MediaBrowser.Controller/MediaEncoding/StreamMode.cs
+++ b/MediaBrowser.Controller/MediaEncoding/StreamMode.cs
@@ -1,0 +1,25 @@
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// How much work a delivery request actually asks FFmpeg to do. Derived from which output codecs
+/// ended up as <c>copy</c>, which is settled by <c>EncodingHelper.TryStreamCopy</c> and can change
+/// again once a live stream is opened — so this is computed on demand rather than stored.
+/// </summary>
+public enum StreamMode
+{
+    /// <summary>
+    /// The video is re-encoded. The expensive case, and the only one that loads the CPU or GPU.
+    /// </summary>
+    Transcode,
+
+    /// <summary>
+    /// The video is copied but the audio is re-encoded, for clients that can play the video as-is
+    /// but not its soundtrack.
+    /// </summary>
+    DirectStream,
+
+    /// <summary>
+    /// Every stream is copied and only the container changes. I/O bound and cheap.
+    /// </summary>
+    Remux
+}

--- a/MediaBrowser.Controller/MediaEncoding/TranscodingJob.cs
+++ b/MediaBrowser.Controller/MediaEncoding/TranscodingJob.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
 using MediaBrowser.Model.Dto;
 using Microsoft.Extensions.Logging;
 
@@ -59,7 +60,7 @@ public sealed class TranscodingJob : IDisposable
     /// <summary>
     /// Gets or sets the process.
     /// </summary>
-    public Process? Process { get; set; }
+    public IFFSession? Session { get; set; }
 
     /// <summary>
     /// Gets or sets the active request count.
@@ -246,22 +247,14 @@ public sealed class TranscodingJob : IDisposable
             TranscodingThrottler?.Stop().GetAwaiter().GetResult();
             TranscodingSegmentCleaner?.Stop();
 
-            var process = Process;
-
             if (!HasExited)
             {
                 try
                 {
-                    _logger.LogInformation("Stopping ffmpeg process with q command for {Path}", Path);
+                    _logger.LogInformation("Stopping ffmpeg process for {Path}", Path);
 
-                    process!.StandardInput.WriteLine("q");
-
-                    // Need to wait because killing is asynchronous.
-                    if (!process.WaitForExit(5000))
-                    {
-                        _logger.LogInformation("Killing FFmpeg process for {Path}", Path);
-                        process.Kill();
-                    }
+                    // Sends q, waits the action's grace period, then kills the tree.
+                    Session!.StopAsync(CancellationToken.None).GetAwaiter().GetResult();
                 }
                 catch (InvalidOperationException)
                 {
@@ -274,8 +267,7 @@ public sealed class TranscodingJob : IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        Process?.Dispose();
-        Process = null;
+        Session = null;
         _killTimer?.Dispose();
         _killTimer = null;
         CancellationTokenSource?.Dispose();

--- a/MediaBrowser.Controller/MediaEncoding/TranscodingThrottler.cs
+++ b/MediaBrowser.Controller/MediaEncoding/TranscodingThrottler.cs
@@ -59,7 +59,7 @@ public class TranscodingThrottler : IDisposable
             try
             {
                 var resumeKey = _mediaEncoder.IsPkeyPauseSupported ? "u" : Environment.NewLine;
-                await _job.Process!.StandardInput.WriteAsync(resumeKey).ConfigureAwait(false);
+                await _job.Session!.SendKeyAsync(resumeKey, CancellationToken.None).ConfigureAwait(false);
                 _isPaused = false;
             }
             catch (Exception ex)
@@ -135,7 +135,7 @@ public class TranscodingThrottler : IDisposable
 
             try
             {
-                await _job.Process!.StandardInput.WriteAsync(pauseKey).ConfigureAwait(false);
+                await _job.Session!.SendKeyAsync(pauseKey, CancellationToken.None).ConfigureAwait(false);
                 _isPaused = true;
             }
             catch (Exception ex)

--- a/MediaBrowser.Controller/Streaming/StreamState.cs
+++ b/MediaBrowser.Controller/Streaming/StreamState.cs
@@ -51,6 +51,36 @@ public class StreamState : EncodingJobInfo, IDisposable
     public VideoRequestDto? VideoRequest => Request as VideoRequestDto;
 
     /// <summary>
+    /// Gets how much work this request asks of FFmpeg.
+    /// <para>
+    /// Computed rather than stored: <c>TryStreamCopy</c> runs once while the state is built and
+    /// again after a live stream is opened, and the HLS master-playlist builder deliberately
+    /// rewrites <see cref="EncodingJobInfo.OutputVideoCodec"/> and restores it while emitting
+    /// variant entries. A cached value would be wrong in both cases.
+    /// </para>
+    /// </summary>
+    public StreamMode StreamMode
+    {
+        get
+        {
+            var audioCopied = EncodingHelper.IsCopyCodec(OutputAudioCodec);
+
+            if (VideoRequest is null)
+            {
+                // Audio-only: there is no video to copy, so copying the audio is the whole job.
+                return audioCopied ? StreamMode.Remux : StreamMode.Transcode;
+            }
+
+            if (!EncodingHelper.IsCopyCodec(OutputVideoCodec))
+            {
+                return StreamMode.Transcode;
+            }
+
+            return audioCopied ? StreamMode.Remux : StreamMode.DirectStream;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the direct stream provider.
     /// </summary>
     /// <remarks>

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -14,6 +14,8 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.MediaEncoding.Encoder;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
@@ -30,6 +32,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
         private readonly IMediaEncoder _mediaEncoder;
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly IPathManager _pathManager;
+        private readonly IFFRunner _ffRunner;
 
         private readonly AsyncKeyedLocker<string> _semaphoreLocks = new(o =>
         {
@@ -45,18 +48,21 @@ namespace MediaBrowser.MediaEncoding.Attachments
         /// <param name="mediaEncoder">The <see cref="IMediaEncoder"/>.</param>
         /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/>.</param>
         /// <param name="pathManager">The <see cref="IPathManager"/>.</param>
+        /// <param name="ffRunner">The <see cref="IFFRunner"/>.</param>
         public AttachmentExtractor(
             ILogger<AttachmentExtractor> logger,
             IFileSystem fileSystem,
             IMediaEncoder mediaEncoder,
             IMediaSourceManager mediaSourceManager,
-            IPathManager pathManager)
+            IPathManager pathManager,
+            IFFRunner ffRunner)
         {
             _logger = logger;
             _fileSystem = fileSystem;
             _mediaEncoder = mediaEncoder;
             _mediaSourceManager = mediaSourceManager;
             _pathManager = pathManager;
+            _ffRunner = ffRunner;
         }
 
         /// <inheritdoc />
@@ -139,7 +145,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
             {
                 Directory.CreateDirectory(outputFolder);
 
-                var dumpArgs = new StringBuilder();
+                var targets = new List<AttachmentTarget>();
                 var missingPaths = new List<string>();
                 foreach (var attachment in mediaSource.MediaAttachments)
                 {
@@ -156,11 +162,7 @@ namespace MediaBrowser.MediaEncoding.Attachments
                         continue;
                     }
 
-                    dumpArgs.AppendFormat(
-                        CultureInfo.InvariantCulture,
-                        "-dump_attachment:{0} \"{1}\" ",
-                        attachment.Index,
-                        EncodingUtils.NormalizePath(attachmentPath));
+                    targets.Add(new AttachmentTarget(attachment.Index, EncodingUtils.NormalizePath(attachmentPath)));
                     missingPaths.Add(attachmentPath);
                 }
 
@@ -170,51 +172,20 @@ namespace MediaBrowser.MediaEncoding.Attachments
                     return;
                 }
 
-                var hasVideoOrAudioStream = mediaSource.MediaStreams
-                    .Any(s => s.Type == MediaStreamType.Video || s.Type == MediaStreamType.Audio);
-                var processArgs = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "{0}{1} -i {2} {3}",
-                    dumpArgs,
-                    inputPath.EndsWith(".concat\"", StringComparison.OrdinalIgnoreCase) ? "-f concat -safe 0" : string.Empty,
-                    inputPath,
-                    hasVideoOrAudioStream ? "-t 0 -f null null" : string.Empty);
-
-                int exitCode;
-
-                using (var process = new Process
-                {
-                    StartInfo = new ProcessStartInfo
+                var result = await _ffRunner.RunAsync(
+                    new AttachmentRequest
                     {
-                        Arguments = processArgs,
-                        FileName = _mediaEncoder.EncoderPath,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden,
-                        ErrorDialog = false
+                        Input = inputPath,
+                        Targets = targets,
+                        IsConcatPlaylist = inputPath.EndsWith(".concat\"", StringComparison.OrdinalIgnoreCase)
                     },
-                    EnableRaisingEvents = true
-                })
-                {
-                    _logger.LogInformation("{File} {Arguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
+                    cancellationToken).ConfigureAwait(false);
 
-                    process.Start();
-
-                    try
-                    {
-                        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-                        exitCode = process.ExitCode;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        process.Kill(true);
-                        exitCode = -1;
-                    }
-                }
+                var exitCode = result.ExitCode;
 
                 var failed = false;
 
-                if (exitCode != 0 && (hasVideoOrAudioStream || exitCode != 1))
+                if (exitCode != 0)
                 {
                     failed = true;
 
@@ -285,65 +256,34 @@ namespace MediaBrowser.MediaEncoding.Attachments
                 // doesn't fail trying to open an output with no streams. It will exit with code 1
                 // ("at least one output file must be specified") which is expected and harmless
                 // since we only need the -dump_attachment side effect.
-                var hasVideoOrAudioStream = mediaSource.MediaStreams
-                    .Any(s => s.Type == MediaStreamType.Video || s.Type == MediaStreamType.Audio);
-                var processArgs = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "-dump_attachment:t \"\" -y {0} -i {1} {2}",
-                    inputPath.EndsWith(".concat\"", StringComparison.OrdinalIgnoreCase) ? "-f concat -safe 0" : string.Empty,
-                    inputPath,
-                    hasVideoOrAudioStream ? "-t 0 -f null null" : string.Empty);
-
-                int exitCode;
-
-                using (var process = new Process
-                {
-                    StartInfo = new ProcessStartInfo
+                var result = await _ffRunner.RunAsync(
+                    new AttachmentRequest
                     {
-                        Arguments = processArgs,
-                        FileName = _mediaEncoder.EncoderPath,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden,
+                        Input = inputPath,
+
+                        // No explicit targets: dump every attachment under its embedded filename,
+                        // which -dump_attachment:t writes relative to the current directory.
                         WorkingDirectory = outputFolder,
-                        ErrorDialog = false
+                        IsConcatPlaylist = inputPath.EndsWith(".concat\"", StringComparison.OrdinalIgnoreCase)
                     },
-                    EnableRaisingEvents = true
-                })
-                {
-                    _logger.LogInformation("{File} {Arguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
+                    cancellationToken).ConfigureAwait(false);
 
-                    process.Start();
-
-                    try
-                    {
-                        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-                        exitCode = process.ExitCode;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        process.Kill(true);
-                        exitCode = -1;
-                    }
-                }
+                var exitCode = result.ExitCode;
 
                 var failed = false;
 
                 if (exitCode != 0)
                 {
-                    if (hasVideoOrAudioStream || exitCode != 1)
-                    {
-                        failed = true;
+                    failed = true;
 
-                        _logger.LogWarning("Deleting extracted attachments {Path} due to failure: {ExitCode}", outputFolder, exitCode);
-                        try
-                        {
-                            Directory.Delete(outputFolder);
-                        }
-                        catch (IOException ex)
-                        {
-                            _logger.LogError(ex, "Error deleting extracted attachments {Path}", outputFolder);
-                        }
+                    _logger.LogWarning("Deleting extracted attachments {Path} due to failure: {ExitCode}", outputFolder, exitCode);
+                    try
+                    {
+                        Directory.Delete(outputFolder);
+                    }
+                    catch (IOException ex)
+                    {
+                        _logger.LogError(ex, "Error deleting extracted attachments {Path}", outputFolder);
                     }
                 }
 
@@ -418,68 +358,33 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new ArgumentException("Path can't be a root directory.", nameof(outputPath)));
 
-            var hasVideoOrAudioStream = mediaSource.MediaStreams
-                .Any(s => s.Type == MediaStreamType.Video || s.Type == MediaStreamType.Audio);
-            var processArgs = string.Format(
-                CultureInfo.InvariantCulture,
-                "-dump_attachment:{1} \"{2}\" -i {0} {3}",
-                inputPath,
-                attachmentStreamIndex,
-                EncodingUtils.NormalizePath(outputPath),
-                hasVideoOrAudioStream ? "-t 0 -f null null" : string.Empty);
-
-            int exitCode;
-
-            using (var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
+            var result = await _ffRunner.RunAsync(
+                new AttachmentRequest
                 {
-                    Arguments = processArgs,
-                    FileName = _mediaEncoder.EncoderPath,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false
+                    Input = inputPath,
+                    Targets = [new AttachmentTarget(attachmentStreamIndex, EncodingUtils.NormalizePath(outputPath))]
                 },
-                EnableRaisingEvents = true
-            })
-            {
-                _logger.LogInformation("{File} {Arguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
+                cancellationToken).ConfigureAwait(false);
 
-                process.Start();
-
-                try
-                {
-                    await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-                    exitCode = process.ExitCode;
-                }
-                catch (OperationCanceledException)
-                {
-                    process.Kill(true);
-                    exitCode = -1;
-                }
-            }
+            var exitCode = result.ExitCode;
 
             var failed = false;
 
             if (exitCode != 0)
             {
-                if (hasVideoOrAudioStream || exitCode != 1)
-                {
-                    failed = true;
+                failed = true;
 
-                    _logger.LogWarning("Deleting extracted attachment {Path} due to failure: {ExitCode}", outputPath, exitCode);
-                    try
+                _logger.LogWarning("Deleting extracted attachment {Path} due to failure: {ExitCode}", outputPath, exitCode);
+                try
+                {
+                    if (File.Exists(outputPath))
                     {
-                        if (File.Exists(outputPath))
-                        {
-                            _fileSystem.DeleteFile(outputPath);
-                        }
+                        _fileSystem.DeleteFile(outputPath);
                     }
-                    catch (IOException ex)
-                    {
-                        _logger.LogError(ex, "Error deleting extracted attachment {Path}", outputPath);
-                    }
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogError(ex, "Error deleting extracted attachment {Path}", outputPath);
                 }
             }
 

--- a/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
+++ b/MediaBrowser.MediaEncoding/Attachments/AttachmentExtractor.cs
@@ -335,7 +335,6 @@ namespace MediaBrowser.MediaEncoding.Attachments
                 {
                     await ExtractAttachmentInternal(
                         _mediaEncoder.GetInputArgument(inputFile, mediaSource),
-                        mediaSource,
                         mediaAttachment.Index,
                         attachmentPath,
                         cancellationToken).ConfigureAwait(false);
@@ -347,7 +346,6 @@ namespace MediaBrowser.MediaEncoding.Attachments
 
         private async Task ExtractAttachmentInternal(
             string inputPath,
-            MediaSourceInfo mediaSource,
             int attachmentStreamIndex,
             string outputPath,
             CancellationToken cancellationToken)

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -4,12 +4,16 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using Microsoft.Extensions.Logging;
 
 namespace MediaBrowser.MediaEncoding.Encoder
@@ -193,12 +197,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private readonly string _encoderPath;
 
+        private readonly IFFRunner? _ffRunner;
+
         private readonly Version _minFFmpegMultiThreadedCli = new Version(7, 0);
 
-        public EncoderValidator(ILogger logger, string encoderPath)
+        public EncoderValidator(ILogger logger, string encoderPath, IFFRunner? ffRunner = null)
         {
             _logger = logger;
             _encoderPath = encoderPath;
+
+            // Null while validating a candidate path: nothing is committed to IFFPaths yet, so the
+            // runner cannot resolve a binary. Only ValidateVersion runs in that state.
+            _ffRunner = ffRunner;
         }
 
         private enum Codec
@@ -218,12 +228,35 @@ namespace MediaBrowser.MediaEncoding.Encoder
         [GeneratedRegex(@"((?<name>lib\w+)\s+(?<major>[0-9]+)\.\s*(?<minor>[0-9]+))", RegexOptions.Multiline)]
         private static partial Regex LibraryRegex();
 
-        public bool ValidateVersion()
+        public async Task<bool> ValidateVersionAsync()
         {
-            string output;
+            var output = string.Empty;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-version", false, null);
+                // Names its own binary: this runs to decide whether that path is usable, so there
+                // is nothing committed to IFFPaths for the runner to resolve.
+                var result = await _ffRunner!.RunAsync(
+                    new ValidateBinaryRequest
+                    {
+                        BinaryPath = _encoderPath,
+                        Stdout = async (stdout, ct) =>
+                        {
+                            using var reader = new StreamReader(stdout);
+                            output = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+                        }
+                    },
+                    CancellationToken.None).ConfigureAwait(false);
+
+                if (!result.Succeeded)
+                {
+                    _logger.LogError(
+                        "FFmpeg validation: {Path} did not report a version ({Reason}). {Stderr}",
+                        _encoderPath,
+                        result.StopReason,
+                        result.Stderr);
+
+                    return false;
+                }
             }
             catch (Exception ex)
             {
@@ -291,26 +324,42 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return true;
         }
 
-        public IEnumerable<string> GetDecoders() => GetCodecs(Codec.Decoder);
+        public Task<IEnumerable<string>> GetDecodersAsync() => GetCodecsAsync(Codec.Decoder);
 
-        public IEnumerable<string> GetEncoders() => GetCodecs(Codec.Encoder);
+        public Task<IEnumerable<string>> GetEncodersAsync() => GetCodecsAsync(Codec.Encoder);
 
-        public IEnumerable<string> GetHwaccels() => GetHwaccelTypes();
+        public Task<IEnumerable<string>> GetHwaccelsAsync() => GetHwaccelTypesAsync();
 
-        public IEnumerable<string> GetFilters() => GetFFmpegFilters();
+        public Task<IEnumerable<string>> GetFiltersAsync() => GetFFmpegFiltersAsync();
 
-        public IDictionary<FilterOptionType, bool> GetFiltersWithOption() => _filterOptionsDict
-            .ToDictionary(item => item.Key, item => CheckFilterWithOption(item.Value.Item1, item.Value.Item2));
+        public async Task<IDictionary<FilterOptionType, bool>> GetFiltersWithOptionAsync()
+        {
+            var results = new Dictionary<FilterOptionType, bool>();
+            foreach (var (key, (filter, option)) in _filterOptionsDict)
+            {
+                results[key] = await CheckFilterWithOptionAsync(filter, option).ConfigureAwait(false);
+            }
 
-        public IDictionary<BitStreamFilterOptionType, bool> GetBitStreamFiltersWithOption() => _bsfOptionsDict
-            .ToDictionary(item => item.Key, item => CheckBitStreamFilterWithOption(item.Value.Item1, item.Value.Item2));
+            return results;
+        }
 
-        public Version? GetFFmpegVersion()
+        public async Task<IDictionary<BitStreamFilterOptionType, bool>> GetBitStreamFiltersWithOptionAsync()
+        {
+            var results = new Dictionary<BitStreamFilterOptionType, bool>();
+            foreach (var (key, (filter, option)) in _bsfOptionsDict)
+            {
+                results[key] = await CheckBitStreamFilterWithOptionAsync(filter, option).ConfigureAwait(false);
+            }
+
+            return results;
+        }
+
+        public async Task<Version?> GetFFmpegVersionAsync()
         {
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-version", false, null);
+                output = await InterrogateAsync("-version", false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -400,7 +449,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return map;
         }
 
-        public bool CheckVaapiDeviceByDriverName(string driverName, string renderNodePath)
+        public async Task<bool> CheckVaapiDeviceByDriverNameAsync(string driverName, string renderNodePath)
         {
             if (!OperatingSystem.IsLinux())
             {
@@ -414,7 +463,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             try
             {
-                var output = GetProcessOutput(_encoderPath, "-v verbose -hide_banner -init_hw_device vaapi=va:" + renderNodePath, true, null);
+                // Two things here are deliberate and easy to undo by accident.
+                //
+                // The explicit -v verbose overrides the level the runner would otherwise derive from
+                // the server's log level. The driver name is only printed while the device is being
+                // initialised, and at the default level of warning that line is never emitted, so the
+                // match below would fail on hardware that is in fact present.
+                //
+                // The answer is the log, not the exit code. There is no input or output file, so
+                // FFmpeg initialises the device and then exits non-zero with rc=234 about on a working
+                // node and on a missing one alike. Only the content distinguishes them, which is why
+                // this reads the output rather than calling InterrogationSucceeds.
+                var output = await InterrogateAsync("-v verbose -init_hw_device vaapi=va:" + renderNodePath, true).ConfigureAwait(false);
                 return output.Contains(driverName, StringComparison.Ordinal);
             }
             catch (Exception ex)
@@ -424,7 +484,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
         }
 
-        public bool CheckVulkanDrmDeviceByExtensionName(string renderNodePath, string[] vulkanExtensions)
+        public async Task<bool> CheckVulkanDrmDeviceByExtensionNameAsync(string renderNodePath, string[] vulkanExtensions)
         {
             if (!OperatingSystem.IsLinux())
             {
@@ -438,8 +498,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             try
             {
-                var command = "-v verbose -hide_banner -init_hw_device drm=dr:" + renderNodePath + " -init_hw_device vulkan=vk@dr";
-                var output = GetProcessOutput(_encoderPath, command, true, null);
+                // Same two properties as the vaapi check above: -v verbose is required for the device
+                // log to be emitted at all, and the verdict comes from that log rather than from the
+                // exit code, which is non-zero either way for want of an output file.
+                //
+                // The devices are chained. "drm=dr:<node>" opens the render node under the alias dr,
+                // then "vulkan=vk@dr" derives a Vulkan device *from* that one — the @ is what makes
+                // this test the Vulkan driver backing this specific node instead of whichever device
+                // the loader would have picked on its own.
+                var command = "-v verbose -init_hw_device drm=dr:" + renderNodePath + " -init_hw_device vulkan=vk@dr";
+                var output = await InterrogateAsync(command, true).ConfigureAwait(false);
+
+                // Every extension must be present; the caller asks about a set it needs in full.
                 foreach (string ext in vulkanExtensions)
                 {
                     if (!output.Contains(ext, StringComparison.Ordinal))
@@ -463,12 +533,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return ApplePlatformHelper.HasAv1HardwareAccel(_logger);
         }
 
-        private IEnumerable<string> GetHwaccelTypes()
+        private async Task<IEnumerable<string>> GetHwaccelTypesAsync()
         {
             string? output = null;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-hwaccels", false, null);
+                output = await InterrogateAsync("-hwaccels", false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -486,7 +556,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return found;
         }
 
-        public bool CheckFilterWithOption(string filter, string option)
+        public async Task<bool> CheckFilterWithOptionAsync(string filter, string option)
         {
             if (string.IsNullOrEmpty(filter) || string.IsNullOrEmpty(option))
             {
@@ -496,7 +566,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-h filter=" + filter, false, null);
+                output = await InterrogateAsync("-h filter=" + filter, false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -504,6 +574,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 return false;
             }
 
+            // Two questions, in order. "-h filter=x" prints help for a filter it knows and a bare
+            // "Unknown filter" line for one it does not, so the header confirms the filter exists
+            // before the option is looked for in its parameter list. Without that first check a
+            // missing filter and a present filter lacking the option are the same answer, and the
+            // warning below would name the wrong problem.
             if (output.Contains("Filter " + filter, StringComparison.Ordinal))
             {
                 return output.Contains(option, StringComparison.Ordinal);
@@ -514,7 +589,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return false;
         }
 
-        public bool CheckBitStreamFilterWithOption(string filter, string option)
+        public async Task<bool> CheckBitStreamFilterWithOptionAsync(string filter, string option)
         {
             if (string.IsNullOrEmpty(filter) || string.IsNullOrEmpty(option))
             {
@@ -524,7 +599,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-h bsf=" + filter, false, null);
+                output = await InterrogateAsync("-h bsf=" + filter, false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -532,6 +607,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 return false;
             }
 
+            // Same two-stage shape as CheckFilterWithOptionAsync, against "-h bsf=" and the header
+            // FFmpeg prints for a bit stream filter.
             if (output.Contains("Bit stream filter " + filter, StringComparison.Ordinal))
             {
                 return output.Contains(option, StringComparison.Ordinal);
@@ -542,7 +619,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return false;
         }
 
-        public bool CheckSupportedRuntimeKey(string keyDesc, Version? ffmpegVersion)
+        public async Task<bool> CheckSupportedRuntimeKeyAsync(string keyDesc, Version? ffmpegVersion)
         {
             if (string.IsNullOrEmpty(keyDesc))
             {
@@ -552,9 +629,26 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                // With multi-threaded cli support, FFmpeg 7 is less sensitive to keyboard input
+                // Asks FFmpeg which keys it will respond to while running, by giving it something to
+                // do and then interrupting it: the runner writes RuntimeKeyProbeRequest.QueryKey ("?")
+                // to stdin, and FFmpeg answers with its key list on stderr.
+                //
+                // The work is a 1x1 null source encoded to nothing, so the run costs nothing while it
+                // lasts. The duration only has to outlive the write — the process is torn down as soon
+                // as the answer is in hand, never actually running for the hours nominated here.
                 var duration = ffmpegVersion >= _minFFmpegMultiThreadedCli ? 10000 : 1000;
-                output = GetProcessOutput(_encoderPath, $"-hide_banner -f lavfi -i nullsrc=s=1x1:d={duration} -f null -", true, "?");
+                var runtime = await _ffRunner!.RunAsync(
+                    new RuntimeKeyProbeRequest
+                    {
+                        Arguments = $"-f lavfi -i nullsrc=s=1x1:d={duration} -f null -",
+
+                        // Complete, not a trailing window: the key list is printed when the query is
+                        // answered and is then followed by ordinary encoding progress, so a window
+                        // sized for diagnosing a failure would scroll the answer away.
+                        Stderr = FFOutputSink.Complete()
+                    },
+                    CancellationToken.None).ConfigureAwait(false);
+                output = runtime.Stderr;
             }
             catch (Exception ex)
             {
@@ -565,23 +659,47 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return output.Contains(keyDesc, StringComparison.Ordinal);
         }
 
-        public bool CheckSupportedHwaccelFlag(string flag)
+        /// <summary>
+        /// Tests whether the encoder accepts a given <c>-hwaccel_flags</c> value, by asking it to do
+        /// trivial work with that flag set and seeing whether it agrees to start.
+        /// </summary>
+        /// <remarks>
+        /// Unlike the device checks above, the verdict here is the exit code and the output is
+        /// discarded: FFmpeg rejects an unknown flag while parsing options, before it does anything.
+        /// Measured against jellyfin-ffmpeg 7.1.4, a known flag exits 0 and an unknown one exits 234.
+        /// </remarks>
+        /// <param name="flag">The <c>-hwaccel_flags</c> value to test, without its leading <c>+</c>.</param>
+        /// <returns><c>true</c> if the encoder accepts the flag; otherwise, <c>false</c>.</returns>
+        public async Task<bool> CheckSupportedHwaccelFlagAsync(string flag)
         {
-            return !string.IsNullOrEmpty(flag) && GetProcessExitCode(_encoderPath, $"-loglevel quiet -hwaccel_flags +{flag} -hide_banner -f lavfi -i nullsrc=s=1x1:d=100 -f null -");
+            return !string.IsNullOrEmpty(flag)
+                && await InterrogationSucceedsAsync($"-hwaccel_flags +{flag} -f lavfi -i nullsrc=s=1x1:d=100 -f null -").ConfigureAwait(false);
         }
 
-        public bool CheckSupportedProberOption(string option, string proberPath)
+        /// <summary>
+        /// Tests whether ffprobe — not ffmpeg, hence <c>probeOnly</c> — recognises an option, so that
+        /// options absent from some builds are only ever passed to a prober that accepts them.
+        /// </summary>
+        /// <remarks>
+        /// Also decided by exit code. The option is named with no value against a 1x1 null source: a
+        /// recognised option exits 0 and an unrecognised one exits 1, since ffprobe fails on the
+        /// option itself long before the source matters.
+        /// </remarks>
+        /// <param name="option">The option name to test, without its leading <c>-</c>.</param>
+        /// <returns><c>true</c> if the prober recognises the option; otherwise, <c>false</c>.</returns>
+        public async Task<bool> CheckSupportedProberOptionAsync(string option)
         {
-            return !string.IsNullOrEmpty(option) && GetProcessExitCode(proberPath, $"-loglevel quiet -f lavfi -i nullsrc=s=1x1:d=1 -{option}");
+            return !string.IsNullOrEmpty(option)
+                && await InterrogationSucceedsAsync($"-f lavfi -i nullsrc=s=1x1:d=1 -{option}", probeOnly: true).ConfigureAwait(false);
         }
 
-        private IEnumerable<string> GetCodecs(Codec codec)
+        private async Task<IEnumerable<string>> GetCodecsAsync(Codec codec)
         {
             string codecstr = codec == Codec.Encoder ? "encoders" : "decoders";
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-" + codecstr, false, null);
+                output = await InterrogateAsync("-" + codecstr, false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -606,12 +724,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return found;
         }
 
-        private IEnumerable<string> GetFFmpegFilters()
+        private async Task<IEnumerable<string>> GetFFmpegFiltersAsync()
         {
             string output;
             try
             {
-                output = GetProcessOutput(_encoderPath, "-filters", false, null);
+                output = await InterrogateAsync("-filters", false).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -634,70 +752,49 @@ namespace MediaBrowser.MediaEncoding.Encoder
             return found;
         }
 
-        private string GetProcessOutput(string path, string arguments, bool readStdErr, string? testKey)
+        /// <summary>
+        /// Runs an interrogation through the shared runner and returns the stream the caller reads.
+        /// Retains all stderr: these probes answer questions by scraping their own output, so a
+        /// truncated middle would silently change the answer.
+        /// </summary>
+        private async Task<string> InterrogateAsync(string arguments, bool readStdErr, bool probeOnly = false)
         {
-            var redirectStandardIn = !string.IsNullOrEmpty(testKey);
-            using (var process = new Process
+            var request = new CapabilitiesRequest
             {
-                StartInfo = new ProcessStartInfo(path, arguments)
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false,
-                    RedirectStandardInput = redirectStandardIn,
-                    StandardOutputEncoding = Encoding.UTF8,
-                    RedirectStandardOutput = true,
-                    StandardErrorEncoding = Encoding.UTF8,
-                    RedirectStandardError = true
-                }
-            })
+                Arguments = arguments,
+                ProbeOnly = probeOnly,
+                Stderr = FFOutputSink.Complete()
+            };
+
+            if (readStdErr)
             {
-                _logger.LogDebug("Running {Path} {Arguments}", path, arguments);
-
-                process.Start();
-
-                if (redirectStandardIn)
-                {
-                    using var writer = process.StandardInput;
-                    writer.Write(testKey);
-                }
-
-                // Drain both streams concurrently to prevent pipe hanging, see #17429
-                using var standardOutput = process.StandardOutput;
-                using var standardError = process.StandardError;
-                var standardOutputTask = standardOutput.ReadToEndAsync();
-                var standardErrorTask = standardError.ReadToEndAsync();
-                process.WaitForExit();
-                Task.WaitAll(standardOutputTask, standardErrorTask);
-
-                return (readStdErr ? standardErrorTask : standardOutputTask).GetAwaiter().GetResult();
+                var stderrResult = await _ffRunner!.RunAsync(request, CancellationToken.None).ConfigureAwait(false);
+                return stderrResult.Stderr;
             }
+
+            var output = string.Empty;
+            await _ffRunner!.RunAsync(
+                request with
+                {
+                    Stdout = async (stdout, ct) =>
+                    {
+                        using var reader = new StreamReader(stdout);
+                        output = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+                    }
+                },
+                CancellationToken.None).ConfigureAwait(false);
+
+            return output;
         }
 
-        private bool GetProcessExitCode(string path, string arguments)
+        /// <summary>Runs an interrogation whose answer is only whether FFmpeg accepted it.</summary>
+        private async Task<bool> InterrogationSucceedsAsync(string arguments, bool probeOnly = false)
         {
-            using var process = new Process();
-            process.StartInfo = new ProcessStartInfo(path, arguments)
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-                WindowStyle = ProcessWindowStyle.Hidden,
-                ErrorDialog = false
-            };
-            _logger.LogDebug("Running {Path} {Arguments}", path, arguments);
+            var result = await _ffRunner!.RunAsync(
+                new CapabilitiesRequest { Arguments = arguments, ProbeOnly = probeOnly },
+                CancellationToken.None).ConfigureAwait(false);
 
-            try
-            {
-                process.Start();
-                process.WaitForExit();
-                return process.ExitCode == 0;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Running {Path} {Arguments} failed with exception {Exception}", path, arguments, ex.Message);
-                return false;
-            }
+            return result.Succeeded;
         }
 
         [GeneratedRegex("^\\s\\S{6}\\s(?<codec>[\\w|-]+)\\s+.+$", RegexOptions.Multiline)]

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -197,17 +197,16 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private readonly string _encoderPath;
 
-        private readonly IFFRunner? _ffRunner;
+        private readonly IFFRunner _ffRunner;
 
         private readonly Version _minFFmpegMultiThreadedCli = new Version(7, 0);
 
-        public EncoderValidator(ILogger logger, string encoderPath, IFFRunner? ffRunner = null)
+        public EncoderValidator(ILogger logger, string encoderPath, IFFRunner ffRunner)
         {
+            ArgumentNullException.ThrowIfNull(ffRunner);
+
             _logger = logger;
             _encoderPath = encoderPath;
-
-            // Null while validating a candidate path: nothing is committed to IFFPaths yet, so the
-            // runner cannot resolve a binary. Only ValidateVersion runs in that state.
             _ffRunner = ffRunner;
         }
 
@@ -235,7 +234,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 // Names its own binary: this runs to decide whether that path is usable, so there
                 // is nothing committed to IFFPaths for the runner to resolve.
-                ArgumentNullException.ThrowIfNull(_ffRunner);
                 var result = await _ffRunner.RunAsync(
                     new ValidateBinaryRequest
                     {
@@ -638,7 +636,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 // lasts. The duration only has to outlive the write — the process is torn down as soon
                 // as the answer is in hand, never actually running for the hours nominated here.
                 var duration = ffmpegVersion >= _minFFmpegMultiThreadedCli ? 10000 : 1000;
-                var runtime = await _ffRunner!.RunAsync(
+                var runtime = await _ffRunner.RunAsync(
                     new RuntimeKeyProbeRequest
                     {
                         Arguments = $"-f lavfi -i nullsrc=s=1x1:d={duration} -f null -",
@@ -769,12 +767,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             if (readStdErr)
             {
-                var stderrResult = await _ffRunner!.RunAsync(request, CancellationToken.None).ConfigureAwait(false);
+                var stderrResult = await _ffRunner.RunAsync(request, CancellationToken.None).ConfigureAwait(false);
                 return stderrResult.Stderr;
             }
 
             var output = string.Empty;
-            await _ffRunner!.RunAsync(
+            await _ffRunner.RunAsync(
                 request with
                 {
                     Stdout = async (stdout, ct) =>
@@ -791,7 +789,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// <summary>Runs an interrogation whose answer is only whether FFmpeg accepted it.</summary>
         private async Task<bool> InterrogationSucceedsAsync(string arguments, bool probeOnly = false)
         {
-            var result = await _ffRunner!.RunAsync(
+            var result = await _ffRunner.RunAsync(
                 new CapabilitiesRequest { Arguments = arguments, ProbeOnly = probeOnly },
                 CancellationToken.None).ConfigureAwait(false);
 

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -235,7 +235,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             {
                 // Names its own binary: this runs to decide whether that path is usable, so there
                 // is nothing committed to IFFPaths for the runner to resolve.
-                var result = await _ffRunner!.RunAsync(
+                ArgumentNullException.ThrowIfNull(_ffRunner);
+                var result = await _ffRunner.RunAsync(
                     new ValidateBinaryRequest
                     {
                         BinaryPath = _encoderPath,

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -23,6 +23,8 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.MediaEncoding.Probing;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
@@ -52,6 +54,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         internal const int DefaultHdrImageExtractionTimeout = 20000;
 
+        /// <summary>
+        /// Frame rate assumed when the source does not report one, used to rebuild trickplay timestamps.
+        /// </summary>
+        private const float FallbackFrameRate = 30;
+
         private readonly ILogger<MediaEncoder> _logger;
         private readonly IServerConfigurationManager _configurationManager;
         private readonly IFileSystem _fileSystem;
@@ -62,9 +69,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private readonly string _startupOptionFFmpegPath;
 
         private readonly AsyncNonKeyedLocker _thumbnailResourcePool;
-
-        private readonly Lock _runningProcessesLock = new();
-        private readonly List<ProcessWrapper> _runningProcesses = new List<ProcessWrapper>();
 
         // MediaEncoder is registered as a Singleton
         private readonly JsonSerializerOptions _jsonSerializerOptions;
@@ -86,8 +90,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         private bool _isVaapiDeviceSupportVulkanDrmModifier = false;
         private bool _isVaapiDeviceSupportVulkanDrmInterop = false;
 
-        private bool _canSetProcessPriority = true;
-
         private bool _isVideoToolboxAv1DecodeAvailable = false;
 
         private static string[] _vulkanImageDrmFmtModifierExts =
@@ -103,9 +105,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
             "VK_EXT_external_memory_host"
         };
 
+        private readonly IFFPaths _ffPaths;
+        private readonly IFFRunner _ffRunner;
+
         private Version _ffmpegVersion = null;
-        private string _ffmpegPath = string.Empty;
-        private string _ffprobePath;
         private int _threads;
 
         public MediaEncoder(
@@ -115,8 +118,12 @@ namespace MediaBrowser.MediaEncoding.Encoder
             IBlurayExaminer blurayExaminer,
             ILocalizationManager localization,
             IConfiguration config,
-            IServerConfigurationManager serverConfig)
+            IServerConfigurationManager serverConfig,
+            IFFPaths ffPaths,
+            IFFRunner ffRunner)
         {
+            _ffPaths = ffPaths;
+            _ffRunner = ffRunner;
             _logger = logger;
             _configurationManager = configurationManager;
             _fileSystem = fileSystem;
@@ -140,10 +147,10 @@ namespace MediaBrowser.MediaEncoding.Encoder
         }
 
         /// <inheritdoc />
-        public string EncoderPath => _ffmpegPath;
+        public string EncoderPath => _ffPaths.EncoderPath;
 
         /// <inheritdoc />
-        public string ProbePath => _ffprobePath;
+        public string ProbePath => _ffPaths.ProbePath;
 
         /// <inheritdoc />
         public Version EncoderVersion => _ffmpegVersion;
@@ -168,16 +175,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         public bool IsVideoToolboxAv1DecodeAvailable => _isVideoToolboxAv1DecodeAvailable;
 
-        [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
-        private static partial Regex FfprobePathRegex();
-
         /// <summary>
         /// Run at startup to validate ffmpeg.
         /// Sets global variables FFmpegPath.
         /// Precedence is: CLI/Env var > Config > $PATH.
         /// </summary>
         /// <returns>bool indicates whether a valid ffmpeg is found.</returns>
-        public bool SetFFmpegPath()
+        public async Task<bool> SetFFmpegPathAsync()
         {
             var skipValidation = _config.GetFFmpegSkipValidation();
             if (skipValidation)
@@ -202,40 +206,37 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
-            if (!ValidatePath(ffmpegPath))
+            if (!await ValidatePathAsync(ffmpegPath).ConfigureAwait(false))
             {
-                _ffmpegPath = null;
+                _ffPaths.SetEncoderPath(string.Empty);
                 _logger.LogError("FFmpeg: Path set by {FfmpegPathSetMethodText} is invalid", ffmpegPathSetMethodText);
                 return false;
             }
 
             // Write the FFmpeg path to the config/encoding.xml file as <EncoderAppPathDisplay> so it appears in UI
             var options = _configurationManager.GetEncodingOptions();
-            options.EncoderAppPathDisplay = _ffmpegPath ?? string.Empty;
+            options.EncoderAppPathDisplay = _ffPaths.EncoderPath;
             _configurationManager.SaveConfiguration("encoding", options);
 
             // Only if mpeg path is set, try and set path to probe
-            if (_ffmpegPath is not null)
+            if (!string.IsNullOrEmpty(_ffPaths.EncoderPath))
             {
-                // Determine a probe path from the mpeg path
-                _ffprobePath = FfprobePathRegex().Replace(_ffmpegPath, "ffprobe$1");
-
                 // Interrogate to understand what coders are supported
-                var validator = new EncoderValidator(_logger, _ffmpegPath);
+                var validator = new EncoderValidator(_logger, _ffPaths.EncoderPath, _ffRunner);
 
-                SetAvailableDecoders(validator.GetDecoders());
-                SetAvailableEncoders(validator.GetEncoders());
-                SetAvailableFilters(validator.GetFilters());
-                SetAvailableFiltersWithOption(validator.GetFiltersWithOption());
-                SetAvailableBitStreamFiltersWithOption(validator.GetBitStreamFiltersWithOption());
-                SetAvailableHwaccels(validator.GetHwaccels());
-                SetMediaEncoderVersion(validator);
+                SetAvailableDecoders(await validator.GetDecodersAsync().ConfigureAwait(false));
+                SetAvailableEncoders(await validator.GetEncodersAsync().ConfigureAwait(false));
+                SetAvailableFilters(await validator.GetFiltersAsync().ConfigureAwait(false));
+                SetAvailableFiltersWithOption(await validator.GetFiltersWithOptionAsync().ConfigureAwait(false));
+                SetAvailableBitStreamFiltersWithOption(await validator.GetBitStreamFiltersWithOptionAsync().ConfigureAwait(false));
+                SetAvailableHwaccels(await validator.GetHwaccelsAsync().ConfigureAwait(false));
+                await SetMediaEncoderVersionAsync(validator).ConfigureAwait(false);
 
                 _threads = EncodingHelper.GetNumberOfThreads(null, options, null);
 
-                _isPkeyPauseSupported = validator.CheckSupportedRuntimeKey("p      pause transcoding", _ffmpegVersion);
-                _isLowPriorityHwDecodeSupported = validator.CheckSupportedHwaccelFlag("low_priority");
-                _proberSupportsFirstVideoFrame = validator.CheckSupportedProberOption("only_first_vframe", _ffprobePath);
+                _isPkeyPauseSupported = await validator.CheckSupportedRuntimeKeyAsync("p      pause transcoding", _ffmpegVersion).ConfigureAwait(false);
+                _isLowPriorityHwDecodeSupported = await validator.CheckSupportedHwaccelFlagAsync("low_priority").ConfigureAwait(false);
+                _proberSupportsFirstVideoFrame = await validator.CheckSupportedProberOptionAsync("only_first_vframe").ConfigureAwait(false);
 
                 // Check the Vaapi device vendor
                 if (OperatingSystem.IsLinux()
@@ -243,11 +244,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     && !string.IsNullOrEmpty(options.VaapiDevice)
                     && options.HardwareAccelerationType == HardwareAccelerationType.vaapi)
                 {
-                    _isVaapiDeviceAmd = validator.CheckVaapiDeviceByDriverName("Mesa Gallium driver", options.VaapiDevice);
-                    _isVaapiDeviceInteliHD = validator.CheckVaapiDeviceByDriverName("Intel iHD driver", options.VaapiDevice);
-                    _isVaapiDeviceInteli965 = validator.CheckVaapiDeviceByDriverName("Intel i965 driver", options.VaapiDevice);
-                    _isVaapiDeviceSupportVulkanDrmModifier = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanImageDrmFmtModifierExts);
-                    _isVaapiDeviceSupportVulkanDrmInterop = validator.CheckVulkanDrmDeviceByExtensionName(options.VaapiDevice, _vulkanExternalMemoryDmaBufExts);
+                    _isVaapiDeviceAmd = await validator.CheckVaapiDeviceByDriverNameAsync("Mesa Gallium driver", options.VaapiDevice).ConfigureAwait(false);
+                    _isVaapiDeviceInteliHD = await validator.CheckVaapiDeviceByDriverNameAsync("Intel iHD driver", options.VaapiDevice).ConfigureAwait(false);
+                    _isVaapiDeviceInteli965 = await validator.CheckVaapiDeviceByDriverNameAsync("Intel i965 driver", options.VaapiDevice).ConfigureAwait(false);
+                    _isVaapiDeviceSupportVulkanDrmModifier = await validator.CheckVulkanDrmDeviceByExtensionNameAsync(options.VaapiDevice, _vulkanImageDrmFmtModifierExts).ConfigureAwait(false);
+                    _isVaapiDeviceSupportVulkanDrmInterop = await validator.CheckVulkanDrmDeviceByExtensionNameAsync(options.VaapiDevice, _vulkanExternalMemoryDmaBufExts).ConfigureAwait(false);
 
                     if (_isVaapiDeviceAmd)
                     {
@@ -280,7 +281,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
-            _logger.LogInformation("FFmpeg: {FfmpegPath}", _ffmpegPath ?? string.Empty);
+            _logger.LogInformation("FFmpeg: {FfmpegPath}", _ffPaths.EncoderPath);
             return !string.IsNullOrWhiteSpace(ffmpegPath);
         }
 
@@ -290,21 +291,21 @@ namespace MediaBrowser.MediaEncoding.Encoder
         /// </summary>
         /// <param name="path">FQPN to test.</param>
         /// <returns><c>true</c> if the version validation succeeded; otherwise, <c>false</c>.</returns>
-        private bool ValidatePath(string path)
+        private async Task<bool> ValidatePathAsync(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
                 return false;
             }
 
-            bool rc = new EncoderValidator(_logger, path).ValidateVersion();
+            bool rc = await new EncoderValidator(_logger, path, _ffRunner).ValidateVersionAsync().ConfigureAwait(false);
             if (!rc)
             {
                 _logger.LogError("FFmpeg: Failed version check: {Path}", path);
                 return false;
             }
 
-            _ffmpegPath = path;
+            _ffPaths.SetEncoderPath(path);
             return true;
         }
 
@@ -354,9 +355,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             _bitStreamFiltersWithOption = dict;
         }
 
-        public void SetMediaEncoderVersion(EncoderValidator validator)
+        public async Task SetMediaEncoderVersionAsync(EncoderValidator validator)
         {
-            _ffmpegVersion = validator.GetFFmpegVersion();
+            _ffmpegVersion = await validator.GetFFmpegVersionAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -510,86 +511,54 @@ namespace MediaBrowser.MediaEncoding.Encoder
             VideoType? videoType,
             CancellationToken cancellationToken)
         {
-            var args = extractChapters
-                ? "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_chapters -show_format"
-                : "{0} -i {1} -threads {2} -v warning -print_format json -show_streams -show_format";
+            InternalMediaInfoResult result = null;
 
-            if (protocol == MediaProtocol.File && !isAudio && _proberSupportsFirstVideoFrame)
+            var request = new ProbeRequest
             {
-                args += " -show_frames -only_first_vframe";
-            }
-
-            args = string.Format(CultureInfo.InvariantCulture, args, probeSizeArgument, inputPath, _threads).Trim();
-
-            var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-
-                    // Must consume both or ffmpeg may hang due to deadlocks.
-                    StandardOutputEncoding = Encoding.UTF8,
-                    RedirectStandardOutput = true,
-
-                    FileName = _ffprobePath,
-                    Arguments = args,
-
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false,
-                },
-                EnableRaisingEvents = true
-            };
-
-            _logger.LogDebug("Starting {ProcessFileName} with args {ProcessArgs}", _ffprobePath, args);
-
-            var memoryStream = new MemoryStream();
-            await using (memoryStream.ConfigureAwait(false))
-            using (var processWrapper = new ProcessWrapper(process, this))
-            {
-                StartProcess(processWrapper);
-                using var reader = process.StandardOutput;
-                await reader.BaseStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                InternalMediaInfoResult result;
-                try
+                Input = inputPath,
+                SourceTuning = probeSizeArgument,
+                IncludeChapters = extractChapters,
+                FirstVideoFrameOnly = protocol == MediaProtocol.File && !isAudio && _proberSupportsFirstVideoFrame,
+                Threads = _threads,
+                Stdout = async (stdout, ct) =>
                 {
                     result = await JsonSerializer.DeserializeAsync<InternalMediaInfoResult>(
-                                        memoryStream,
-                                        _jsonSerializerOptions,
-                                        cancellationToken).ConfigureAwait(false);
+                        stdout,
+                        _jsonSerializerOptions,
+                        ct).ConfigureAwait(false);
                 }
-                catch
-                {
-                    StopProcess(processWrapper, 100);
+            };
 
-                    throw;
-                }
+            var runResult = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
 
-                if (result is null || (result.Streams is null && result.Format is null))
-                {
-                    throw new FfmpegException("ffprobe failed - streams and format are both null.");
-                }
+            if (!runResult.Succeeded)
+            {
+                throw new FfmpegException($"ffprobe failed for {primaryPath}: {runResult.Stderr}");
+            }
 
-                if (result.Streams is not null)
+            if (result is null || (result.Streams is null && result.Format is null))
+            {
+                throw new FfmpegException("ffprobe failed - streams and format are both null.");
+            }
+
+            if (result.Streams is not null)
+            {
+                // Normalize aspect ratio if invalid
+                foreach (var stream in result.Streams)
                 {
-                    // Normalize aspect ratio if invalid
-                    foreach (var stream in result.Streams)
+                    if (string.Equals(stream.DisplayAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (string.Equals(stream.DisplayAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
-                        {
-                            stream.DisplayAspectRatio = string.Empty;
-                        }
+                        stream.DisplayAspectRatio = string.Empty;
+                    }
 
-                        if (string.Equals(stream.SampleAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
-                        {
-                            stream.SampleAspectRatio = string.Empty;
-                        }
+                    if (string.Equals(stream.SampleAspectRatio, "0:1", StringComparison.OrdinalIgnoreCase))
+                    {
+                        stream.SampleAspectRatio = string.Empty;
                     }
                 }
-
-                return new ProbeResultNormalizer(_logger, _localization).GetMediaInfo(result, videoType, isAudio, primaryPath, protocol);
             }
+
+            return new ProbeResultNormalizer(_logger, _localization).GetMediaInfo(result, videoType, isAudio, primaryPath, protocol);
         }
 
         /// <inheritdoc />
@@ -646,29 +615,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             return await ExtractImageInternal(inputArgument, container, videoStream, imageStreamIndex, threedFormat, offset, false, targetFormat, isAudio, cancellationToken).ConfigureAwait(false);
-        }
-
-        private string GetImageResolutionParameter()
-        {
-            var imageResolutionParameter = _serverConfig.Configuration.ChapterImageResolution switch
-            {
-                ImageResolution.P144 => "256x144",
-                ImageResolution.P240 => "426x240",
-                ImageResolution.P360 => "640x360",
-                ImageResolution.P480 => "854x480",
-                ImageResolution.P720 => "1280x720",
-                ImageResolution.P1080 => "1920x1080",
-                ImageResolution.P1440 => "2560x1440",
-                ImageResolution.P2160 => "3840x2160",
-                _ => string.Empty
-            };
-
-            if (!string.IsNullOrEmpty(imageResolutionParameter))
-            {
-                imageResolutionParameter = " -s " + imageResolutionParameter;
-            }
-
-            return imageResolutionParameter;
         }
 
         private async Task<string> ExtractImageInternal(
@@ -745,89 +691,55 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 }
             }
 
-            var vf = string.Join(',', filters);
-            var mapArg = imageStreamIndex.HasValue ? (" -map 0:" + imageStreamIndex.Value.ToString(CultureInfo.InvariantCulture)) : string.Empty;
-            var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-i {0}{1} -threads {2} -v quiet -vframes 1 -vf {3}{4}{5} -f image2 \"{6}\"",
-                inputPath,
-                mapArg,
-                _threads,
-                vf,
-                isAudio ? string.Empty : GetImageResolutionParameter(),
-                EncodingHelper.GetVideoSyncOption("-1", EncoderVersion), // auto decide fps mode
-                tempExtractPath);
-
-            if (offset.HasValue)
+            var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
+            if (timeoutMs <= 0)
             {
-                args = string.Format(CultureInfo.InvariantCulture, "-ss {0} ", GetTimeParameter(offset.Value)) + args;
+                timeoutMs = enableHdrExtraction ? DefaultHdrImageExtractionTimeout : DefaultSdrImageExtractionTimeout;
             }
 
-            // The mpegts demuxer cannot seek to keyframes, so we have to let the
-            // decoder discard non-keyframes, which may contain corrupted images.
+            var inputFormat = string.IsNullOrWhiteSpace(container)
+                ? string.Empty
+                : EncodingHelper.GetInputFormat(container) ?? string.Empty;
+
+            // The mpegts demuxer cannot seek to keyframes, so we have to let the decoder discard
+            // non-keyframes, which may contain corrupted images.
             var seekMpegTs = offset.HasValue && string.Equals("mpegts", container, StringComparison.OrdinalIgnoreCase);
-            if (useIFrame && (useTradeoff || seekMpegTs))
-            {
-                args = "-skip_frame nokey " + args;
-            }
 
-            if (!string.IsNullOrWhiteSpace(container))
+            var request = new ImageRequest
             {
-                var inputFormat = EncodingHelper.GetInputFormat(container);
-                if (!string.IsNullOrWhiteSpace(inputFormat))
-                {
-                    args = "-f " + inputFormat + " " + args;
-                }
-            }
+                Input = inputPath,
+                OutputPath = tempExtractPath,
+                Filters = string.Join(',', filters),
+                EncoderVersion = EncoderVersion,
+                InputFormat = inputFormat,
+                SeekTo = offset ?? TimeSpan.Zero,
+                StreamIndex = imageStreamIndex ?? ImageRequest.AutoStreamIndex,
 
-            var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    FileName = _ffmpegPath,
-                    Arguments = args,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false,
-                },
-                EnableRaisingEvents = true
+                // Cover art is already at its native size; only chapter stills get rescaled.
+                Resolution = isAudio ? ImageResolution.MatchSource : _serverConfig.Configuration.ChapterImageResolution,
+                KeyFrameOnly = useIFrame && (useTradeoff || seekMpegTs),
+                Threads = _threads,
+                Timeout = TimeSpan.FromMilliseconds(timeoutMs)
             };
 
-            _logger.LogDebug("{ProcessFileName} {ProcessArguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
-
-            using (var processWrapper = new ProcessWrapper(process, this))
+            FFResult result;
+            using (await _thumbnailResourcePool.LockAsync(cancellationToken).ConfigureAwait(false))
             {
-                using (await _thumbnailResourcePool.LockAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    StartProcess(processWrapper);
-
-                    var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
-                    if (timeoutMs <= 0)
-                    {
-                        timeoutMs = enableHdrExtraction ? DefaultHdrImageExtractionTimeout : DefaultSdrImageExtractionTimeout;
-                    }
-
-                    try
-                    {
-                        await process.WaitForExitAsync(TimeSpan.FromMilliseconds(timeoutMs)).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException ex)
-                    {
-                        process.Kill(true);
-                        throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg image extraction timed out for {0} after {1}ms", inputPath, timeoutMs), ex);
-                    }
-                }
-
-                var file = _fileSystem.GetFileInfo(tempExtractPath);
-
-                if (processWrapper.ExitCode > 0 || !file.Exists || file.Length == 0)
-                {
-                    throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg image extraction failed for {0}", inputPath));
-                }
-
-                return tempExtractPath;
+                result = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
             }
+
+            if (result.StopReason == FFStopReason.TimedOut)
+            {
+                throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg image extraction timed out for {0} after {1}ms", inputPath, timeoutMs));
+            }
+
+            var file = _fileSystem.GetFileInfo(tempExtractPath);
+            if (!result.Succeeded || !file.Exists || file.Length == 0)
+            {
+                throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg image extraction failed for {0}", inputPath));
+            }
+
+            return tempExtractPath;
         }
 
         /// <inheritdoc />
@@ -928,32 +840,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 throw new InvalidOperationException("EncodingHelper returned empty or invalid filter parameters.");
             }
 
-            // Normalize invalid PTS from containers for non keyframe only mode
-            if (!enableKeyFrameOnlyExtraction)
-            {
-                var fpsFilterIndex = filterParam.IndexOf("fps=", StringComparison.Ordinal);
-                if (fpsFilterIndex >= 0)
-                {
-                    var inputFrameRate = (imageStream.ReferenceFrameRate.HasValue && imageStream.ReferenceFrameRate > 0)
-                        ? imageStream.ReferenceFrameRate.Value : 30;
-
-                    var setPtsFilter = string.Create(CultureInfo.InvariantCulture, $"setpts=N/{inputFrameRate:F3}/TB,");
-
-                    filterParam = filterParam.Insert(fpsFilterIndex, setPtsFilter);
-                }
-                else
-                {
-                    throw new InvalidOperationException("EncodingHelper returned invalid filter parameters.");
-                }
-            }
+            // Keyframe-only extraction takes whatever keyframes exist, so it never samples a timeline.
+            var normalizeFrameRate = enableKeyFrameOnlyExtraction
+                ? 0
+                : (imageStream.ReferenceFrameRate is > 0 ? imageStream.ReferenceFrameRate.Value : FallbackFrameRate);
 
             try
             {
                 return await ExtractVideoImagesOnIntervalInternal(
                     (enableKeyFrameOnlyExtraction ? "-skip_frame nokey " : string.Empty) + inputArg,
                     filterParam,
+                    normalizeFrameRate,
                     vidEncoder,
-                    threads,
                     qualityScale,
                     priority,
                     cancellationToken).ConfigureAwait(false);
@@ -968,14 +866,14 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _logger.LogWarning(ex, "I-frame trickplay extraction failed, will attempt standard way. Input: {InputFile}", inputFile);
             }
 
-            return await ExtractVideoImagesOnIntervalInternal(inputArg, filterParam, vidEncoder, threads, qualityScale, priority, cancellationToken).ConfigureAwait(false);
+            return await ExtractVideoImagesOnIntervalInternal(inputArg, filterParam, normalizeFrameRate, vidEncoder, qualityScale, priority, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<string> ExtractVideoImagesOnIntervalInternal(
             string inputArg,
             string filterParam,
+            double normalizeFrameRate,
             string vidEncoder,
-            int? outputThreads,
             int? qualityScale,
             ProcessPriorityClass? priority,
             CancellationToken cancellationToken)
@@ -985,149 +883,59 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 throw new InvalidOperationException("Empty or invalid input argument.");
             }
 
-            // ffmpeg qscale is a value from 1-31, with 1 being best quality and 31 being worst
-            // jpeg quality is a value from 0-100, with 0 being worst quality and 100 being best
-            var encoderQuality = Math.Clamp(qualityScale ?? 4, 1, 31);
-            var encoderQualityOption = "-qscale:v ";
-
-            if (vidEncoder.Contains("vaapi", StringComparison.OrdinalIgnoreCase)
-                || vidEncoder.Contains("qsv", StringComparison.OrdinalIgnoreCase))
-            {
-                // vaapi and qsv's mjpeg encoder use jpeg quality as input, instead of ffmpeg defined qscale
-                encoderQuality = 100 - ((encoderQuality - 1) * (100 / 30));
-                encoderQualityOption = "-global_quality:v ";
-            }
-
-            if (vidEncoder.Contains("videotoolbox", StringComparison.OrdinalIgnoreCase))
-            {
-                // videotoolbox's mjpeg encoder uses jpeg quality scaled to QP2LAMBDA (118) instead of ffmpeg defined qscale
-                encoderQuality = 118 - ((encoderQuality - 1) * (118 / 30));
-            }
-
-            if (vidEncoder.Contains("rkmpp", StringComparison.OrdinalIgnoreCase))
-            {
-                // rkmpp's mjpeg encoder uses jpeg quality as input (max is 99, not 100), instead of ffmpeg defined qscale
-                encoderQuality = 99 - ((encoderQuality - 1) * (99 / 30));
-                encoderQualityOption = "-qp_init:v ";
-            }
-
             // Output arguments
             var targetDirectory = Path.Combine(_configurationManager.ApplicationPaths.TempDirectory, Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(targetDirectory);
             var outputPath = Path.Combine(targetDirectory, "%08d.jpg");
 
-            // Final command arguments
-            var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-loglevel error {0} -an -sn {1} -threads {2} -c:v {3} {4}{5}{6}-f {7} \"{8}\"",
-                inputArg,
-                filterParam,
-                outputThreads.GetValueOrDefault(_threads),
-                vidEncoder,
-                encoderQualityOption + encoderQuality + " ",
-                vidEncoder.Contains("videotoolbox", StringComparison.InvariantCultureIgnoreCase) ? "-allow_sw 1 " : string.Empty, // allow_sw fallback for some intel macs
-                EncodingHelper.GetVideoSyncOption("0", EncoderVersion).Trim() + " ", // passthrough timestamp
-                "image2",
-                outputPath);
+            var idleTimeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
+            idleTimeoutMs = idleTimeoutMs <= 0 ? DefaultHdrImageExtractionTimeout : idleTimeoutMs;
 
-            // Start ffmpeg process
-            var process = new Process
+            var request = new TrickplayRequest
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    FileName = _ffmpegPath,
-                    Arguments = args,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false,
-                },
-                EnableRaisingEvents = true
+                Input = inputArg,
+                FilterChain = filterParam,
+                NormalizeTimestampsAtFrameRate = normalizeFrameRate,
+                OutputPath = outputPath,
+                VideoEncoder = vidEncoder,
+                EncoderVersion = EncoderVersion,
+                QualityScale = qualityScale ?? TrickplayRequest.DefaultQualityScale,
+                Priority = priority ?? FFDefaults.InheritPriority,
+
+                // ffmpeg runs for as long as the media is long, so the wall clock cannot bound this.
+                // New tiles appearing is the liveness signal instead.
+                IdleTimeout = TimeSpan.FromMilliseconds(idleTimeoutMs),
+                ProgressProbe = () => _fileSystem.GetFilePaths(targetDirectory).Count()
             };
 
-            var processDescription = string.Format(CultureInfo.InvariantCulture, "{0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
-            _logger.LogInformation("Trickplay generation: {ProcessDescription}", processDescription);
-
-            using (var processWrapper = new ProcessWrapper(process, this))
+            FFResult result;
+            using (await _thumbnailResourcePool.LockAsync(cancellationToken).ConfigureAwait(false))
             {
-                bool ranToCompletion = false;
-
-                using (await _thumbnailResourcePool.LockAsync(cancellationToken).ConfigureAwait(false))
-                {
-                    StartProcess(processWrapper);
-
-                    // Set process priority
-                    if (priority.HasValue)
-                    {
-                        try
-                        {
-                            processWrapper.Process.PriorityClass = priority.Value;
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogDebug(ex, "Unable to set process priority to {Priority} for {Description}", priority.Value, processDescription);
-                        }
-                    }
-
-                    // Need to give ffmpeg enough time to make all the thumbnails, which could be a while,
-                    // but we still need to detect if the process hangs.
-                    // Making the assumption that as long as new jpegs are showing up, everything is good.
-
-                    bool isResponsive = true;
-                    int lastCount = 0;
-                    var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
-                    timeoutMs = timeoutMs <= 0 ? DefaultHdrImageExtractionTimeout : timeoutMs;
-
-                    while (isResponsive && !cancellationToken.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            await process.WaitForExitAsync(TimeSpan.FromMilliseconds(timeoutMs)).ConfigureAwait(false);
-
-                            ranToCompletion = true;
-                            break;
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            // We don't actually expect the process to be finished in one timeout span, just that one image has been generated.
-                        }
-
-                        var jpegCount = _fileSystem.GetFilePaths(targetDirectory).Count();
-
-                        isResponsive = jpegCount > lastCount;
-                        lastCount = jpegCount;
-                    }
-
-                    if (!ranToCompletion)
-                    {
-                        if (!isResponsive)
-                        {
-                            _logger.LogInformation("Trickplay process unresponsive.");
-                        }
-
-                        _logger.LogInformation("Stopping trickplay extraction.");
-                        StopProcess(processWrapper, 1000);
-                    }
-                }
-
-                if (!ranToCompletion || processWrapper.ExitCode != 0)
-                {
-                    // Cleanup temp folder here, because the targetDirectory is not returned and the cleanup for failed ffmpeg process is not possible for caller.
-                    // Ideally the ffmpeg should not write any files if it fails, but it seems like it is not guaranteed.
-                    try
-                    {
-                        Directory.Delete(targetDirectory, true);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogError(e, "Failed to delete ffmpeg temp directory {TargetDirectory}", targetDirectory);
-                    }
-
-                    throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg image extraction failed for {0}", processDescription));
-                }
-
-                return targetDirectory;
+                result = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
             }
+
+            if (!result.Succeeded)
+            {
+                if (result.StopReason == FFStopReason.Stalled)
+                {
+                    _logger.LogInformation("Trickplay process stopped producing images; giving up.");
+                }
+
+                // Clean up here: targetDirectory is not returned on failure, so the caller cannot.
+                // ffmpeg ideally would not write anything when it fails, but that is not guaranteed.
+                try
+                {
+                    Directory.Delete(targetDirectory, true);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to delete ffmpeg temp directory {TargetDirectory}", targetDirectory);
+                }
+
+                throw new FfmpegException(string.Format(CultureInfo.InvariantCulture, "ffmpeg trickplay extraction failed for {0}", outputPath));
+            }
+
+            return targetDirectory;
         }
 
         public string GetTimeParameter(long ticks)
@@ -1140,71 +948,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public string GetTimeParameter(TimeSpan time)
         {
             return time.ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
-        }
-
-        private void StartProcess(ProcessWrapper process)
-        {
-            process.Process.Start();
-
-            if (_canSetProcessPriority)
-            {
-                try
-                {
-                    process.Process.PriorityClass = ProcessPriorityClass.BelowNormal;
-                }
-                catch (Exception ex)
-                {
-                    _canSetProcessPriority = false;
-                    _logger.LogWarning(ex, "Unable to set process priority to BelowNormal for {ProcessFileName}. Further attempts will be skipped.", process.Process.StartInfo.FileName);
-                }
-            }
-
-            lock (_runningProcessesLock)
-            {
-                _runningProcesses.Add(process);
-            }
-        }
-
-        private void StopProcess(ProcessWrapper process, int waitTimeMs)
-        {
-            try
-            {
-                if (process.Process.WaitForExit(waitTimeMs))
-                {
-                    return;
-                }
-
-                _logger.LogInformation("Killing ffmpeg process");
-
-                process.Process.Kill();
-            }
-            catch (InvalidOperationException)
-            {
-                // The process has already exited or
-                // there is no process associated with this Process object.
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error killing process");
-            }
-        }
-
-        private void StopProcesses()
-        {
-            List<ProcessWrapper> processes;
-            lock (_runningProcessesLock)
-            {
-                processes = _runningProcesses.ToList();
-                _runningProcesses.Clear();
-            }
-
-            foreach (var process in processes)
-            {
-                if (!process.HasExited)
-                {
-                    StopProcess(process, 500);
-                }
-            }
         }
 
         public string EscapeSubtitleFilterPath(string path)
@@ -1234,7 +977,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         {
             if (dispose)
             {
-                StopProcesses();
                 _thumbnailResourcePool.Dispose();
             }
         }
@@ -1359,67 +1101,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
         public bool CanExtractSubtitles(string codec)
         {
             return _configurationManager.GetEncodingOptions().EnableSubtitleExtraction;
-        }
-
-        private sealed class ProcessWrapper : IDisposable
-        {
-            private readonly MediaEncoder _mediaEncoder;
-
-            private bool _disposed = false;
-
-            public ProcessWrapper(Process process, MediaEncoder mediaEncoder)
-            {
-                Process = process;
-                _mediaEncoder = mediaEncoder;
-                Process.Exited += OnProcessExited;
-            }
-
-            public Process Process { get; }
-
-            public bool HasExited { get; private set; }
-
-            public int? ExitCode { get; private set; }
-
-            private void OnProcessExited(object sender, EventArgs e)
-            {
-                var process = (Process)sender;
-
-                HasExited = true;
-
-                try
-                {
-                    ExitCode = process.ExitCode;
-                }
-                catch
-                {
-                }
-
-                DisposeProcess(process);
-            }
-
-            private void DisposeProcess(Process process)
-            {
-                lock (_mediaEncoder._runningProcessesLock)
-                {
-                    _mediaEncoder._runningProcesses.Remove(this);
-                }
-
-                process.Dispose();
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    if (Process is not null)
-                    {
-                        Process.Exited -= OnProcessExited;
-                        DisposeProcess(Process);
-                    }
-                }
-
-                _disposed = true;
-            }
         }
     }
 }

--- a/MediaBrowser.MediaEncoding/FFProcessing/FFPaths.cs
+++ b/MediaBrowser.MediaEncoding/FFProcessing/FFPaths.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+
+namespace MediaBrowser.MediaEncoding.FFProcessing;
+
+/// <inheritdoc cref="IFFPaths"/>
+public sealed partial class FFPaths : IFFPaths
+{
+    // Held as one object and swapped atomically. Written during startup and read by every action
+    // thereafter, so publishing the two separately would let a reader pick up a new encoder path
+    // beside a stale prober path.
+    private volatile Resolved _resolved = new(string.Empty, string.Empty);
+
+    /// <inheritdoc />
+    public string EncoderPath => _resolved.Encoder;
+
+    /// <inheritdoc />
+    public string ProbePath => _resolved.Prober;
+
+    /// <inheritdoc />
+    public void SetEncoderPath(string encoderPath)
+    {
+        var encoder = encoderPath ?? string.Empty;
+
+        // Replace only the file name, so a versioned or prefixed binary such as
+        // jellyfin-ffmpeg.exe still resolves to ffprobe.exe beside it.
+        var prober = encoder.Length == 0
+            ? string.Empty
+            : ProberNameRegex().Replace(encoder, "ffprobe$1");
+
+        _resolved = new Resolved(encoder, prober);
+    }
+
+    [GeneratedRegex(@"[^\/\\]+?(\.[^\/\\\n.]+)?$")]
+    private static partial Regex ProberNameRegex();
+
+    private sealed record Resolved(string Encoder, string Prober);
+}

--- a/MediaBrowser.MediaEncoding/FFProcessing/FFRunner.cs
+++ b/MediaBrowser.MediaEncoding/FFProcessing/FFRunner.cs
@@ -1,0 +1,580 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+using Microsoft.Extensions.Logging;
+
+namespace MediaBrowser.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Starts an FFmpeg or FFprobe process, supervises it, and kills the tree on cancellation.
+/// </summary>
+public sealed class FFRunner : IFFRunner, IDisposable
+{
+    /// <summary>
+    /// Starting capacity for the rendered arguments. Measured against real invocations, this covers
+    /// everything but the longest filter chains without a regrow, and costs 1 KB transiently per spawn.
+    /// </summary>
+    private const int ArgumentsCapacity = 512;
+
+    private readonly ILogger<FFRunner> _logger;
+    private readonly IFFPaths _paths;
+
+    /// <summary>
+    /// Every live child, so shutdown can reach one whose cancellation token never fired. Each run
+    /// already kills its own process, so this only covers the case where nothing cancels it.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, Process> _running = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FFRunner"/> class.
+    /// </summary>
+    /// <param name="logger">The logger. Its enabled level also drives FFmpeg's own verbosity.</param>
+    /// <param name="paths">Supplies the resolved ffmpeg and ffprobe locations.</param>
+    public FFRunner(ILogger<FFRunner> logger, IFFPaths paths)
+    {
+        _logger = logger;
+        _paths = paths;
+    }
+
+    /// <inheritdoc />
+    public async Task<FFResult> RunAsync(FFRequest request, CancellationToken cancellationToken)
+    {
+        var session = await StartAsync(request, cancellationToken).ConfigureAwait(false);
+        await using (session.ConfigureAwait(false))
+        {
+            return await session.Completion.ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Build the global flags implied by the action and log level, then the operation's own
+    /// arguments.
+    /// </summary>
+    private string BuildArguments(FFRequest request, in FFActionPolicy policy)
+    {
+        var sb = new StringBuilder(ArgumentsCapacity);
+
+        sb.Append("-hide_banner -loglevel ")
+            .Append(policy.StderrIsPayload ? FFLogLevel.ForPayload(_logger) : FFLogLevel.For(_logger))
+            .Append(' ');
+
+        if (policy.RequiresProgressStats)
+        {
+            // FFmpeg drops its status line below info. Asking for it explicitly keeps the log quiet
+            // without the progress feed going dark.
+            sb.Append("-stats ");
+        }
+
+        // FFprobe doesn't accept any of these arguments.
+        if (!policy.ProbeOnly)
+        {
+            if (policy.Stdin == FFStdinMode.FireAndForget)
+            {
+                sb.Append("-nostdin ");
+            }
+
+            sb.Append(policy.Overwrite ? "-y " : "-n ");
+        }
+
+        request.BuildArguments(sb);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <inheritdoc />
+    public async Task<IFFSession> StartAsync(FFRequest request, CancellationToken cancellationToken)
+    {
+        var started = await StartCoreAsync(request, cancellationToken).ConfigureAwait(false);
+
+        return new FFSession(this, started, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public string GetCommandLine(FFRequest request) => Resolve(request).CommandLine;
+
+    /// <summary>
+    /// Resolves a request's policy and determines the executable and the full argument string.
+    /// <para>
+    /// Both <see cref="GetCommandLine"/> and <see cref="StartCoreAsync"/> use this resolved command.
+    /// </para>
+    /// </summary>
+    private ResolvedCommand Resolve(FFRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var policy = request.ResolvePolicy();
+
+        return new ResolvedCommand(policy, ResolveBinaryPath(request, policy), BuildArguments(request, policy));
+    }
+
+    /// <summary>
+    /// Picks the executable for a request: the one it names, or the resolved prober or encoder.
+    /// </summary>
+    private string ResolveBinaryPath(FFRequest request, in FFActionPolicy policy)
+    {
+        var fileName = request.BinaryPathOverride.Length > 0
+            ? request.BinaryPathOverride
+            : (policy.ProbeOnly ? _paths.ProbePath : _paths.EncoderPath);
+
+        if (string.IsNullOrEmpty(fileName))
+        {
+            throw new FfmpegException(
+                $"{request.Action}: no {(policy.ProbeOnly ? "ffprobe" : "ffmpeg")} path has been resolved.");
+        }
+
+        return fileName;
+    }
+
+    /// <summary>
+    /// Launches the process and starts both drains, returning before it exits.
+    /// </summary>
+    private async Task<StartedProcess> StartCoreAsync(
+        FFRequest request,
+        CancellationToken cancellationToken)
+    {
+        var (policy, fileName, arguments) = Resolve(request);
+        _logger.LogDebug("{Action}: {FileName} {Arguments}", request.Action, fileName, arguments);
+
+        var process = CreateProcess(request, fileName, arguments);
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            // Nothing else will ever see this one, so it has to be released here.
+            process.Dispose();
+
+            _logger.LogError(ex, "{Action}: failed to start {FileName}", request.Action, fileName);
+            throw new FfmpegException($"{request.Action}: failed to start {fileName}", ex);
+        }
+
+        _running[process.Id] = process;
+        ApplyPriority(process, request, policy.Priority);
+
+        if (policy.Stdin == FFStdinMode.FireAndForget)
+        {
+            TryCloseStdin(process, request);
+        }
+        else if (request.Action == FFAction.ProbeRuntimeKeys)
+        {
+            await WriteRuntimeKeyAsync(process, request).ConfigureAwait(false);
+        }
+
+        // Drains start before the exit wait because a full pipe would block the child, which then never exits.
+        var stderrTask = DrainStderrAsync(process, request);
+        var stdoutTask = request.Stdout(process.StandardOutput.BaseStream, cancellationToken);
+
+        return new StartedProcess(request, policy, process, fileName, arguments, stopwatch, stderrTask, stdoutTask);
+    }
+
+    /// <summary>
+    /// Waits under the deadlines, terminates whatever is left, and builds the outcome. The process
+    /// is disposed here, so this runs exactly once per start.
+    /// </summary>
+    private async Task<FFResult> SuperviseAsync(StartedProcess started, CancellationToken cancellationToken)
+    {
+        var (request, policy, process, fileName, arguments, stopwatch, stderrTask, stdoutTask) = started;
+        var stopReason = FFStopReason.Unknown;
+
+        try
+        {
+            using (var hardTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+            {
+                // Unbounded (-1 ms) is accepted and never fires; zero fires at once, so no policy should use that.
+                hardTimeout.CancelAfter(policy.Timeout);
+
+                try
+                {
+                    stopReason = await WaitAsync(process, request, policy, cancellationToken, hardTimeout.Token)
+                        .ConfigureAwait(false);
+                }
+                finally
+                {
+                    // Also covers a throw out of WaitAsync: disposing a Process does not kill it.
+                    await TerminateAsync(process, policy, request).ConfigureAwait(false);
+                    _running.TryRemove(process.Id, out _);
+                }
+            }
+
+            // Freeze it here so Elapsed measures the child's lifetime rather than also counting the
+            // drains below, and so every later read reports the same value.
+            stopwatch.Stop();
+
+            var stderr = await stderrTask.ConfigureAwait(false);
+
+            try
+            {
+                await stdoutTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // The consumer aborted because the process is already gone.
+            }
+
+            var result = new FFResult(
+                stopReason == FFStopReason.Exited ? process.ExitCode : -1,
+                stderr,
+                stopwatch.Elapsed,
+                stopReason);
+
+            if (stopReason == FFStopReason.Cancelled)
+            {
+                // The caller asked for this, so it is not an FFmpeg failure and must not read as one.
+                _logger.LogDebug("{Action}: cancelled after {Elapsed}", request.Action, stopwatch.Elapsed);
+            }
+            else if (!result.Succeeded)
+            {
+                _logger.LogError(
+                    "{Action}: exited {ExitCode} after {Elapsed} ({Reason}). Command: {FileName} {Arguments}. stderr: {Stderr}",
+                    request.Action,
+                    result.ExitCode,
+                    stopwatch.Elapsed,
+                    stopReason,
+                    fileName,
+                    arguments,
+                    stderr);
+            }
+
+            return result;
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Waits under the wall clock, and under the idle watchdog when the request supplies a real
+    /// progress signal. CPU time is deliberately not used as liveness: a process blocked on a slow
+    /// network read accrues none and would be killed while working correctly.
+    /// </summary>
+    private static async Task<FFStopReason> WaitAsync(
+        Process process,
+        FFRequest request,
+        FFActionPolicy policy,
+        CancellationToken callerToken,
+        CancellationToken hardToken)
+    {
+        if (!request.HasProgressSignal)
+        {
+            try
+            {
+                await process.WaitForExitAsync(hardToken).ConfigureAwait(false);
+                return FFStopReason.Exited;
+            }
+            catch (OperationCanceledException)
+            {
+                return callerToken.IsCancellationRequested ? FFStopReason.Cancelled : FFStopReason.TimedOut;
+            }
+        }
+
+        var lastProbe = SafeProbe(request.ProgressProbe);
+
+        while (true)
+        {
+            using var idle = CancellationTokenSource.CreateLinkedTokenSource(hardToken);
+            idle.CancelAfter(policy.IdleTimeout);
+
+            try
+            {
+                await process.WaitForExitAsync(idle.Token).ConfigureAwait(false);
+                return FFStopReason.Exited;
+            }
+            catch (OperationCanceledException)
+            {
+                if (callerToken.IsCancellationRequested)
+                {
+                    return FFStopReason.Cancelled;
+                }
+
+                if (hardToken.IsCancellationRequested)
+                {
+                    return FFStopReason.TimedOut;
+                }
+
+                var probe = SafeProbe(request.ProgressProbe);
+                if (probe <= lastProbe)
+                {
+                    return FFStopReason.Stalled;
+                }
+
+                lastProbe = probe;
+            }
+        }
+    }
+
+    private static Process CreateProcess(FFRequest request, string fileName, string arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            ErrorDialog = false,
+
+            // An inherited handle under a service manager can block the child on a read forever.
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            RedirectStandardError = true,
+            StandardErrorEncoding = Encoding.UTF8,
+
+            WorkingDirectory = request.WorkingDirectory
+        };
+
+        return new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+    }
+
+    private void TryCloseStdin(Process process, FFRequest request)
+    {
+        try
+        {
+            process.StandardInput.Close();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "{Action}: could not close stdin", request.Action);
+        }
+    }
+
+    private async Task WriteRuntimeKeyAsync(Process process, FFRequest request)
+    {
+        try
+        {
+            await process.StandardInput.WriteAsync(RuntimeKeyProbeRequest.QueryKey).ConfigureAwait(false);
+            await process.StandardInput.FlushAsync().ConfigureAwait(false);
+            process.StandardInput.Close();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "{Action}: could not write the runtime key", request.Action);
+        }
+    }
+
+    /// <summary>
+    /// Always drains stderr, whatever the sink does with it: a full pipe blocks the child, and a
+    /// blocked child never exits.
+    /// </summary>
+    private async Task<string> DrainStderrAsync(Process process, FFRequest request)
+    {
+        try
+        {
+            var line = await process.StandardError.ReadLineAsync().ConfigureAwait(false);
+            while (line is not null)
+            {
+                await request.Stderr.WriteLineAsync(line, CancellationToken.None).ConfigureAwait(false);
+                line = await process.StandardError.ReadLineAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "{Action}: stderr drain ended early", request.Action);
+        }
+
+        return request.Stderr.GetRetainedText();
+    }
+
+    private async Task TerminateAsync(Process process, FFActionPolicy policy, FFRequest request)
+    {
+        try
+        {
+            if (process.HasExited)
+            {
+                return;
+            }
+
+            if (policy.Stdin == FFStdinMode.ControlChannel)
+            {
+                await process.StandardInput.WriteLineAsync("q").ConfigureAwait(false);
+                await process.StandardInput.FlushAsync().ConfigureAwait(false);
+
+                using var grace = new CancellationTokenSource(policy.GracefulStopTimeout);
+                try
+                {
+                    await process.WaitForExitAsync(grace.Token).ConfigureAwait(false);
+                    return;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Fall through to the kill.
+                }
+            }
+
+            process.Kill(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "{Action}: failed to terminate the process", request.Action);
+        }
+    }
+
+    private void ApplyPriority(Process process, FFRequest request, ProcessPriorityClass priority)
+    {
+        if (priority == FFDefaults.InheritPriority)
+        {
+            return;
+        }
+
+        try
+        {
+            process.PriorityClass = priority;
+        }
+        catch (Exception ex)
+        {
+            // A short-lived child can exit before this runs.
+            _logger.LogDebug(ex, "{Action}: could not set process priority to {Priority}", request.Action, priority);
+        }
+    }
+
+    /// <summary>
+    /// Kills anything still running. The server is going down, so there is no point asking politely
+    /// or waiting; a run being cancelled normally has already gone through <c>TerminateAsync</c>.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var (_, process) in _running)
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(true);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not kill FFmpeg process {ProcessId} during shutdown", process.Id);
+            }
+        }
+
+        _running.Clear();
+    }
+
+    private static long SafeProbe(Func<long> probe)
+    {
+        try
+        {
+            return probe();
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// How a request will run, before anything has been launched. Produced only by
+    /// <see cref="Resolve"/>.
+    /// </summary>
+    private readonly record struct ResolvedCommand(
+        FFActionPolicy Policy,
+        string FileName,
+        string Arguments)
+    {
+        /// <summary>
+        /// Gets the command line as it would be typed into a shell. The one place that decides how a
+        /// command is rendered as text.
+        /// </summary>
+        public string CommandLine => FileName + " " + Arguments;
+    }
+
+    /// <summary>
+    /// A launched process plus everything needed to supervise it. Deconstructed rather than passed
+    /// as eight arguments.
+    /// </summary>
+    private sealed record StartedProcess(
+        FFRequest Request,
+        FFActionPolicy Policy,
+        Process Process,
+        string FileName,
+        string Arguments,
+        Stopwatch Stopwatch,
+        Task<string> StderrTask,
+        Task StdoutTask);
+
+    /// <summary>
+    /// Hands a running process back to the caller. Supervision starts immediately, so the process
+    /// is still bounded by its deadlines even if the caller never touches the session again.
+    /// </summary>
+    private sealed class FFSession : IFFSession
+    {
+        private readonly StartedProcess _started;
+        private readonly CancellationTokenSource _stopSignal;
+
+        public FFSession(FFRunner runner, StartedProcess started, CancellationToken cancellationToken)
+        {
+            _started = started;
+            _stopSignal = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            ProcessId = started.Process.Id;
+            Completion = SuperviseThenReleaseAsync(runner, started);
+        }
+
+        public int ProcessId { get; }
+
+        public Task<FFResult> Completion { get; }
+
+        public async Task SendKeyAsync(string key, CancellationToken cancellationToken)
+        {
+            if (_started.Policy.Stdin != FFStdinMode.ControlChannel)
+            {
+                throw new InvalidOperationException($"{_started.Request.Action} is not steerable.");
+            }
+
+            await _started.Process.StandardInput.WriteAsync(key.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await _started.Process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Releases the linked token source once supervision ends, so a caller that only awaits
+        /// <see cref="Completion"/> — which is the normal shape — leaks nothing by never disposing.
+        /// </summary>
+        private async Task<FFResult> SuperviseThenReleaseAsync(FFRunner runner, StartedProcess started)
+        {
+            try
+            {
+                return await runner.SuperviseAsync(started, _stopSignal.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                _stopSignal.Dispose();
+            }
+        }
+
+        public async Task<FFResult> StopAsync(CancellationToken cancellationToken)
+        {
+            // Cancelling is what drives the graceful stop: supervision writes q, waits the action's
+            // grace period, then kills the tree.
+            try
+            {
+                await _stopSignal.CancelAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already finished and released itself; the result below is what mattered.
+            }
+
+            // Honour the caller's token: a stuck completion must not pin the caller indefinitely.
+            return await Completion.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // The token source releases itself when supervision ends, so this only has to make sure
+            // supervision has in fact ended. Disposing again is harmless and keeps the ownership
+            // obvious to anyone reading the class.
+            await StopAsync(CancellationToken.None).ConfigureAwait(false);
+            _stopSignal.Dispose();
+        }
+    }
+}

--- a/MediaBrowser.MediaEncoding/FFProcessing/FFRunner.cs
+++ b/MediaBrowser.MediaEncoding/FFProcessing/FFRunner.cs
@@ -110,8 +110,28 @@ public sealed class FFRunner : IFFRunner, IDisposable
         ArgumentNullException.ThrowIfNull(request);
         var policy = request.ResolvePolicy();
 
+        // This is the only point that knows whether the request supplies
+        // the progress signal the idle watchdog needs.
+        policy.EnsureCoherent(request.Action, request.HasProgressSignal);
+
         return new ResolvedCommand(policy, ResolveBinaryPath(request, policy), BuildArguments(request, policy));
     }
+
+    /// <summary>
+    /// Guarantees what <see cref="FFActionPolicy.StderrIsPayload"/> promises: an action reading its
+    /// own stderr as the answer gets a sink that keeps all of it.
+    /// <para>
+    /// The log-level floor alone is not enough. The default sink retains a trailing window, which is
+    /// right for output that only explains a failure and wrong for output that <em>is</em> the
+    /// result — the part that matters could be anywhere in it. Leaving this to each caller makes the
+    /// guarantee depend on every call site remembering, and the failure is silent: a truncated
+    /// answer parses as no answer.
+    /// </para>
+    /// </summary>
+    private static FFRequest UpgradeSinkIfPayload(FFRequest request, in FFActionPolicy policy)
+        => policy.StderrIsPayload && !request.Stderr.RetainsEverything
+            ? request with { Stderr = FFOutputSink.Complete() }
+            : request;
 
     /// <summary>
     /// Picks the executable for a request: the one it names, or the resolved prober or encoder.
@@ -141,6 +161,8 @@ public sealed class FFRunner : IFFRunner, IDisposable
         var (policy, fileName, arguments) = Resolve(request);
         _logger.LogDebug("{Action}: {FileName} {Arguments}", request.Action, fileName, arguments);
 
+        request = UpgradeSinkIfPayload(request, policy);
+
         var process = CreateProcess(request, fileName, arguments);
         var stopwatch = Stopwatch.StartNew();
 
@@ -160,13 +182,19 @@ public sealed class FFRunner : IFFRunner, IDisposable
         _running[process.Id] = process;
         ApplyPriority(process, request, policy.Priority);
 
-        if (policy.Stdin == FFStdinMode.FireAndForget)
+        switch (policy.Stdin)
         {
-            TryCloseStdin(process, request);
-        }
-        else if (request.Action == FFAction.ProbeRuntimeKeys)
-        {
-            await WriteRuntimeKeyAsync(process, request).ConfigureAwait(false);
+            case FFStdinMode.FireAndForget:
+                TryCloseStdin(process, request);
+                break;
+
+            case FFStdinMode.WriteThenClose:
+                await WriteQueryKeyAsync(process, request).ConfigureAwait(false);
+                break;
+
+            default:
+                // ControlChannel: left open for the caller to steer through IFFSession.
+                break;
         }
 
         // Drains start before the exit wait because a full pipe would block the child, which then never exits.
@@ -348,7 +376,11 @@ public sealed class FFRunner : IFFRunner, IDisposable
         }
     }
 
-    private async Task WriteRuntimeKeyAsync(Process process, FFRequest request)
+    /// <summary>
+    /// Asks the question that <see cref="FFStdinMode.WriteThenClose"/> exists for, then closes stdin
+    /// so the child sees end of input.
+    /// </summary>
+    private async Task WriteQueryKeyAsync(Process process, FFRequest request)
     {
         try
         {
@@ -358,7 +390,7 @@ public sealed class FFRunner : IFFRunner, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "{Action}: could not write the runtime key", request.Action);
+            _logger.LogDebug(ex, "{Action}: could not write the query key", request.Action);
         }
     }
 
@@ -385,6 +417,10 @@ public sealed class FFRunner : IFFRunner, IDisposable
         return request.Stderr.GetRetainedText();
     }
 
+    /// <summary>
+    /// Ends the process, asking first where the action allows it. Called from a <c>finally</c>, so it
+    /// never throws: an exception here would replace whatever sent us down that path.
+    /// </summary>
     private async Task TerminateAsync(Process process, FFActionPolicy policy, FFRequest request)
     {
         try
@@ -394,21 +430,15 @@ public sealed class FFRunner : IFFRunner, IDisposable
                 return;
             }
 
-            if (policy.Stdin == FFStdinMode.ControlChannel)
+            // Asking is best-effort and must never cost us the kill. Only an exit skips it — a failed
+            // request to stop falls through, because the caller is left with a live process either
+            // way and this is the last chance to reap it. SuperviseAsync drops the process from
+            // _running the moment this returns, so anything still alive here is beyond the reach of
+            // the shutdown sweep too.
+            if (policy.Stdin == FFStdinMode.ControlChannel
+                && await TryStopPolitelyAsync(process, policy, request).ConfigureAwait(false))
             {
-                await process.StandardInput.WriteLineAsync("q").ConfigureAwait(false);
-                await process.StandardInput.FlushAsync().ConfigureAwait(false);
-
-                using var grace = new CancellationTokenSource(policy.GracefulStopTimeout);
-                try
-                {
-                    await process.WaitForExitAsync(grace.Token).ConfigureAwait(false);
-                    return;
-                }
-                catch (OperationCanceledException)
-                {
-                    // Fall through to the kill.
-                }
+                return;
             }
 
             process.Kill(true);
@@ -416,6 +446,36 @@ public sealed class FFRunner : IFFRunner, IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "{Action}: failed to terminate the process", request.Action);
+        }
+    }
+
+    /// <summary>
+    /// Writes the quit key and waits out the action's grace period.
+    /// </summary>
+    /// <returns>
+    /// Whether the process actually exited. Any failure reports <c>false</c> so the caller escalates.
+    /// </returns>
+    private async Task<bool> TryStopPolitelyAsync(Process process, FFActionPolicy policy, FFRequest request)
+    {
+        try
+        {
+            await process.StandardInput.WriteLineAsync("q").ConfigureAwait(false);
+            await process.StandardInput.FlushAsync().ConfigureAwait(false);
+
+            using var grace = new CancellationTokenSource(policy.GracefulStopTimeout);
+            await process.WaitForExitAsync(grace.Token).ConfigureAwait(false);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Covers the grace expiring and stdin not being writable at all. A child that has
+            // closed its stdin makes the write throw an IOException on a broken pipe. A handle
+            // already disposed throws ObjectDisposedException. Neither may cost us the kill: the
+            // caller is left with a live process either way.
+            _logger.LogDebug(ex, "{Action}: did not stop when asked; killing", request.Action);
+
+            return false;
         }
     }
 

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -21,6 +21,8 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
@@ -38,6 +40,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private readonly ILogger<SubtitleEncoder> _logger;
         private readonly IFileSystem _fileSystem;
         private readonly IMediaEncoder _mediaEncoder;
+        private readonly IFFRunner _ffRunner;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly ISubtitleParser _subtitleParser;
@@ -57,6 +60,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ILogger<SubtitleEncoder> logger,
             IFileSystem fileSystem,
             IMediaEncoder mediaEncoder,
+            IFFRunner ffRunner,
             IHttpClientFactory httpClientFactory,
             IMediaSourceManager mediaSourceManager,
             ISubtitleParser subtitleParser,
@@ -66,6 +70,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             _logger = logger;
             _fileSystem = fileSystem;
             _mediaEncoder = mediaEncoder;
+            _ffRunner = ffRunner;
             _httpClientFactory = httpClientFactory;
             _mediaSourceManager = mediaSourceManager;
             _subtitleParser = subtitleParser;
@@ -440,24 +445,16 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
             var encodingParam = await GetSubtitleFileCharacterSet(subtitleStream, subtitleStream.Language, mediaSource, cancellationToken).ConfigureAwait(false);
 
-            // FFmpeg automatically convert character encoding when it is UTF-16
-            // If we specify character encoding, it rejects with "do not specify a character encoding" and "Unable to recode subtitle event"
-            if ((inputPath.EndsWith(".smi", StringComparison.Ordinal) || inputPath.EndsWith(".sami", StringComparison.Ordinal)) &&
-                (encodingParam.Equals("UTF-16BE", StringComparison.OrdinalIgnoreCase) ||
-                 encodingParam.Equals("UTF-16LE", StringComparison.OrdinalIgnoreCase)))
+            var request = new SubtitleConvertRequest
             {
-                encodingParam = string.Empty;
-            }
-            else if (!string.IsNullOrEmpty(encodingParam))
-            {
-                encodingParam = " -sub_charenc " + encodingParam;
-            }
-
-            var args = string.Format(CultureInfo.InvariantCulture, "-y {0} -i \"{1}\" -c:s srt \"{2}\"", encodingParam, inputPath, outputPath);
+                Input = inputPath,
+                OutputPath = outputPath,
+                SourceCharacterEncoding = encodingParam
+            };
 
             await ExtractSubtitlesForFile(
                 inputPath,
-                args,
+                request,
                 [outputPath],
                 cancellationToken).ConfigureAwait(false);
 
@@ -593,10 +590,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             {
                 var inputPath = _mediaEncoder.GetInputArgument(mksFile, mediaSource);
                 var outputPaths = new List<string>();
-                var args = string.Format(
-                    CultureInfo.InvariantCulture,
-                    "-y -i {0}",
-                    inputPath);
+                var targets = new List<SubtitleTarget>();
 
                 foreach (var subtitleStream in subtitleStreams)
                 {
@@ -611,9 +605,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                         continue;
                     }
 
-                    var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
-                    // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
-                    var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
                     var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
                     if (streamIndex == -1)
@@ -625,16 +616,18 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
 
                     outputPaths.Add(outputPath);
-                    args += string.Format(
-                        CultureInfo.InvariantCulture,
-                        " -map 0:{0} -an -vn -c:s {1}{2} -flush_packets 1 \"{3}\"",
+                    targets.Add(new SubtitleTarget(
                         streamIndex,
-                        outputCodec,
-                        outputFormatOption,
-                        outputPath);
+                        outputPath,
+                        IsCodecCopyable(subtitleStream.Codec),
+                        MediaStream.IsVobSubFormat(subtitleStream.Codec)));
                 }
 
-                await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
+                await ExtractSubtitlesForFile(
+                    inputPath,
+                    new SubtitleExtractRequest { Input = inputPath, Targets = targets },
+                    outputPaths,
+                    cancellationToken).ConfigureAwait(false);
 
                 foreach (var outputPath in outputPaths)
                 {
@@ -650,10 +643,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         {
             var inputPath = _mediaEncoder.GetInputArgument(mediaSource.Path, mediaSource);
             var outputPaths = new List<string>();
-            var args = string.Format(
-                CultureInfo.InvariantCulture,
-                "-y -i {0}",
-                inputPath);
+            var targets = new List<SubtitleTarget>();
 
             foreach (var subtitleStream in subtitleStreams)
             {
@@ -669,9 +659,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                     continue;
                 }
 
-                var outputCodec = IsCodecCopyable(subtitleStream.Codec) ? "copy" : "srt";
-                // FFmpeg does not provide an .idx/.sub muxer, so VobSub streams must be written as MKS files.
-                var outputFormatOption = MediaStream.IsVobSubFormat(subtitleStream.Codec) ? " -f matroska" : string.Empty;
                 var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, subtitleStream);
 
                 if (streamIndex == -1)
@@ -683,18 +670,20 @@ namespace MediaBrowser.MediaEncoding.Subtitles
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new FileNotFoundException($"Calculated path ({outputPath}) is not valid."));
 
                 outputPaths.Add(outputPath);
-                args += string.Format(
-                    CultureInfo.InvariantCulture,
-                    " -map 0:{0} -an -vn -c:s {1}{2} -flush_packets 1 \"{3}\"",
+                targets.Add(new SubtitleTarget(
                     streamIndex,
-                    outputCodec,
-                    outputFormatOption,
-                    outputPath);
+                    outputPath,
+                    IsCodecCopyable(subtitleStream.Codec),
+                    MediaStream.IsVobSubFormat(subtitleStream.Codec)));
             }
 
             if (outputPaths.Count > 0)
             {
-                await ExtractSubtitlesForFile(inputPath, args, outputPaths, cancellationToken).ConfigureAwait(false);
+                await ExtractSubtitlesForFile(
+                    inputPath,
+                    new SubtitleExtractRequest { Input = inputPath, Targets = targets },
+                    outputPaths,
+                    cancellationToken).ConfigureAwait(false);
 
                 foreach (var outputPath in outputPaths)
                 {
@@ -705,15 +694,16 @@ namespace MediaBrowser.MediaEncoding.Subtitles
 
         private async Task ExtractSubtitlesForFile(
             string inputPath,
-            string args,
+            FFRequest request,
             IReadOnlyList<string> outputPaths,
             CancellationToken cancellationToken)
         {
-            var (exitCode, ffmpegError) = await RunSubtitleExtractionProcess(args, cancellationToken).ConfigureAwait(false);
+            var result = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
+            var ffmpegError = result.Stderr;
 
             var failed = false;
 
-            if (exitCode == -1)
+            if (!result.Succeeded)
             {
                 failed = true;
 
@@ -833,106 +823,23 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ArgumentException.ThrowIfNullOrEmpty(outputPath);
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath)));
-            var processArgs = string.Format(
-                CultureInfo.InvariantCulture,
-                "-y -i {0} -copyts -map 0:{1} -an -vn -c:s {2} \"{3}\"",
-                inputPath,
-                subtitleStreamIndex,
-                outputCodec,
-                outputPath);
+            var request = new SubtitleExtractRequest
+            {
+                Input = inputPath,
+                Targets = [new SubtitleTarget(
+                    subtitleStreamIndex,
+                    outputPath,
+                    string.Equals(outputCodec, "copy", StringComparison.OrdinalIgnoreCase),
+                    false)]
+            };
 
             await ExtractSubtitlesForFile(
                 inputPath,
-                processArgs,
+                request,
                 [outputPath],
                 cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Runs ffmpeg to extract or convert subtitles, capturing its exit code and stderr output.
-        /// </summary>
-        /// <remarks>
-        /// stdin is redirected and closed, and <c>-nostdin</c> is prepended to the arguments, so ffmpeg can never
-        /// block reading an inherited stdin handle (which happens when Jellyfin runs as a service, e.g. under NSSM,
-        /// and stalls subtitle extraction until the timeout). stderr is redirected and drained so a full pipe buffer
-        /// cannot deadlock ffmpeg and so its output can be surfaced on failure; stdout is left un-redirected as it is
-        /// unused for subtitle extraction.
-        /// </remarks>
-        /// <param name="arguments">The ffmpeg command line arguments.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The ffmpeg exit code (-1 on timeout) and its captured stderr output.</returns>
-        private async Task<(int ExitCode, string StandardError)> RunSubtitleExtractionProcess(string arguments, CancellationToken cancellationToken)
-        {
-            int exitCode;
-            var standardError = string.Empty;
-
-            using (var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardInput = true,
-                    RedirectStandardError = true,
-                    FileName = _mediaEncoder.EncoderPath,
-                    Arguments = "-nostdin " + arguments,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    ErrorDialog = false
-                },
-                EnableRaisingEvents = true
-            })
-            {
-                _logger.LogInformation("{File} {Arguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
-
-                try
-                {
-                    process.Start();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error starting ffmpeg");
-                    throw;
-                }
-
-                // Close stdin so ffmpeg observes EOF instead of blocking on an inherited handle.
-                process.StandardInput.Close();
-
-                // Begin draining stderr before waiting for exit; a full stderr pipe buffer would otherwise deadlock ffmpeg.
-                var standardErrorTask = process.StandardError.ReadToEndAsync(CancellationToken.None);
-                var timeoutMinutes = _serverConfigurationManager.GetEncodingOptions().SubtitleExtractionTimeoutMinutes;
-                using var waitSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                waitSource.CancelAfter(TimeSpan.FromMinutes(timeoutMinutes));
-
-                try
-                {
-                    await process.WaitForExitAsync(waitSource.Token).ConfigureAwait(false);
-                    exitCode = process.ExitCode;
-                }
-                catch (OperationCanceledException)
-                {
-                    process.Kill(true);
-                    exitCode = -1;
-                }
-
-                try
-                {
-                    standardError = await standardErrorTask.ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    // Reading ffmpeg output was cancelled; nothing more to capture.
-                }
-            }
-
-            return (exitCode, standardError);
-        }
-
-        /// <summary>
-        /// Sets the ass font.
-        /// </summary>
-        /// <param name="file">The file.</param>
-        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <c>System.Threading.CancellationToken.None</c>.</param>
-        /// <returns>Task.</returns>
         private async Task SetAssFont(string file, CancellationToken cancellationToken = default)
         {
             _logger.LogInformation("Setting ass font within {File}", file);

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -45,7 +45,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly ISubtitleParser _subtitleParser;
         private readonly IPathManager _pathManager;
-        private readonly IServerConfigurationManager _serverConfigurationManager;
 
         /// <summary>
         /// The _semaphoreLocks.
@@ -64,8 +63,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             IHttpClientFactory httpClientFactory,
             IMediaSourceManager mediaSourceManager,
             ISubtitleParser subtitleParser,
-            IPathManager pathManager,
-            IServerConfigurationManager serverConfigurationManager)
+            IPathManager pathManager)
         {
             _logger = logger;
             _fileSystem = fileSystem;
@@ -75,7 +73,6 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             _mediaSourceManager = mediaSourceManager;
             _subtitleParser = subtitleParser;
             _pathManager = pathManager;
-            _serverConfigurationManager = serverConfigurationManager;
         }
 
         internal MemoryStream ConvertSubtitles(

--- a/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/SubtitleEncoder.cs
@@ -45,6 +45,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
         private readonly IMediaSourceManager _mediaSourceManager;
         private readonly ISubtitleParser _subtitleParser;
         private readonly IPathManager _pathManager;
+        private readonly IServerConfigurationManager _serverConfigurationManager;
 
         /// <summary>
         /// The _semaphoreLocks.
@@ -63,7 +64,8 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             IHttpClientFactory httpClientFactory,
             IMediaSourceManager mediaSourceManager,
             ISubtitleParser subtitleParser,
-            IPathManager pathManager)
+            IPathManager pathManager,
+            IServerConfigurationManager serverConfigurationManager)
         {
             _logger = logger;
             _fileSystem = fileSystem;
@@ -73,6 +75,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             _mediaSourceManager = mediaSourceManager;
             _subtitleParser = subtitleParser;
             _pathManager = pathManager;
+            _serverConfigurationManager = serverConfigurationManager;
         }
 
         internal MemoryStream ConvertSubtitles(
@@ -695,6 +698,9 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             IReadOnlyList<string> outputPaths,
             CancellationToken cancellationToken)
         {
+            var timeoutMinutes = _serverConfigurationManager.GetEncodingOptions().SubtitleExtractionTimeoutMinutes;
+            request = request with { Timeout = TimeSpan.FromMinutes(timeoutMinutes) };
+
             var result = await _ffRunner.RunAsync(request, cancellationToken).ConfigureAwait(false);
             var ffmpegError = result.Stderr;
 
@@ -820,6 +826,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             ArgumentException.ThrowIfNullOrEmpty(outputPath);
 
             Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath)));
+
             var request = new SubtitleExtractRequest
             {
                 Input = inputPath,

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -19,6 +19,8 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dlna;
@@ -42,6 +44,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
     private readonly ISessionManager _sessionManager;
     private readonly EncodingHelper _encodingHelper;
     private readonly IMediaEncoder _mediaEncoder;
+    private readonly IFFRunner _ffRunner;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IAttachmentExtractor _attachmentExtractor;
 
@@ -65,6 +68,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
     /// <param name="sessionManager">The <see cref="ISessionManager"/>.</param>
     /// <param name="encodingHelper">The <see cref="EncodingHelper"/>.</param>
     /// <param name="mediaEncoder">The <see cref="IMediaEncoder"/>.</param>
+    /// <param name="ffRunner">The <see cref="IFFRunner"/>.</param>
     /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/>.</param>
     /// <param name="attachmentExtractor">The <see cref="IAttachmentExtractor"/>.</param>
     public TranscodeManager(
@@ -76,6 +80,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         ISessionManager sessionManager,
         EncodingHelper encodingHelper,
         IMediaEncoder mediaEncoder,
+        IFFRunner ffRunner,
         IMediaSourceManager mediaSourceManager,
         IAttachmentExtractor attachmentExtractor)
     {
@@ -87,6 +92,7 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         _sessionManager = sessionManager;
         _encodingHelper = encodingHelper;
         _mediaEncoder = mediaEncoder;
+        _ffRunner = ffRunner;
         _mediaSourceManager = mediaSourceManager;
         _attachmentExtractor = attachmentExtractor;
 
@@ -414,53 +420,22 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
             }
         }
 
-        var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                WindowStyle = ProcessWindowStyle.Hidden,
-                CreateNoWindow = true,
-                UseShellExecute = false,
-
-                // Must consume both stdout and stderr or deadlocks may occur
-                // RedirectStandardOutput = true,
-                StandardErrorEncoding = Encoding.UTF8,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-                FileName = _mediaEncoder.EncoderPath,
-                Arguments = commandLineArguments,
-                WorkingDirectory = string.IsNullOrWhiteSpace(workingDirectory) ? string.Empty : workingDirectory,
-                ErrorDialog = false
-            },
-            EnableRaisingEvents = true
-        };
-
         var transcodingJob = OnTranscodeBeginning(
             outputPath,
             state.Request.PlaySessionId,
             state.MediaSource.LiveStreamId,
             Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture),
             transcodingJobType,
-            process,
             state.Request.DeviceId,
             state,
             cancellationTokenSource);
 
-        _logger.LogInformation("{Filename} {Arguments}", process.StartInfo.FileName, process.StartInfo.Arguments);
-
-        var logFilePrefix = "FFmpeg.Transcode-";
-        if (state.VideoRequest is not null
-            && EncodingHelper.IsCopyCodec(state.OutputVideoCodec))
+        var logFilePrefix = state.StreamMode switch
         {
-            logFilePrefix = EncodingHelper.IsCopyCodec(state.OutputAudioCodec)
-                ? "FFmpeg.Remux-"
-                : "FFmpeg.DirectStream-";
-        }
-
-        if (state.VideoRequest is null && EncodingHelper.IsCopyCodec(state.OutputAudioCodec))
-        {
-            logFilePrefix = "FFmpeg.Remux-";
-        }
+            StreamMode.Remux => "FFmpeg.Remux-",
+            StreamMode.DirectStream => "FFmpeg.DirectStream-",
+            _ => "FFmpeg.Transcode-"
+        };
 
         var logFilePath = Path.Combine(
             _serverConfigurationManager.ApplicationPaths.LogDirectoryPath,
@@ -475,35 +450,71 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
             IODefaults.FileStreamBufferSize,
             FileOptions.Asynchronous);
 
+        var request = new StreamRequest
+        {
+            Delivery = transcodingJobType == TranscodingJobType.Progressive ? FFDelivery.Progressive : FFDelivery.Hls,
+            Mode = state.StreamMode,
+            Arguments = commandLineArguments,
+            WorkingDirectory = workingDirectory ?? string.Empty,
+
+            // One read serves both the log file and the progress feed.
+            Stderr = new JobLogSink(_logger, state, logStream)
+        };
+
         await JsonSerializer.SerializeAsync(logStream, state.MediaSource, cancellationToken: cancellationTokenSource.Token).ConfigureAwait(false);
-        var commandLineLogMessageBytes = Encoding.UTF8.GetBytes(
-            Environment.NewLine
-            + Environment.NewLine
-            + process.StartInfo.FileName + " " + process.StartInfo.Arguments
-            + Environment.NewLine
-            + Environment.NewLine);
 
-        await logStream.WriteAsync(commandLineLogMessageBytes, cancellationTokenSource.Token).ConfigureAwait(false);
+        // Ask the runner rather than pairing the encoder path with our own arguments. The runner adds
+        // the global flags — the derived -loglevel, -stats, the overwrite flag — so those two strings
+        // are no longer the whole command, and a header built from them would not reproduce when
+        // pasted into a shell. This is the artifact people attach to bug reports; it has to be real.
+        //
+        // Written before StartAsync, and this is why the request is built first: JobLogSink starts
+        // writing FFmpeg's stderr into the same stream the moment the process is up, so a header
+        // written afterwards would interleave with it.
+        await logStream.WriteAsync(
+            Encoding.UTF8.GetBytes(
+                Environment.NewLine + Environment.NewLine
+                + _ffRunner.GetCommandLine(request)
+                + Environment.NewLine + Environment.NewLine),
+            cancellationTokenSource.Token).ConfigureAwait(false);
 
-        process.Exited += (_, _) => OnFfMpegProcessExited(process, transcodingJob, state);
-
+        IFFSession session;
         try
         {
-            process.Start();
+            session = await _ffRunner.StartAsync(request, cancellationTokenSource.Token).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error starting FFmpeg");
             OnTranscodeFailedToStart(outputPath, transcodingJobType, state);
 
+            // Nothing will complete, so the exit path that normally closes this never runs.
+            await logStream.DisposeAsync().ConfigureAwait(false);
+
             throw;
+        }
+
+        transcodingJob.Session = session;
+
+        // Not awaited: the caller must be able to stop playback while this is still running.
+        _ = ReportExitAsync();
+
+        async Task ReportExitAsync()
+        {
+            try
+            {
+                var result = await session.Completion.ConfigureAwait(false);
+                OnFfMpegProcessExited(result, transcodingJob, state, logStream);
+            }
+            catch (Exception ex)
+            {
+                // Nothing awaits this, so an escape here would be lost entirely.
+                _logger.LogError(ex, "Error finalising the transcode for {Path}", outputPath);
+            }
         }
 
         _logger.LogDebug("Launched FFmpeg process");
         state.TranscodingJob = transcodingJob;
-
-        // Important - don't await the log task or we won't be able to kill FFmpeg when the user stops playback
-        _ = new JobLogger(_logger).StartStreamingLog(state, process.StandardError, logStream);
 
         // Wait for the file to exist before proceeding
         var ffmpegTargetFile = state.WaitForPath ?? outputPath;
@@ -580,7 +591,6 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         string? liveStreamId,
         string transcodingJobId,
         TranscodingJobType type,
-        Process process,
         string? deviceId,
         StreamState state,
         CancellationTokenSource cancellationTokenSource)
@@ -591,7 +601,6 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
             {
                 Type = type,
                 Path = path,
-                Process = process,
                 ActiveRequestCount = 1,
                 DeviceId = deviceId,
                 CancellationTokenSource = cancellationTokenSource,
@@ -638,23 +647,29 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
         }
     }
 
-    private void OnFfMpegProcessExited(Process process, TranscodingJob job, StreamState state)
+    private void OnFfMpegProcessExited(FFResult result, TranscodingJob job, StreamState state, Stream logStream)
     {
         job.HasExited = true;
-        job.ExitCode = process.ExitCode;
+        job.ExitCode = result.ExitCode;
 
         ReportTranscodingProgress(job, state, null, null, null, null, null);
 
         _logger.LogDebug("Disposing stream resources");
         state.Dispose();
+        logStream.Dispose();
 
-        if (process.ExitCode == 0)
+        if (result.Succeeded)
         {
             _logger.LogInformation("FFmpeg exited with code 0");
         }
+        else if (result.StopReason == FFStopReason.Cancelled)
+        {
+            // Playback stopped, which is not a failure.
+            _logger.LogDebug("FFmpeg stopped for {Path}", job.Path);
+        }
         else
         {
-            _logger.LogError("FFmpeg exited with code {0}", process.ExitCode);
+            _logger.LogError("FFmpeg exited with code {ExitCode}", result.ExitCode);
         }
 
         job.Dispose();

--- a/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
+++ b/MediaBrowser.MediaEncoding/Transcoding/TranscodeManager.cs
@@ -465,8 +465,8 @@ public sealed class TranscodeManager : ITranscodeManager, IDisposable
 
         // Ask the runner rather than pairing the encoder path with our own arguments. The runner adds
         // the global flags — the derived -loglevel, -stats, the overwrite flag — so those two strings
-        // are no longer the whole command, and a header built from them would not reproduce when
-        // pasted into a shell. This is the artifact people attach to bug reports; it has to be real.
+        // are not the whole command, and a header built from them would not reproduce when pasted
+        // into a shell. This is the artifact people attach to bug reports; it has to be real.
         //
         // Written before StartAsync, and this is why the request is built first: JobLogSink starts
         // writing FFmpeg's stderr into the same stream the moment the process is up, so a header

--- a/README.md
+++ b/README.md
@@ -157,6 +157,28 @@ This repository also includes unit tests that are used to validate functionality
 2. Run tests in Visual Studio using the [Test Explorer](https://docs.microsoft.com/en-us/visualstudio/test/run-unit-tests-with-test-explorer)
 3. Run individual tests in Visual Studio Code using the associated [CodeLens annotation](https://github.com/OmniSharp/omnisharp-vscode/wiki/How-to-run-and-debug-unit-tests)
 
+#### Tests Requiring FFmpeg
+
+A few tests run a real FFmpeg to check that the arguments the server generates are actually
+accepted, rather than merely well-formed. They need an FFmpeg binary, so they are marked
+`Explicit` and none of the commands above will run them.
+
+Run them with xUnit's `-explicit` switch, which only the in-process runner understands — it is a
+single dash, and `dotnet test` does not accept it:
+
+```bash
+dotnet run --project tests/Jellyfin.MediaEncoding.Tests -- -explicit only  # just these tests
+dotnet run --project tests/Jellyfin.MediaEncoding.Tests -- -explicit on    # these plus the rest
+```
+
+The binary is taken from `JELLYFIN_ffmpeg`, the same environment variable the server itself
+honours and the one `--ffmpeg` sets, falling back to `/usr/share/jellyfin-ffmpeg/ffmpeg`. FFprobe
+is not configured separately; it is derived from that path exactly as the server derives it. If no
+binary is found the tests fail rather than skip.
+
+Any media these tests need is synthesised at runtime with FFmpeg's `lavfi` sources into a
+temporary directory and deleted afterwards.
+
 ### Advanced Configuration
 
 The following sections describe some more advanced scenarios for running the server from source that build upon the standard instructions above.

--- a/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
@@ -86,7 +86,7 @@ namespace Jellyfin.LiveTv.IO
 
             await JsonSerializer.SerializeAsync(_logFileStream, mediaSource, _jsonOptions, cancellationToken).ConfigureAwait(false);
             await _logFileStream.WriteAsync(
-                Encoding.UTF8.GetBytes(Environment.NewLine + Environment.NewLine + _mediaEncoder.EncoderPath + Environment.NewLine + Environment.NewLine),
+                Encoding.UTF8.GetBytes(Environment.NewLine + Environment.NewLine + _ffRunner.GetCommandLine(request) + Environment.NewLine + Environment.NewLine),
                 cancellationToken).ConfigureAwait(false);
 
             // Cancellation is the stop signal: the runner writes q, waits the action's grace period,

--- a/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
@@ -35,7 +35,6 @@ namespace Jellyfin.LiveTv.IO
         private readonly IFFRunner _ffRunner;
         private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
         private FileStream _logFileStream;
-        private string _targetPath;
         private bool _disposed;
 
         public EncodedRecorder(
@@ -70,7 +69,6 @@ namespace Jellyfin.LiveTv.IO
 
         private async Task RecordFromFile(MediaSourceInfo mediaSource, string inputFile, string targetFile, Action onStarted, CancellationToken cancellationToken)
         {
-            _targetPath = targetFile;
             Directory.CreateDirectory(Path.GetDirectoryName(targetFile));
             if (!File.Exists(targetFile))
             {
@@ -105,7 +103,7 @@ namespace Jellyfin.LiveTv.IO
                 throw;
             }
 
-            _logger.LogInformation("ffmpeg recording process started for {Path}", _targetPath);
+            _logger.LogInformation("ffmpeg recording process started for {Path}", targetFile);
             onStarted();
 
             var result = await session.Completion.ConfigureAwait(false);
@@ -124,7 +122,7 @@ namespace Jellyfin.LiveTv.IO
 
             if (!result.Succeeded)
             {
-                throw new FfmpegException($"Recording for {_targetPath} failed. Exit code {result.ExitCode}");
+                throw new FfmpegException($"Recording for {targetFile} failed. Exit code {result.ExitCode}");
             }
         }
 

--- a/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
@@ -19,6 +19,8 @@ using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
@@ -30,25 +32,22 @@ namespace Jellyfin.LiveTv.IO
         private readonly ILogger _logger;
         private readonly IMediaEncoder _mediaEncoder;
         private readonly IServerApplicationPaths _appPaths;
-        private readonly TaskCompletionSource<bool> _taskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly IServerConfigurationManager _serverConfigurationManager;
+        private readonly IFFRunner _ffRunner;
         private readonly JsonSerializerOptions _jsonOptions = JsonDefaults.Options;
-        private bool _hasExited;
         private FileStream _logFileStream;
         private string _targetPath;
-        private Process _process;
         private bool _disposed;
 
         public EncodedRecorder(
             ILogger logger,
             IMediaEncoder mediaEncoder,
             IServerApplicationPaths appPaths,
-            IServerConfigurationManager serverConfigurationManager)
+            IFFRunner ffRunner)
         {
             _logger = logger;
             _mediaEncoder = mediaEncoder;
             _appPaths = appPaths;
-            _serverConfigurationManager = serverConfigurationManager;
+            _ffRunner = ffRunner;
         }
 
         private static bool CopySubtitles => false;
@@ -78,125 +77,74 @@ namespace Jellyfin.LiveTv.IO
                 FileHelper.CreateEmpty(targetFile);
             }
 
-            var processStartInfo = new ProcessStartInfo
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-
-                StandardErrorEncoding = Encoding.UTF8,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-
-                FileName = _mediaEncoder.EncoderPath,
-                Arguments = GetCommandLineArgs(mediaSource, inputFile, targetFile),
-
-                WindowStyle = ProcessWindowStyle.Hidden,
-                ErrorDialog = false
-            };
-
-            _logger.LogInformation("{Filename} {Arguments}", processStartInfo.FileName, processStartInfo.Arguments);
-
             var logFilePath = Path.Combine(_appPaths.LogDirectoryPath, "record-transcode-" + Guid.NewGuid() + ".txt");
             Directory.CreateDirectory(Path.GetDirectoryName(logFilePath));
 
-            // FFMpeg writes debug/error info to stderr. This is useful when debugging so let's put it in the log directory.
             _logFileStream = new FileStream(logFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
 
+            var request = BuildRequest(mediaSource, inputFile, targetFile);
+
             await JsonSerializer.SerializeAsync(_logFileStream, mediaSource, _jsonOptions, cancellationToken).ConfigureAwait(false);
-            await _logFileStream.WriteAsync(Encoding.UTF8.GetBytes(Environment.NewLine + Environment.NewLine + processStartInfo.FileName + " " + processStartInfo.Arguments + Environment.NewLine + Environment.NewLine), cancellationToken).ConfigureAwait(false);
+            await _logFileStream.WriteAsync(
+                Encoding.UTF8.GetBytes(Environment.NewLine + Environment.NewLine + _mediaEncoder.EncoderPath + Environment.NewLine + Environment.NewLine),
+                cancellationToken).ConfigureAwait(false);
 
-            _process = new Process
+            // Cancellation is the stop signal: the runner writes q, waits the action's grace period,
+            // then kills the tree. That replaces the old Register(Stop) plus manual escalation.
+            IFFSession session;
+            try
             {
-                StartInfo = processStartInfo,
-                EnableRaisingEvents = true
-            };
-            _process.Exited += (_, _) => OnFfMpegProcessExited(_process);
+                session = await _ffRunner.StartAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Nothing will complete, so the path that normally closes this never runs.
+                await _logFileStream.DisposeAsync().ConfigureAwait(false);
+                _logFileStream = null;
 
-            _process.Start();
-
-            cancellationToken.Register(Stop);
-
-            onStarted();
-
-            // Important - don't await the log task or we won't be able to kill ffmpeg when the user stops playback
-            _ = StartStreamingLog(_process.StandardError.BaseStream, _logFileStream);
+                throw;
+            }
 
             _logger.LogInformation("ffmpeg recording process started for {Path}", _targetPath);
+            onStarted();
 
-            // Block until ffmpeg exits
-            await _taskCompletionSource.Task.ConfigureAwait(false);
+            var result = await session.Completion.ConfigureAwait(false);
+
+            if (_logFileStream is not null)
+            {
+                await _logFileStream.DisposeAsync().ConfigureAwait(false);
+                _logFileStream = null;
+            }
+
+            if (result.StopReason == FFStopReason.Cancelled)
+            {
+                // The recording was stopped deliberately, by the duration cap or by the user.
+                return;
+            }
+
+            if (!result.Succeeded)
+            {
+                throw new FfmpegException($"Recording for {_targetPath} failed. Exit code {result.ExitCode}");
+            }
         }
 
-        private string GetCommandLineArgs(MediaSourceInfo mediaSource, string inputTempFile, string targetFile)
+        private RecordRequest BuildRequest(MediaSourceInfo mediaSource, string inputTempFile, string targetFile)
         {
-            string videoArgs = "-codec:v:0 copy -fflags +genpts";
-
-            var flags = new List<string>();
-            if (mediaSource.IgnoreDts)
+            return new RecordRequest
             {
-                flags.Add("+igndts");
-            }
+                Input = "\"" + inputTempFile + "\"",
+                OutputPath = "\"" + targetFile.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"",
+                EncoderVersion = _mediaEncoder.EncoderVersion,
+                IgnoreDts = mediaSource.IgnoreDts,
+                IgnoreIndex = mediaSource.IgnoreIndex,
+                GeneratePts = mediaSource.GenPtsInput,
+                ReadAtNativeFramerate = mediaSource.ReadAtNativeFramerate,
+                RequiresLooping = mediaSource.RequiresLooping,
+                CopySubtitles = CopySubtitles,
 
-            if (mediaSource.IgnoreIndex)
-            {
-                flags.Add("+ignidx");
-            }
-
-            if (mediaSource.GenPtsInput)
-            {
-                flags.Add("+genpts");
-            }
-
-            var inputModifier = "-async 1";
-
-            if (flags.Count > 0)
-            {
-                inputModifier += " -fflags " + string.Join(string.Empty, flags);
-            }
-
-            if (mediaSource.ReadAtNativeFramerate)
-            {
-                inputModifier += " -re";
-
-                // Set a larger catchup value to revert to the old behavior,
-                // otherwise, remuxing might stall due to this new option
-                if (_mediaEncoder.EncoderVersion >= new Version(8, 0))
-                {
-                    inputModifier += " -readrate_catchup 100";
-                }
-            }
-
-            if (mediaSource.RequiresLooping)
-            {
-                inputModifier += " -stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
-            }
-
-            var analyzeDurationSeconds = 5;
-            var analyzeDuration = " -analyzeduration " +
-                  (analyzeDurationSeconds * 1000000).ToString(CultureInfo.InvariantCulture);
-            inputModifier += analyzeDuration;
-
-            var subtitleArgs = CopySubtitles ? " -codec:s copy" : " -sn";
-
-            // var outputParam = string.Equals(Path.GetExtension(targetFile), ".mp4", StringComparison.OrdinalIgnoreCase) ?
-            //    " -f mp4 -movflags frag_keyframe+empty_moov" :
-            //    string.Empty;
-
-            var outputParam = string.Empty;
-
-            var threads = EncodingHelper.GetNumberOfThreads(null, _serverConfigurationManager.GetEncodingOptions(), null);
-            var commandLineArgs = string.Format(
-                CultureInfo.InvariantCulture,
-                "-i \"{0}\" {2} -map_metadata -1 -threads {6} {3}{4}{5} -y \"{1}\"",
-                inputTempFile,
-                targetFile.Replace("\"", "\\\"", StringComparison.Ordinal), // Escape quotes in filename
-                videoArgs,
-                GetAudioArgs(mediaSource),
-                subtitleArgs,
-                outputParam,
-                threads);
-
-            return inputModifier + " " + commandLineArgs;
+                // Written through as it arrives so the log is readable while the recording runs.
+                Stderr = FFOutputSink.ToStream(_logFileStream)
+            };
         }
 
         private static string GetAudioArgs(MediaSourceInfo mediaSource)
@@ -207,111 +155,9 @@ namespace Jellyfin.LiveTv.IO
         protected string GetOutputSizeParam()
             => "-vf \"yadif=0:-1:0\"";
 
-        private void Stop()
-        {
-            if (!_hasExited)
-            {
-                try
-                {
-                    _logger.LogInformation("Stopping ffmpeg recording process for {Path}", _targetPath);
-
-                    _process.StandardInput.WriteLine("q");
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error stopping recording transcoding job for {Path}", _targetPath);
-                }
-
-                if (_hasExited)
-                {
-                    return;
-                }
-
-                try
-                {
-                    _logger.LogInformation("Calling recording process.WaitForExit for {Path}", _targetPath);
-
-                    if (_process.WaitForExit(10000))
-                    {
-                        return;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error waiting for recording process to exit for {Path}", _targetPath);
-                }
-
-                if (_hasExited)
-                {
-                    return;
-                }
-
-                try
-                {
-                    _logger.LogInformation("Killing ffmpeg recording process for {Path}", _targetPath);
-
-                    _process.Kill();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error killing recording transcoding job for {Path}", _targetPath);
-                }
-            }
-        }
-
         /// <summary>
         /// Processes the exited.
         /// </summary>
-        private void OnFfMpegProcessExited(Process process)
-        {
-            using (process)
-            {
-                _hasExited = true;
-
-                _logFileStream?.Dispose();
-                _logFileStream = null;
-
-                var exitCode = process.ExitCode;
-
-                _logger.LogInformation("FFMpeg recording exited with code {ExitCode} for {Path}", exitCode, _targetPath);
-
-                if (exitCode == 0)
-                {
-                    _taskCompletionSource.TrySetResult(true);
-                }
-                else
-                {
-                    _taskCompletionSource.TrySetException(
-                        new FfmpegException(
-                            string.Format(
-                                CultureInfo.InvariantCulture,
-                                "Recording for {0} failed. Exit code {1}",
-                                _targetPath,
-                                exitCode)));
-                }
-            }
-        }
-
-        private async Task StartStreamingLog(Stream source, FileStream target)
-        {
-            try
-            {
-                using (var reader = new StreamReader(source))
-                {
-                    await foreach (var line in reader.ReadAllLinesAsync().ConfigureAwait(false))
-                    {
-                        var bytes = Encoding.UTF8.GetBytes(Environment.NewLine + line);
-
-                        await target.WriteAsync(bytes.AsMemory()).ConfigureAwait(false);
-                        await target.FlushAsync().ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error reading ffmpeg recording log");
-            }
-        }
 
         /// <inheritdoc />
         public void Dispose()
@@ -334,11 +180,9 @@ namespace Jellyfin.LiveTv.IO
             if (disposing)
             {
                 _logFileStream?.Dispose();
-                _process?.Dispose();
             }
 
             _logFileStream = null;
-            _process = null;
 
             _disposed = true;
         }

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -22,6 +22,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
@@ -45,6 +46,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     private readonly ILibraryMonitor _libraryMonitor;
     private readonly IProviderManager _providerManager;
     private readonly IMediaEncoder _mediaEncoder;
+    private readonly IFFRunner _ffRunner;
     private readonly IMediaSourceManager _mediaSourceManager;
     private readonly IStreamHelper _streamHelper;
     private readonly TimerManager _timerManager;
@@ -66,6 +68,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     /// <param name="libraryMonitor">The <see cref="ILibraryMonitor"/>.</param>
     /// <param name="providerManager">The <see cref="IProviderManager"/>.</param>
     /// <param name="mediaEncoder">The <see cref="IMediaEncoder"/>.</param>
+    /// <param name="ffRunner">The <see cref="IFFRunner"/>.</param>
     /// <param name="mediaSourceManager">The <see cref="IMediaSourceManager"/>.</param>
     /// <param name="streamHelper">The <see cref="IStreamHelper"/>.</param>
     /// <param name="timerManager">The <see cref="TimerManager"/>.</param>
@@ -80,6 +83,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         ILibraryMonitor libraryMonitor,
         IProviderManager providerManager,
         IMediaEncoder mediaEncoder,
+        IFFRunner ffRunner,
         IMediaSourceManager mediaSourceManager,
         IStreamHelper streamHelper,
         TimerManager timerManager,
@@ -94,6 +98,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         _libraryMonitor = libraryMonitor;
         _providerManager = providerManager;
         _mediaEncoder = mediaEncoder;
+        _ffRunner = ffRunner;
         _mediaSourceManager = mediaSourceManager;
         _streamHelper = streamHelper;
         _timerManager = timerManager;
@@ -794,7 +799,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             || !(mediaSource.Container ?? string.Empty).EndsWith("ts", StringComparison.OrdinalIgnoreCase)
             || (mediaSource.Protocol != MediaProtocol.File && mediaSource.Protocol != MediaProtocol.Http))
         {
-            return new EncodedRecorder(_logger, _mediaEncoder, _config.ApplicationPaths, _config);
+            return new EncodedRecorder(_logger, _mediaEncoder, _config.ApplicationPaths, _ffRunner);
         }
 
         return new DirectRecorder(_logger, _httpClientFactory, _streamHelper);

--- a/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Cache/CacheDecorator.cs
@@ -1,9 +1,9 @@
 #pragma warning disable CA1826 // Do not use Enumerable methods on indexable collections
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.MediaEncoding.Hls.Extractors;
 using Jellyfin.MediaEncoding.Keyframes;
 using MediaBrowser.Controller.Persistence;
@@ -40,22 +40,24 @@ public class CacheDecorator : IKeyframeExtractor
     public bool IsMetadataBased => _keyframeExtractor.IsMetadataBased;
 
     /// <inheritdoc />
-    public bool TryExtractKeyframes(Guid itemId, string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
+    public async Task<KeyframeData?> ExtractKeyframesAsync(Guid itemId, string filePath, CancellationToken cancellationToken)
     {
-        keyframeData = _keyframeRepository.GetKeyframeData(itemId).FirstOrDefault();
-        if (keyframeData is null)
+        var keyframeData = _keyframeRepository.GetKeyframeData(itemId).FirstOrDefault();
+        if (keyframeData is not null)
         {
-            if (!_keyframeExtractor.TryExtractKeyframes(itemId, filePath, out var result))
-            {
-                _logger.LogDebug("Failed to extract keyframes using {ExtractorName}", _keyframeExtractorName);
-                return false;
-            }
-
-            _logger.LogDebug("Successfully extracted keyframes using {ExtractorName}", _keyframeExtractorName);
-            keyframeData = result;
-            _keyframeRepository.SaveKeyframeDataAsync(itemId, keyframeData, CancellationToken.None).GetAwaiter().GetResult();
+            return keyframeData;
         }
 
-        return true;
+        keyframeData = await _keyframeExtractor.ExtractKeyframesAsync(itemId, filePath, cancellationToken).ConfigureAwait(false);
+        if (keyframeData is null)
+        {
+            _logger.LogDebug("Failed to extract keyframes using {ExtractorName}", _keyframeExtractorName);
+            return null;
+        }
+
+        _logger.LogDebug("Successfully extracted keyframes using {ExtractorName}", _keyframeExtractorName);
+        await _keyframeRepository.SaveKeyframeDataAsync(itemId, keyframeData, cancellationToken).ConfigureAwait(false);
+
+        return keyframeData;
     }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Extractors/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Extractors/FfProbeKeyframeExtractor.cs
@@ -1,10 +1,12 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Emby.Naming.Common;
 using Jellyfin.Extensions;
 using Jellyfin.MediaEncoding.Keyframes;
-using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using Microsoft.Extensions.Logging;
 using Extractor = Jellyfin.MediaEncoding.Keyframes.FfProbe.FfProbeKeyframeExtractor;
 
@@ -13,19 +15,19 @@ namespace Jellyfin.MediaEncoding.Hls.Extractors;
 /// <inheritdoc />
 public class FfProbeKeyframeExtractor : IKeyframeExtractor
 {
-    private readonly IMediaEncoder _mediaEncoder;
+    private readonly IFFRunner _ffRunner;
     private readonly NamingOptions _namingOptions;
     private readonly ILogger<FfProbeKeyframeExtractor> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FfProbeKeyframeExtractor"/> class.
     /// </summary>
-    /// <param name="mediaEncoder">An instance of the <see cref="IMediaEncoder"/> interface.</param>
+    /// <param name="ffRunner">An instance of the <see cref="IFFRunner"/> interface.</param>
     /// <param name="namingOptions">An instance of <see cref="NamingOptions"/>.</param>
     /// <param name="logger">An instance of the <see cref="ILogger{FfprobeKeyframeExtractor}"/> interface.</param>
-    public FfProbeKeyframeExtractor(IMediaEncoder mediaEncoder, NamingOptions namingOptions, ILogger<FfProbeKeyframeExtractor> logger)
+    public FfProbeKeyframeExtractor(IFFRunner ffRunner, NamingOptions namingOptions, ILogger<FfProbeKeyframeExtractor> logger)
     {
-        _mediaEncoder = mediaEncoder;
+        _ffRunner = ffRunner;
         _namingOptions = namingOptions;
         _logger = logger;
     }
@@ -34,25 +36,53 @@ public class FfProbeKeyframeExtractor : IKeyframeExtractor
     public bool IsMetadataBased => false;
 
     /// <inheritdoc />
-    public bool TryExtractKeyframes(Guid itemId, string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
+    public async Task<KeyframeData?> ExtractKeyframesAsync(Guid itemId, string filePath, CancellationToken cancellationToken)
     {
         if (!_namingOptions.VideoFileExtensions.Contains(Path.GetExtension(filePath.AsSpan()), StringComparison.OrdinalIgnoreCase))
         {
-            keyframeData = null;
-            return false;
+            return null;
         }
+
+        KeyframeData? keyframeData = null;
 
         try
         {
-            keyframeData = Extractor.GetKeyframeData(_mediaEncoder.ProbePath, filePath);
-            return keyframeData.KeyframeTicks.Count > 0;
+            // The library owns the parsing; this layer only owns getting ffprobe to produce it.
+            var result = await _ffRunner.RunAsync(
+                new KeyframeScanRequest
+                {
+                    FilePath = filePath,
+                    Stdout = (stdout, _) =>
+                    {
+                        using var reader = new StreamReader(stdout);
+                        keyframeData = Extractor.ParseStream(reader);
+                        return Task.CompletedTask;
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                _logger.LogError(
+                    "Extracting keyframes from {FilePath} using ffprobe failed: {Stderr}",
+                    filePath,
+                    result.Stderr);
+
+                return null;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is not "this file has no keyframes"; letting it surface as null would
+            // cache that conclusion and hide why the scan stopped.
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Extracting keyframes from {FilePath} using ffprobe failed", filePath);
+            return null;
         }
 
-        keyframeData = null;
-        return false;
+        return keyframeData?.KeyframeTicks.Count > 0 ? keyframeData : null;
     }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Extractors/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Extractors/FfProbeKeyframeExtractor.cs
@@ -52,12 +52,11 @@ public class FfProbeKeyframeExtractor : IKeyframeExtractor
                 new KeyframeScanRequest
                 {
                     FilePath = filePath,
-                    Stdout = (stdout, _) =>
-                    {
-                        using var reader = new StreamReader(stdout);
-                        keyframeData = Extractor.ParseStream(reader);
-                        return Task.CompletedTask;
-                    }
+
+                    // Task.Run because Extractor.ParseStream is a blocking read loop
+                    Stdout = (stdout, ct) => Task.Run(
+                        () => keyframeData = Extractor.ParseStream(new StreamReader(stdout)),
+                        ct)
                 },
                 cancellationToken).ConfigureAwait(false);
 

--- a/src/Jellyfin.MediaEncoding.Hls/Extractors/IKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Extractors/IKeyframeExtractor.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.MediaEncoding.Keyframes;
 
 namespace Jellyfin.MediaEncoding.Hls.Extractors;
@@ -19,7 +20,7 @@ public interface IKeyframeExtractor
     /// </summary>
     /// <param name="itemId">The item id.</param>
     /// <param name="filePath">The path to the file.</param>
-    /// <param name="keyframeData">The keyframes.</param>
-    /// <returns>A value indicating whether the keyframe extraction was successful.</returns>
-    bool TryExtractKeyframes(Guid itemId, string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The keyframes, or <c>null</c> when this extractor cannot handle the file.</returns>
+    Task<KeyframeData?> ExtractKeyframesAsync(Guid itemId, string filePath, CancellationToken cancellationToken);
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Extractors/MatroskaKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Extractors/MatroskaKeyframeExtractor.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.MediaEncoding.Keyframes;
 using Microsoft.Extensions.Logging;
 using Extractor = Jellyfin.MediaEncoding.Keyframes.Matroska.MatroskaKeyframeExtractor;
@@ -24,25 +25,24 @@ public class MatroskaKeyframeExtractor : IKeyframeExtractor
     public bool IsMetadataBased => true;
 
     /// <inheritdoc />
-    public bool TryExtractKeyframes(Guid itemId, string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
+    public Task<KeyframeData?> ExtractKeyframesAsync(Guid itemId, string filePath, CancellationToken cancellationToken)
     {
         if (!filePath.AsSpan().EndsWith(".mkv", StringComparison.OrdinalIgnoreCase))
         {
-            keyframeData = null;
-            return false;
+            return Task.FromResult<KeyframeData?>(null);
         }
 
         try
         {
-            keyframeData = Extractor.GetKeyframeData(filePath);
-            return keyframeData.KeyframeTicks.Count > 0;
+            // Reading the container index is pure file work, so there is nothing to await here.
+            var keyframeData = Extractor.GetKeyframeData(filePath);
+            return Task.FromResult(keyframeData.KeyframeTicks.Count > 0 ? keyframeData : null);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Extracting keyframes from {FilePath} using matroska metadata failed", filePath);
         }
 
-        keyframeData = null;
-        return false;
+        return Task.FromResult<KeyframeData?>(null);
     }
 }

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/CreateMainPlaylistRequest.cs
@@ -3,7 +3,7 @@ using System;
 namespace Jellyfin.MediaEncoding.Hls.Playlist;
 
 /// <summary>
-/// Request class for the <see cref="IDynamicHlsPlaylistGenerator.CreateMainPlaylist(CreateMainPlaylistRequest)"/> method.
+/// Request class for the <see cref="IDynamicHlsPlaylistGenerator.CreateMainPlaylistAsync(CreateMainPlaylistRequest, System.Threading.CancellationToken)"/> method.
 /// </summary>
 public class CreateMainPlaylistRequest
 {

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/DynamicHlsPlaylistGenerator.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.MediaEncoding.Hls.Extractors;
 using Jellyfin.MediaEncoding.Keyframes;
 using MediaBrowser.Common.Configuration;
@@ -31,13 +33,13 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
     }
 
     /// <inheritdoc />
-    public string CreateMainPlaylist(CreateMainPlaylistRequest request)
+    public async Task<string> CreateMainPlaylistAsync(CreateMainPlaylistRequest request, CancellationToken cancellationToken)
     {
         IReadOnlyList<double> segments;
         // For video transcodes it is sufficient with equal length segments as ffmpeg will create new keyframes
         if (request.IsRemuxingVideo
             && request.MediaSourceId is not null
-            && TryExtractKeyframes(request.MediaSourceId.Value, request.FilePath, out var keyframeData))
+            && await ExtractKeyframesAsync(request.MediaSourceId.Value, request.FilePath, cancellationToken).ConfigureAwait(false) is { } keyframeData)
         {
             segments = ComputeSegments(keyframeData, request.DesiredSegmentLengthMs);
         }
@@ -106,28 +108,23 @@ public class DynamicHlsPlaylistGenerator : IDynamicHlsPlaylistGenerator
         return builder.ToString();
     }
 
-    private bool TryExtractKeyframes(Guid itemId, string filePath, [NotNullWhen(true)] out KeyframeData? keyframeData)
+    private async Task<KeyframeData?> ExtractKeyframesAsync(Guid itemId, string filePath, CancellationToken cancellationToken)
     {
-        keyframeData = null;
         if (!IsExtractionAllowedForFile(filePath, _serverConfigurationManager.GetEncodingOptions().AllowOnDemandMetadataBasedKeyframeExtractionForExtensions))
         {
-            return false;
+            return null;
         }
 
-        var len = _extractors.Length;
-        for (var i = 0; i < len; i++)
+        foreach (var extractor in _extractors)
         {
-            var extractor = _extractors[i];
-            if (!extractor.TryExtractKeyframes(itemId, filePath, out var result))
+            var result = await extractor.ExtractKeyframesAsync(itemId, filePath, cancellationToken).ConfigureAwait(false);
+            if (result is not null)
             {
-                continue;
+                return result;
             }
-
-            keyframeData = result;
-            return true;
         }
 
-        return false;
+        return null;
     }
 
     internal static bool IsExtractionAllowedForFile(ReadOnlySpan<char> filePath, IReadOnlyList<string> allowedExtensions)

--- a/src/Jellyfin.MediaEncoding.Hls/Playlist/IDynamicHlsPlaylistGenerator.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/Playlist/IDynamicHlsPlaylistGenerator.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Jellyfin.MediaEncoding.Hls.Playlist;
 
 /// <summary>
@@ -9,6 +12,7 @@ public interface IDynamicHlsPlaylistGenerator
     /// Creates the main playlist containing the main video or audio stream.
     /// </summary>
     /// <param name="request">An instance of the <see cref="CreateMainPlaylistRequest"/> class.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The playlist as a formatted string.</returns>
-    string CreateMainPlaylist(CreateMainPlaylistRequest request);
+    Task<string> CreateMainPlaylistAsync(CreateMainPlaylistRequest request, CancellationToken cancellationToken);
 }

--- a/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
+++ b/src/Jellyfin.MediaEncoding.Hls/ScheduledTasks/KeyframeExtractionScheduledTask.cs
@@ -50,7 +50,7 @@ public class KeyframeExtractionScheduledTask : IScheduledTask
     public string Category => _localizationManager.GetLocalizedString("TasksLibraryCategory");
 
     /// <inheritdoc />
-    public Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
         var query = new InternalItemsQuery
         {
@@ -85,7 +85,7 @@ public class KeyframeExtractionScheduledTask : IScheduledTask
                     foreach (var extractor in _keyframeExtractors)
                     {
                         // The cache decorator will make sure to save the keyframes
-                        if (extractor.TryExtractKeyframes(video.Id, path, out _))
+                        if (await extractor.ExtractKeyframesAsync(video.Id, path, cancellationToken).ConfigureAwait(false) is not null)
                         {
                             break;
                         }
@@ -102,7 +102,6 @@ public class KeyframeExtractionScheduledTask : IScheduledTask
         }
 
         progress.Report(100);
-        return Task.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
+++ b/src/Jellyfin.MediaEncoding.Keyframes/FfProbe/FfProbeKeyframeExtractor.cs
@@ -18,6 +18,9 @@ public static class FfProbeKeyframeExtractor
     /// <param name="ffProbePath">The path to the ffprobe executable.</param>
     /// <param name="filePath">The file path.</param>
     /// <returns>An instance of <see cref="KeyframeData"/>.</returns>
+    [Obsolete("Spawns an unsupervised process: no timeout, no cancellation and no stderr capture. "
+        + "Jellyfin now runs this through IFFRunner and only parses here. Retained for external "
+        + "callers; use ParseStream with your own supervised process instead.")]
     public static KeyframeData GetKeyframeData(string ffProbePath, string filePath)
     {
         using var process = new Process
@@ -34,9 +37,8 @@ public static class FfProbeKeyframeExtractor
                 UseShellExecute = false,
                 StandardOutputEncoding = Encoding.UTF8,
                 RedirectStandardOutput = true,
-
                 WindowStyle = ProcessWindowStyle.Hidden,
-                ErrorDialog = false,
+                ErrorDialog = false
             },
             EnableRaisingEvents = true
         };
@@ -44,14 +46,14 @@ public static class FfProbeKeyframeExtractor
         try
         {
             process.Start();
+
             try
             {
                 process.PriorityClass = ProcessPriorityClass.BelowNormal;
             }
             catch
             {
-                // We do not care if process priority setting fails
-                // Ideally log a warning but this does not have a logger available
+                // Not fatal; priority is an optimisation.
             }
 
             return ParseStream(process.StandardOutput);
@@ -67,14 +69,19 @@ public static class FfProbeKeyframeExtractor
             }
             catch
             {
-                // We do not care if this fails
+                // Best effort.
             }
 
             throw;
         }
     }
 
-    internal static KeyframeData ParseStream(StreamReader reader)
+    /// <summary>
+    /// Parses ffprobe's CSV output into keyframe data.
+    /// </summary>
+    /// <param name="reader">The ffprobe standard output.</param>
+    /// <returns>An instance of <see cref="KeyframeData"/>.</returns>
+    public static KeyframeData ParseStream(StreamReader reader)
     {
         var keyframes = new List<long>();
         double streamDuration = 0;

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Controller.Tests.MediaEncoding.FFProcessing;
 public static class FFActionPolicyTests
 {
     /// <summary>
-    /// The distinctive values per action: what each arm exists to say. Anything not listed is
+    /// Gets the distinctive values per action: what each arm exists to say. Anything not listed is
     /// inherited and is covered by the cross-cutting invariants below instead.
     /// </summary>
     public static TheoryData<FFAction, bool, bool, FFStdinMode, bool, bool> Distinctive => new()
@@ -39,7 +39,7 @@ public static class FFActionPolicyTests
         { FFAction.Stream, false, true, FFStdinMode.ControlChannel, true, false },
     };
 
-    /// <summary>The deadline and priority each action is expected to carry.</summary>
+    /// <summary>Gets the deadline and priority each action is expected to carry.</summary>
     public static TheoryData<FFAction, TimeSpan, TimeSpan, ProcessPriorityClass> Bounds => new()
     {
         // action, timeout, idleTimeout, priority

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding.FFProcessing;
+
+/// <summary>
+/// Pins <see cref="FFActionPolicy.For"/>.
+/// <para>
+/// Every arm of that table states only what makes its action unusual and inherits the rest, which
+/// makes it cheap to write and easy to break: deleting a line does not fail to compile, it silently
+/// swaps in a background default. Several of those defaults are wrong in ways nothing observes at
+/// run time — an interrogation that quietly loses its deadline still works until the day it hangs.
+/// These tests are what turns that into a build failure.
+/// </para>
+/// </summary>
+public static class FFActionPolicyTests
+{
+    /// <summary>
+    /// The distinctive values per action: what each arm exists to say. Anything not listed is
+    /// inherited and is covered by the cross-cutting invariants below instead.
+    /// </summary>
+    public static TheoryData<FFAction, bool, bool, FFStdinMode, bool, bool> Distinctive => new()
+    {
+        // action, probeOnly, overwrite, stdin, requiresProgressStats, stderrIsPayload
+        { FFAction.Probe, true, false, FFStdinMode.FireAndForget, false, false },
+        { FFAction.ScanKeyframes, true, false, FFStdinMode.FireAndForget, false, false },
+        { FFAction.ValidateBinary, false, false, FFStdinMode.FireAndForget, false, false },
+        { FFAction.Capabilities, false, false, FFStdinMode.FireAndForget, false, true },
+        { FFAction.ProbeRuntimeKeys, false, false, FFStdinMode.ControlChannel, false, true },
+        { FFAction.MeasureLoudness, false, false, FFStdinMode.FireAndForget, false, true },
+        { FFAction.ExtractAttachment, false, true, FFStdinMode.FireAndForget, false, false },
+        { FFAction.ExtractSubtitle, false, true, FFStdinMode.FireAndForget, false, false },
+        { FFAction.ExtractImage, false, true, FFStdinMode.FireAndForget, false, false },
+        { FFAction.GenerateTrickplay, false, true, FFStdinMode.FireAndForget, false, false },
+        { FFAction.Record, false, true, FFStdinMode.ControlChannel, false, false },
+        { FFAction.Stream, false, true, FFStdinMode.ControlChannel, true, false },
+    };
+
+    /// <summary>The deadline and priority each action is expected to carry.</summary>
+    public static TheoryData<FFAction, TimeSpan, TimeSpan, ProcessPriorityClass> Bounds => new()
+    {
+        // action, timeout, idleTimeout, priority
+        { FFAction.Probe, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.ScanKeyframes, FFActionPolicy.FullFileScan, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.ValidateBinary, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
+        { FFAction.Capabilities, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
+        { FFAction.ProbeRuntimeKeys, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
+        { FFAction.MeasureLoudness, FFActionPolicy.FullAudioScan, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractAttachment, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractSubtitle, FFActionPolicy.DefaultSubtitleExtraction, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractImage, FFActionPolicy.DefaultImageExtraction, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
+        { FFAction.GenerateTrickplay, FFDefaults.Unbounded, FFActionPolicy.DefaultImageExtraction, ProcessPriorityClass.BelowNormal },
+        { FFAction.Record, FFDefaults.Unbounded, FFDefaults.Unbounded, ProcessPriorityClass.Normal },
+        { FFAction.Stream, FFDefaults.Unbounded, FFDefaults.Unbounded, ProcessPriorityClass.Normal },
+    };
+
+    public static TheoryData<FFAction> AllActions => new(Enum.GetValues<FFAction>());
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public static void For_DefinesAPolicyForEveryAction(FFAction action)
+    {
+        // The table's fallback arm throws, so a newly added action with no arm of its own fails here
+        // rather than at the moment something first tries to run it.
+        var exception = Record.Exception(() => FFActionPolicy.For(action));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public static void For_RejectsAnActionOutsideTheEnum()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => FFActionPolicy.For((FFAction)(-1)));
+    }
+
+    [Fact]
+    public static void EveryActionIsPinnedByTheseTests()
+    {
+        // Guards the tables above, which are hand-maintained: adding an action without adding rows
+        // would otherwise leave it silently unpinned while everything still passes.
+        var actions = Enum.GetValues<FFAction>();
+
+        Assert.Equal(actions.Length, Distinctive.Count);
+        Assert.Equal(actions.Length, Bounds.Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(Distinctive))]
+    public static void For_CarriesTheDistinctiveValues(
+        FFAction action,
+        bool probeOnly,
+        bool overwrite,
+        FFStdinMode stdin,
+        bool requiresProgressStats,
+        bool stderrIsPayload)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        Assert.Equal(probeOnly, policy.ProbeOnly);
+        Assert.Equal(overwrite, policy.Overwrite);
+        Assert.Equal(stdin, policy.Stdin);
+        Assert.Equal(requiresProgressStats, policy.RequiresProgressStats);
+        Assert.Equal(stderrIsPayload, policy.StderrIsPayload);
+    }
+
+    [Theory]
+    [MemberData(nameof(Bounds))]
+    public static void For_CarriesTheExpectedBounds(
+        FFAction action,
+        TimeSpan timeout,
+        TimeSpan idleTimeout,
+        ProcessPriorityClass priority)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        Assert.Equal(timeout, policy.Timeout);
+        Assert.Equal(idleTimeout, policy.IdleTimeout);
+        Assert.Equal(priority, policy.Priority);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public static void NoActionIsUnboundedInEveryDimension(FFAction action)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        if (policy.Timeout != FFDefaults.Unbounded)
+        {
+            return;
+        }
+
+        // An action may drop the wall clock only because something else bounds it: an idle watchdog,
+        // or a control channel that lets the caller stop it when the viewer or the recording is done.
+        // Losing both is how a process becomes unkillable in practice, and nothing at run time would
+        // report it — the run simply never ends.
+        Assert.True(
+            policy.IdleTimeout != FFDefaults.Unbounded || policy.Stdin == FFStdinMode.ControlChannel,
+            $"{action} has no wall clock, no idle watchdog and no way to be asked to stop.");
+    }
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public static void OnlyASteerableActionCanBeAskedToStop(FFAction action)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        if (policy.GracefulStopTimeout == TimeSpan.Zero)
+        {
+            return;
+        }
+
+        // The grace period is the wait after writing "q" to stdin. An action that closes stdin has
+        // nowhere to write it, so the grace would be spent waiting for a message never delivered
+        // before killing the process anyway.
+        Assert.Equal(FFStdinMode.ControlChannel, policy.Stdin);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public static void AProbeNeverClaimsToOverwrite(FFAction action)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        if (!policy.ProbeOnly)
+        {
+            return;
+        }
+
+        // ffprobe registers neither -y nor -n, so the runner omits them for a probe. Setting the flag
+        // would therefore be inert, and an inert setting that reads as meaningful is worse than none.
+        Assert.False(policy.Overwrite);
+    }
+
+    [Fact]
+    public static void OnlyTrickplayArmsTheIdleWatchdog()
+    {
+        // Stated as a rule in the table's own documentation. The watchdog only means anything where
+        // the request supplies a progress signal, and trickplay's tile count is the only one.
+        var armed = Enum.GetValues<FFAction>()
+            .Where(a => FFActionPolicy.For(a).IdleTimeout != FFDefaults.Unbounded)
+            .ToArray();
+
+        Assert.Equal([FFAction.GenerateTrickplay], armed);
+    }
+
+    [Fact]
+    public static void OnlyStderrScrapersFloorTheLogLevel()
+    {
+        // StderrIsPayload both floors -loglevel at info and retains all of stderr rather than a
+        // trailing window. Every action that parses its own stderr for the answer must be here; the
+        // failure mode for a missing one is silent, so the set is pinned rather than spot-checked.
+        var payload = Enum.GetValues<FFAction>()
+            .Where(a => FFActionPolicy.For(a).StderrIsPayload)
+            .ToArray();
+
+        Assert.Equal(
+            [FFAction.Capabilities, FFAction.ProbeRuntimeKeys, FFAction.MeasureLoudness],
+            payload);
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFActionPolicyTests.cs
@@ -29,7 +29,7 @@ public static class FFActionPolicyTests
         { FFAction.ScanKeyframes, true, false, FFStdinMode.FireAndForget, false, false },
         { FFAction.ValidateBinary, false, false, FFStdinMode.FireAndForget, false, false },
         { FFAction.Capabilities, false, false, FFStdinMode.FireAndForget, false, true },
-        { FFAction.ProbeRuntimeKeys, false, false, FFStdinMode.ControlChannel, false, true },
+        { FFAction.ProbeRuntimeKeys, false, false, FFStdinMode.WriteThenClose, false, true },
         { FFAction.MeasureLoudness, false, false, FFStdinMode.FireAndForget, false, true },
         { FFAction.ExtractAttachment, false, true, FFStdinMode.FireAndForget, false, false },
         { FFAction.ExtractSubtitle, false, true, FFStdinMode.FireAndForget, false, false },
@@ -39,22 +39,25 @@ public static class FFActionPolicyTests
         { FFAction.Stream, false, true, FFStdinMode.ControlChannel, true, false },
     };
 
-    /// <summary>Gets the deadline and priority each action is expected to carry.</summary>
-    public static TheoryData<FFAction, TimeSpan, TimeSpan, ProcessPriorityClass> Bounds => new()
+    /// <summary>
+    /// Gets the deadlines, stop grace and priority each action is expected to carry. A zero grace
+    /// means the action is killed outright rather than asked to stop first.
+    /// </summary>
+    public static TheoryData<FFAction, TimeSpan, TimeSpan, TimeSpan, ProcessPriorityClass> Bounds => new()
     {
-        // action, timeout, idleTimeout, priority
-        { FFAction.Probe, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.ScanKeyframes, FFActionPolicy.FullFileScan, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.ValidateBinary, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
-        { FFAction.Capabilities, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
-        { FFAction.ProbeRuntimeKeys, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, FFDefaults.InheritPriority },
-        { FFAction.MeasureLoudness, FFActionPolicy.FullAudioScan, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.ExtractAttachment, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.ExtractSubtitle, FFActionPolicy.DefaultSubtitleExtraction, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.ExtractImage, FFActionPolicy.DefaultImageExtraction, FFDefaults.Unbounded, ProcessPriorityClass.BelowNormal },
-        { FFAction.GenerateTrickplay, FFDefaults.Unbounded, FFActionPolicy.DefaultImageExtraction, ProcessPriorityClass.BelowNormal },
-        { FFAction.Record, FFDefaults.Unbounded, FFDefaults.Unbounded, ProcessPriorityClass.Normal },
-        { FFAction.Stream, FFDefaults.Unbounded, FFDefaults.Unbounded, ProcessPriorityClass.Normal },
+        // action, timeout, idleTimeout, gracefulStopTimeout, priority
+        { FFAction.Probe, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.ScanKeyframes, FFActionPolicy.FullFileScan, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.ValidateBinary, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, TimeSpan.Zero, FFDefaults.InheritPriority },
+        { FFAction.Capabilities, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, TimeSpan.Zero, FFDefaults.InheritPriority },
+        { FFAction.ProbeRuntimeKeys, FFActionPolicy.StartupInterrogation, FFDefaults.Unbounded, TimeSpan.Zero, FFDefaults.InheritPriority },
+        { FFAction.MeasureLoudness, FFActionPolicy.FullAudioScan, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractAttachment, FFActionPolicy.MetadataRead, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractSubtitle, FFActionPolicy.DefaultSubtitleExtraction, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.ExtractImage, FFActionPolicy.DefaultImageExtraction, FFDefaults.Unbounded, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.GenerateTrickplay, FFDefaults.Unbounded, FFActionPolicy.DefaultImageExtraction, TimeSpan.Zero, ProcessPriorityClass.BelowNormal },
+        { FFAction.Record, FFDefaults.Unbounded, FFDefaults.Unbounded, FFActionPolicy.RecordingStopGrace, ProcessPriorityClass.Normal },
+        { FFAction.Stream, FFDefaults.Unbounded, FFDefaults.Unbounded, FFActionPolicy.StreamStopGrace, ProcessPriorityClass.Normal },
     };
 
     public static TheoryData<FFAction> AllActions => new(Enum.GetValues<FFAction>());
@@ -112,12 +115,14 @@ public static class FFActionPolicyTests
         FFAction action,
         TimeSpan timeout,
         TimeSpan idleTimeout,
+        TimeSpan gracefulStopTimeout,
         ProcessPriorityClass priority)
     {
         var policy = FFActionPolicy.For(action);
 
         Assert.Equal(timeout, policy.Timeout);
         Assert.Equal(idleTimeout, policy.IdleTimeout);
+        Assert.Equal(gracefulStopTimeout, policy.GracefulStopTimeout);
         Assert.Equal(priority, policy.Priority);
     }
 
@@ -184,6 +189,60 @@ public static class FFActionPolicyTests
             .ToArray();
 
         Assert.Equal([FFAction.GenerateTrickplay], armed);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllActions))]
+    public static void EveryShippedPolicyIsCoherent(FFAction action)
+    {
+        // Trickplay is the only action whose request supplies a liveness probe, and the only one that
+        // needs to: it is also the only one without a wall clock other than the two steerable ones.
+        var hasProgressSignal = action == FFAction.GenerateTrickplay;
+
+        var exception = Record.Exception(() => FFActionPolicy.For(action).EnsureCoherent(action, hasProgressSignal));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public static void EnsureCoherent_RejectsAStopGraceWithNowhereToSendTheKey()
+    {
+        var policy = FFActionPolicy.For(FFAction.ExtractImage) with { GracefulStopTimeout = TimeSpan.FromSeconds(5) };
+
+        Assert.Throws<InvalidOperationException>(() => policy.EnsureCoherent(FFAction.ExtractImage, false));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public static void EnsureCoherent_RejectsAProbeAskingForEncoderBehaviour(bool steerable, bool wantsStats)
+    {
+        var policy = FFActionPolicy.For(FFAction.Probe) with
+        {
+            Stdin = steerable ? FFStdinMode.ControlChannel : FFStdinMode.FireAndForget,
+            RequiresProgressStats = wantsStats
+        };
+
+        Assert.Throws<InvalidOperationException>(() => policy.EnsureCoherent(FFAction.Probe, false));
+    }
+
+    [Fact]
+    public static void EnsureCoherent_RejectsAnIdleWatchdogWithNoProbeBehindIt()
+    {
+        // The half that no policy-only assertion can see. Trickplay's arm is correct; drop the probe
+        // from its request and the watchdog never arms, leaving nothing at all able to end the run.
+        var policy = FFActionPolicy.For(FFAction.GenerateTrickplay);
+
+        Assert.Throws<InvalidOperationException>(() => policy.EnsureCoherent(FFAction.GenerateTrickplay, false));
+        Assert.Null(Record.Exception(() => policy.EnsureCoherent(FFAction.GenerateTrickplay, true)));
+    }
+
+    [Fact]
+    public static void EnsureCoherent_RejectsDroppingEveryBoundAtOnce()
+    {
+        var policy = FFActionPolicy.For(FFAction.ExtractImage) with { Timeout = FFDefaults.Unbounded };
+
+        Assert.Throws<InvalidOperationException>(() => policy.EnsureCoherent(FFAction.ExtractImage, false));
     }
 
     [Fact]

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFOutputSinkTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFOutputSinkTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding.FFProcessing;
+
+public static class FFOutputSinkTests
+{
+    private static async Task<FFOutputSink> FillAsync(FFOutputSink sink, params string[] lines)
+    {
+        foreach (var line in lines)
+        {
+            await sink.WriteLineAsync(line, CancellationToken.None);
+        }
+
+        return sink;
+    }
+
+    [Fact]
+    public static async Task Diagnostic_KeepsEverythingUnderBudget()
+    {
+        var sink = await FillAsync(FFOutputSink.Diagnostic(), "first", "second", "third");
+
+        Assert.Equal(
+            string.Join(Environment.NewLine, "first", "second", "third"),
+            sink.GetRetainedText());
+    }
+
+    [Fact]
+    public static async Task Diagnostic_KeepsExactlyTheLastLines()
+    {
+        var sink = FFOutputSink.Diagnostic();
+        var lines = Enumerable.Range(0, FFOutputSink.DefaultRetainedLines * 3).Select(i => $"line {i}").ToArray();
+        await FillAsync(sink, lines);
+
+        var retained = sink.GetRetainedText().Split(Environment.NewLine);
+
+        Assert.Equal(FFOutputSink.DefaultRetainedLines, retained.Length);
+        Assert.Equal(lines[^FFOutputSink.DefaultRetainedLines..], retained);
+    }
+
+    [Fact]
+    public static async Task Diagnostic_EvictsWholeLinesNotFragments()
+    {
+        var sink = FFOutputSink.Diagnostic();
+        var lines = Enumerable.Range(0, 1000).Select(i => $"line {i} " + new string('x', 200)).ToArray();
+        await FillAsync(sink, lines);
+
+        // Every retained line is intact: none was cut mid-string.
+        Assert.All(
+            sink.GetRetainedText().Split(Environment.NewLine),
+            line => Assert.Contains(lines, original => original == line));
+    }
+
+    [Fact]
+    public static async Task Diagnostic_DoesNotSplitSurrogatePairs()
+    {
+        // Each line is entirely non-BMP, so a blind character-offset cut would strand a lone
+        // surrogate. Whole-line eviction cannot.
+        var sink = FFOutputSink.Diagnostic();
+        var line = string.Concat(Enumerable.Repeat("\U0001F600", 500));
+        await FillAsync(sink, Enumerable.Repeat(line, FFOutputSink.DefaultRetainedLines * 3).ToArray());
+
+        var retained = sink.GetRetainedText();
+
+        // EnumerateRunes yields the replacement character for a stranded surrogate, so its
+        // absence is exactly the property we want.
+        Assert.DoesNotContain(retained.EnumerateRunes(), rune => rune == Rune.ReplacementChar);
+    }
+
+    [Fact]
+    public static async Task Diagnostic_KeepsAVeryLongLineWhole()
+    {
+        // The bound is a line count, so length does not cause truncation. ReadLineAsync already
+        // materialised the string, so cutting it would not save the allocation anyway.
+        var huge = new string('y', 512 * 1024);
+        var sink = await FillAsync(FFOutputSink.Diagnostic(), huge);
+
+        Assert.Equal(huge, sink.GetRetainedText());
+    }
+
+    [Fact]
+    public static async Task Complete_KeepsEverything()
+    {
+        var sink = FFOutputSink.Complete();
+        var lines = Enumerable.Range(0, 5000).Select(i => $"line {i}").ToArray();
+        await FillAsync(sink, lines);
+
+        Assert.Equal(lines, sink.GetRetainedText().Split(Environment.NewLine));
+    }
+
+    [Fact]
+    public static async Task ToStream_WritesThroughAndRetainsNothing()
+    {
+        using var destination = new MemoryStream();
+        var sink = await FillAsync(FFOutputSink.ToStream(destination), "alpha", "beta");
+
+        Assert.Equal(string.Empty, sink.GetRetainedText());
+        Assert.Equal(
+            "alpha" + Environment.NewLine + "beta" + Environment.NewLine,
+            Encoding.UTF8.GetString(destination.ToArray()));
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFOutputSinkTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFOutputSinkTests.cs
@@ -105,4 +105,17 @@ public static class FFOutputSinkTests
             "alpha" + Environment.NewLine + "beta" + Environment.NewLine,
             Encoding.UTF8.GetString(destination.ToArray()));
     }
+
+    [Fact]
+    public static void OnlyCompleteClaimsToRetainEverything()
+    {
+        // The runner substitutes a retaining sink for an action whose stderr is its answer, and this
+        // is how it tells. A sink that dropped output while reporting true would truncate that answer
+        // with nothing to show for it.
+        using var destination = new MemoryStream();
+
+        Assert.True(FFOutputSink.Complete().RetainsEverything);
+        Assert.False(FFOutputSink.Diagnostic().RetainsEverything);
+        Assert.False(FFOutputSink.ToStream(destination).RetainsEverything);
+    }
 }

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFRequestTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFRequestTests.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Text;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding.FFProcessing;
+
+public static class FFRequestTests
+{
+    private static string Args(FFRequest request)
+    {
+        var builder = new StringBuilder();
+        request.BuildArguments(builder);
+        return builder.ToString();
+    }
+
+    [Theory]
+    [InlineData(FFAction.Probe)]
+    [InlineData(FFAction.ScanKeyframes)]
+    [InlineData(FFAction.Capabilities)]
+    [InlineData(FFAction.ProbeRuntimeKeys)]
+    [InlineData(FFAction.MeasureLoudness)]
+    [InlineData(FFAction.ExtractAttachment)]
+    [InlineData(FFAction.ExtractSubtitle)]
+    [InlineData(FFAction.ExtractImage)]
+    [InlineData(FFAction.GenerateTrickplay)]
+    [InlineData(FFAction.Record)]
+    public static void Policy_EveryActionHasOne(FFAction action)
+    {
+        var policy = FFActionPolicy.For(action);
+
+        Assert.NotEqual(TimeSpan.Zero, policy.Timeout);
+        Assert.NotEqual(TimeSpan.Zero, policy.IdleTimeout);
+        Assert.NotEqual(TimeSpan.Zero, policy.Timeout);
+    }
+
+    [Fact]
+    public static void Policy_OnlyProbesAreProbeOnly()
+    {
+        Assert.True(FFActionPolicy.For(FFAction.Probe).ProbeOnly);
+        Assert.True(FFActionPolicy.For(FFAction.ScanKeyframes).ProbeOnly);
+        Assert.False(FFActionPolicy.For(FFAction.ExtractImage).ProbeOnly);
+    }
+
+    [Theory]
+    [InlineData(FFAction.Probe)]
+    [InlineData(FFAction.ScanKeyframes)]
+    [InlineData(FFAction.Capabilities)]
+    [InlineData(FFAction.ProbeRuntimeKeys)]
+    [InlineData(FFAction.MeasureLoudness)]
+    [InlineData(FFAction.ExtractAttachment)]
+    [InlineData(FFAction.ExtractSubtitle)]
+    [InlineData(FFAction.ExtractImage)]
+    [InlineData(FFAction.GenerateTrickplay)]
+    [InlineData(FFAction.Record)]
+    public static void Policy_ProbeOnlyImpliesFireAndForget(FFAction action)
+    {
+        // ffprobe has no runtime-key interface, so a steerable probe is not a thing.
+        var policy = FFActionPolicy.For(action);
+
+        if (policy.ProbeOnly)
+        {
+            Assert.Equal(FFStdinMode.FireAndForget, policy.Stdin);
+        }
+    }
+
+    [Fact]
+    public static void Request_ProbeOnlyOverrideCannotMakeItSteerable()
+    {
+        // ProbeOnly is the one policy field a request may override, so cover that path too.
+        var request = new CapabilitiesRequest { Arguments = "-hwaccels", ProbeOnly = true };
+        var policy = request.ResolvePolicy();
+
+        Assert.True(policy.ProbeOnly);
+        Assert.Equal(FFStdinMode.FireAndForget, policy.Stdin);
+    }
+
+    [Fact]
+    public static void Policy_OnlyRecordIsSteerableByDefault()
+    {
+        Assert.Equal(FFStdinMode.ControlChannel, FFActionPolicy.For(FFAction.Record).Stdin);
+        Assert.Equal(FFStdinMode.FireAndForget, FFActionPolicy.For(FFAction.GenerateTrickplay).Stdin);
+        Assert.Equal(FFStdinMode.FireAndForget, FFActionPolicy.For(FFAction.Probe).Stdin);
+    }
+
+    [Theory]
+    [InlineData(FFAction.MeasureLoudness)]
+    [InlineData(FFAction.Capabilities)]
+    [InlineData(FFAction.ProbeRuntimeKeys)]
+    public static void Policy_ActionsThatParseTheirOwnStderrSaySo(FFAction action)
+    {
+        // These read stderr as the answer. Without the flag the runner derives -loglevel from the
+        // server level, and at the default that is quiet enough to suppress the answer entirely —
+        // silently, since ffmpeg still exits 0.
+        Assert.True(FFActionPolicy.For(action).StderrIsPayload);
+    }
+
+    [Theory]
+    [InlineData(FFAction.Probe)]
+    [InlineData(FFAction.ScanKeyframes)]
+    [InlineData(FFAction.ExtractAttachment)]
+    [InlineData(FFAction.ExtractSubtitle)]
+    [InlineData(FFAction.ExtractImage)]
+    [InlineData(FFAction.GenerateTrickplay)]
+    [InlineData(FFAction.Record)]
+    public static void Policy_ActionsWhoseStderrIsOnlyDiagnosticSaySo(FFAction action)
+    {
+        Assert.False(FFActionPolicy.For(action).StderrIsPayload);
+    }
+
+    [Fact]
+    public static void DefaultResult_DoesNotClaimSuccess()
+    {
+        // FFResult is a record struct, so FFStopReason.Unknown occupies zero specifically so that state reports failure.
+        Assert.False(default(FFResult).Succeeded);
+    }
+
+    [Fact]
+    public static void Request_TimeoutAndPriorityFallBackToTheAction()
+    {
+        var request = new ProbeRequest { Input = "file:\"a.mkv\"" };
+        var policy = request.ResolvePolicy();
+
+        Assert.Equal(FFActionPolicy.For(FFAction.Probe).Timeout, policy.Timeout);
+        Assert.Equal(FFActionPolicy.For(FFAction.Probe).Priority, policy.Priority);
+    }
+
+    [Fact]
+    public static void Request_ExplicitTimeoutWins()
+    {
+        var request = new ProbeRequest { Input = "file:\"a.mkv\"", Timeout = TimeSpan.FromSeconds(7) };
+        var policy = request.ResolvePolicy();
+
+        Assert.Equal(TimeSpan.FromSeconds(7), policy.Timeout);
+    }
+
+    [Fact]
+    public static void RuntimeKeyProbe_IsSteerableAndPlainCapabilitiesIsNot()
+    {
+        // The runtime-key test cannot run with -nostdin, because that disables what it is testing.
+        var probe = new RuntimeKeyProbeRequest { Arguments = "-f lavfi -i nullsrc" };
+        var capabilities = new CapabilitiesRequest { Arguments = "-hwaccels" };
+
+        Assert.Equal(FFStdinMode.ControlChannel, probe.ResolvePolicy().Stdin);
+        Assert.Equal(FFStdinMode.FireAndForget, capabilities.ResolvePolicy().Stdin);
+    }
+
+    [Fact]
+    public static void Capabilities_CanTargetTheProber()
+    {
+        var request = new CapabilitiesRequest { Arguments = "-loglevel quiet", ProbeOnly = true };
+        var policy = request.ResolvePolicy();
+
+        Assert.True(policy.ProbeOnly);
+    }
+
+    [Theory]
+    [InlineData(FFDelivery.Progressive, StreamMode.Transcode)]
+    [InlineData(FFDelivery.Progressive, StreamMode.Remux)]
+    [InlineData(FFDelivery.Hls, StreamMode.DirectStream)]
+    [InlineData(FFDelivery.Hls, StreamMode.Remux)]
+    public static void Stream_AlwaysOverwrites(FFDelivery delivery, StreamMode mode)
+    {
+        // The runner is the only source of the overwrite flag, and delivery routinely writes over
+        // output an abandoned session left behind. If -n were ever emitted, FFmpeg would refuse the
+        // write and still exit 0 — playback silently dead with nothing in the log. StreamRequest
+        // pins Overwrite on whatever the policy table says; this holds it there.
+        var request = new StreamRequest
+        {
+            Delivery = delivery,
+            Mode = mode,
+            Arguments = "-i \"in.mkv\" -c:v copy -c:a copy \"out.mkv\""
+        };
+
+        Assert.True(request.ResolvePolicy().Overwrite);
+    }
+
+    [Fact]
+    public static void Probe_BuildsExpectedArguments()
+    {
+        var request = new ProbeRequest
+        {
+            Input = "file:\"a.mkv\"",
+            SourceTuning = "-analyzeduration 5000000 -probesize 1000000",
+            IncludeChapters = true,
+            Threads = 4
+        };
+
+        Assert.Equal(
+            "-analyzeduration 5000000 -probesize 1000000 -i file:\"a.mkv\" -threads 4 "
+            + "-print_format json -show_streams -show_chapters -show_format",
+            Args(request));
+    }
+
+    [Fact]
+    public static void Probe_ZeroThreadsOmitsTheFlag()
+    {
+        var request = new ProbeRequest { Input = "file:\"a.mkv\"" };
+        var args = Args(request);
+
+        Assert.DoesNotContain("-threads", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public static void Attachment_NoTargetsDumpsAllByEmbeddedName()
+    {
+        var request = new AttachmentRequest { Input = "file:\"a.mkv\"" };
+        var args = Args(request);
+
+        Assert.Equal(
+            "-dump_attachment:t \"\" -i file:\"a.mkv\" -map 0:t? -t 0 -f null null",
+            args);
+    }
+
+    [Fact]
+    public static void Attachment_TargetsAreDumpedByIndex()
+    {
+        var request = new AttachmentRequest
+        {
+            Input = "file:\"a.mkv\"",
+            Targets = [new AttachmentTarget(3, "/f/one.ttf"), new AttachmentTarget(4, "/f/two.ttf")]
+        };
+        var args = Args(request);
+
+        Assert.Equal(
+            "-dump_attachment:3 \"/f/one.ttf\" -dump_attachment:4 \"/f/two.ttf\" "
+            + "-i file:\"a.mkv\" -map 0:t? -t 0 -f null null",
+            args);
+    }
+
+    [Fact]
+    public static void Attachment_ShapeIsIdenticalWhateverTheSourceContains()
+    {
+        // -map 0:t? means subtitle-only containers and attachment-less sources take the same
+        // command shape as an A/V file, and all three exit 0.
+        var request = new AttachmentRequest
+        {
+            Input = "file:\"subs.mks\"",
+            Targets = [new AttachmentTarget(2, "/f/x.ttf")]
+        };
+        var args = Args(request);
+
+        Assert.EndsWith("-i file:\"subs.mks\" -map 0:t? -t 0 -f null null", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public static void Attachment_ConcatPlaylistGetsDemuxerFlags()
+    {
+        var request = new AttachmentRequest { Input = "file:\"a.concat\"", IsConcatPlaylist = true };
+        var args = Args(request);
+
+        Assert.Contains("-f concat -safe 0 -i", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public static void Watchdog_OnlyRunsWhenARealProgressSignalExists()
+    {
+        // CPU time is not liveness: work blocked on a slow network read accrues none.
+        Assert.False(new ProbeRequest { Input = "x" }.HasProgressSignal);
+        Assert.True(new ProbeRequest { Input = "x", ProgressProbe = () => 1 }.HasProgressSignal);
+    }
+
+    [Fact]
+    public static void Policy_OnlyTrickplayWatchesForIdleness()
+    {
+        Assert.NotEqual(FFDefaults.Unbounded, FFActionPolicy.For(FFAction.GenerateTrickplay).IdleTimeout);
+        Assert.Equal(FFDefaults.Unbounded, FFActionPolicy.For(FFAction.Probe).IdleTimeout);
+        Assert.Equal(FFDefaults.Unbounded, FFActionPolicy.For(FFAction.ScanKeyframes).IdleTimeout);
+    }
+
+    [Fact]
+    public static void Policy_EveryNonStreamingActionHasAWallClock()
+    {
+        // These bound the run on their own, so none of them may be unbounded.
+        FFAction[] bounded =
+        [
+            FFAction.Probe,
+            FFAction.ScanKeyframes,
+            FFAction.Capabilities,
+            FFAction.MeasureLoudness,
+            FFAction.ExtractAttachment,
+            FFAction.ExtractSubtitle,
+            FFAction.ExtractImage
+        ];
+
+        foreach (var action in bounded)
+        {
+            var policy = FFActionPolicy.For(action);
+            Assert.NotEqual(FFDefaults.Unbounded, policy.Timeout);
+        }
+    }
+
+    [Fact]
+    public static void KeyframeScan_SelectsVideoAndCsv()
+    {
+        var args = Args(new KeyframeScanRequest { FilePath = "/m/a.mkv" });
+
+        Assert.Contains("-skip_frame nokey", args, StringComparison.Ordinal);
+        Assert.Contains("-select_streams v -of csv \"/m/a.mkv\"", args, StringComparison.Ordinal);
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFRequestTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/FFRequestTests.cs
@@ -137,13 +137,15 @@ public static class FFRequestTests
     }
 
     [Fact]
-    public static void RuntimeKeyProbe_IsSteerableAndPlainCapabilitiesIsNot()
+    public static void RuntimeKeyProbe_WritesStdinOnceAndPlainCapabilitiesDoesNot()
     {
-        // The runtime-key test cannot run with -nostdin, because that disables what it is testing.
+        // The runtime-key test cannot run with -nostdin, because that disables what it is testing —
+        // but it is not a control channel either. It writes its query, closes stdin, and from then on
+        // cannot be asked to quit, which is why terminating it goes straight to the kill.
         var probe = new RuntimeKeyProbeRequest { Arguments = "-f lavfi -i nullsrc" };
         var capabilities = new CapabilitiesRequest { Arguments = "-hwaccels" };
 
-        Assert.Equal(FFStdinMode.ControlChannel, probe.ResolvePolicy().Stdin);
+        Assert.Equal(FFStdinMode.WriteThenClose, probe.ResolvePolicy().Stdin);
         Assert.Equal(FFStdinMode.FireAndForget, capabilities.ResolvePolicy().Stdin);
     }
 

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/StreamModeTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/FFProcessing/StreamModeTests.cs
@@ -1,0 +1,61 @@
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dto;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding.FFProcessing;
+
+public static class StreamModeTests
+{
+    private static StreamState StateFor(bool videoRequested, string outputVideoCodec, string outputAudioCodec)
+    {
+        var state = new StreamState(
+            Mock.Of<IMediaSourceManager>(),
+            TranscodingJobType.Progressive,
+            Mock.Of<ITranscodeManager>())
+        {
+            OutputVideoCodec = outputVideoCodec,
+            OutputAudioCodec = outputAudioCodec
+        };
+
+        // VideoRequest is derived from the request's runtime type.
+        state.Request = videoRequested ? new VideoRequestDto() : new StreamingRequestDto();
+
+        return state;
+    }
+
+    [Theory]
+    // Video requested: the video codec decides, then the audio codec breaks the tie.
+    [InlineData(true, "copy", "copy", StreamMode.Remux)]
+    [InlineData(true, "copy", "aac", StreamMode.DirectStream)]
+    [InlineData(true, "h264", "copy", StreamMode.Transcode)]
+    [InlineData(true, "h264", "aac", StreamMode.Transcode)]
+    // Audio only: there is no video to copy, so copying the audio is the whole job.
+    [InlineData(false, "", "copy", StreamMode.Remux)]
+    [InlineData(false, "", "aac", StreamMode.Transcode)]
+    public static void StreamMode_MatchesTheDeliveryItDescribes(
+        bool videoRequested,
+        string outputVideoCodec,
+        string outputAudioCodec,
+        StreamMode expected)
+    {
+        Assert.Equal(expected, StateFor(videoRequested, outputVideoCodec, outputAudioCodec).StreamMode);
+    }
+
+    [Fact]
+    public static void StreamMode_FollowsALateCodecChange()
+    {
+        // TryStreamCopy runs again once a live stream is opened, and the HLS master-playlist
+        // builder rewrites the video codec and restores it. A cached mode would be wrong for both.
+        var state = StateFor(true, "copy", "copy");
+        Assert.Equal(StreamMode.Remux, state.StreamMode);
+
+        state.OutputVideoCodec = "h264";
+        Assert.Equal(StreamMode.Transcode, state.StreamMode);
+
+        state.OutputVideoCodec = "copy";
+        Assert.Equal(StreamMode.Remux, state.StreamMode);
+    }
+}

--- a/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/EncoderValidatorTests.cs
@@ -1,13 +1,19 @@
 using System;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
 using MediaBrowser.MediaEncoding.Encoder;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Jellyfin.MediaEncoding.Tests
 {
     public class EncoderValidatorTests
     {
-        private readonly EncoderValidator _encoderValidator = new EncoderValidator(new NullLogger<EncoderValidatorTests>(), "ffmpeg");
+        // These cases only parse text that FFmpeg already printed, so the runner is never reached.
+        private readonly EncoderValidator _encoderValidator = new EncoderValidator(
+            new NullLogger<EncoderValidatorTests>(),
+            "ffmpeg",
+            Mock.Of<IFFRunner>());
 
         [Theory]
         [ClassData(typeof(GetFFmpegVersionTestData))]

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFRunnerFFmpegTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFRunnerFFmpegTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+using MediaBrowser.MediaEncoding.FFProcessing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.FFProcessing;
+
+/// <summary>
+/// Runs the rendered command lines through a real FFmpeg, which is the only way to check that the
+/// arguments are actually accepted rather than merely well-formed.
+/// <para>
+/// Every test here is <c>Explicit</c>: it needs an external binary, so leaving it on by default
+/// would break contributor machines that lack it, and skipping when the binary is absent would
+/// report green for a suite that never ran. Opt in with:
+/// </para>
+/// <code>dotnet run --project tests/Jellyfin.MediaEncoding.Tests -- -explicit only</code>
+/// <para>See "Tests Requiring FFmpeg" in the repository README.</para>
+/// </summary>
+public sealed class FFRunnerFFmpegTests : IClassFixture<SynthesizedMediaFixture>, IDisposable
+{
+    private readonly SynthesizedMediaFixture _media;
+    private readonly FFRunner _runner;
+
+    public FFRunnerFFmpegTests(SynthesizedMediaFixture media)
+    {
+        _media = media;
+
+        // The real holder, so these tests also cover the ffmpeg -> ffprobe path derivation.
+        var paths = new FFPaths();
+        paths.SetEncoderPath(_media.EncoderPath);
+
+        _runner = new FFRunner(NullLogger<FFRunner>.Instance, paths);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _runner.Dispose();
+
+    [Fact(Explicit = true)]
+    public async Task Attachment_DumpsFromVideoContainer()
+    {
+        var target = Path.Combine(_media.Root, "from_av.ttf");
+
+        var result = await RunDumpAsync(_media.VideoWithAttachment, 2, target);
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.True(File.Exists(target));
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Attachment_DumpsFromSubtitleOnlyContainer()
+    {
+        // The case that previously produced exit 234, "Output file does not contain any stream".
+        var target = Path.Combine(_media.Root, "from_mks.ttf");
+
+        var result = await RunDumpAsync(_media.SubtitlesWithAttachment, 1, target);
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.True(File.Exists(target));
+    }
+
+    [Theory(Explicit = true)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Attachment_SourceWithoutAttachmentsStillSucceeds(bool useMp4)
+    {
+        // -map 0:t? tolerates matching nothing
+        var source = useMp4 ? _media.Mp4 : _media.VideoWithoutAttachment;
+
+        var result = await _runner.RunAsync(
+            new AttachmentRequest { Input = Quote(source) },
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded, result.Stderr);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Attachment_DumpAllWritesIntoTheWorkingDirectory()
+    {
+        var workDir = Directory.CreateTempSubdirectory("jf-dumpall-").FullName;
+
+        try
+        {
+            var result = await _runner.RunAsync(
+                new AttachmentRequest
+                {
+                    Input = Quote(_media.VideoWithAttachment),
+                    WorkingDirectory = workDir
+                },
+                CancellationToken.None);
+
+            Assert.True(result.Succeeded, result.Stderr);
+            Assert.True(File.Exists(Path.Combine(workDir, _media.AttachmentName)));
+        }
+        finally
+        {
+            Directory.Delete(workDir, true);
+        }
+    }
+
+    [Theory(Explicit = true)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Probe_ProducesParseableJson(bool includeChapters)
+    {
+        string json = string.Empty;
+
+        var result = await _runner.RunAsync(
+            new ProbeRequest
+            {
+                Input = Quote(_media.Mp4),
+                IncludeChapters = includeChapters,
+                Stdout = async (stdout, ct) =>
+                {
+                    using var reader = new StreamReader(stdout);
+                    json = await reader.ReadToEndAsync(ct);
+                }
+            },
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded, result.Stderr);
+
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.TryGetProperty("streams", out var streams));
+        Assert.Contains(streams.EnumerateArray(), s => s.GetProperty("codec_type").GetString() == "video");
+        Assert.Equal(includeChapters, document.RootElement.TryGetProperty("chapters", out _));
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Probe_RejectsNothingItIsGiven()
+    {
+        // ffprobe accepts neither -nostdin nor -y, and swallows the following argument if given
+        // one, so a regression here corrupts the whole command rather than failing cleanly.
+        var result = await _runner.RunAsync(
+            new ProbeRequest { Input = Quote(_media.VideoWithAttachment), Threads = 2 },
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.DoesNotContain("Option not found", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Cancellation_KillsTheProcess()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await _runner.RunAsync(
+            new ProbeRequest { Input = Quote(_media.Mp4) },
+            cts.Token);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(FFStopReason.Cancelled, result.StopReason);
+    }
+
+    private Task<FFResult> RunDumpAsync(string source, int streamIndex, string target)
+        => _runner.RunAsync(
+            new AttachmentRequest
+            {
+                Input = Quote(source),
+                Targets = [new AttachmentTarget(streamIndex, target)]
+            },
+            CancellationToken.None);
+
+    private static string Quote(string path) => "file:\"" + path + "\"";
+}

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFRunnerFFmpegTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFRunnerFFmpegTests.cs
@@ -159,6 +159,99 @@ public sealed class FFRunnerFFmpegTests : IClassFixture<SynthesizedMediaFixture>
         Assert.Equal(FFStopReason.Cancelled, result.StopReason);
     }
 
+    [Fact(Explicit = true)]
+    public async Task Loudness_MeasurementSurvivesWithoutTheCallerAskingForIt()
+    {
+        // Guards the log-level floor against a real ebur128, with a request that names no sink at
+        // all — as AudioNormalizationTask does. Measured against jellyfin-ffmpeg 7.1.4, the summary
+        // is emitted at info and verbose and at nothing below, so without StderrIsPayload raising the
+        // derived level this run still exits 0 with the caller's regex matching nothing.
+        //
+        // It does not cover the sink substitution that flag also performs: ebur128 prints its summary
+        // last, so a trailing window would hold it regardless.
+        var result = await _runner.RunAsync(
+            new LoudnessRequest { Path = _media.Mp4 },
+            CancellationToken.None);
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.Contains("Summary:", result.Stderr, StringComparison.Ordinal);
+        Assert.Contains("I:", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Termination_KillsAWriteThenCloseProcessThatOutlivesItsDeadline()
+    {
+        // ProbeRuntimeKeys uses FFStdinMode.WriteThenClose: stdin carries its query and is then shut,
+        // so there is no way to ask it to quit and termination must go straight to the kill.
+        //
+        // -re paces the null source in real time, so the run outlives the deadline instead of
+        // finishing on its own the way the real startup interrogation does.
+        var session = await _runner.StartAsync(
+            new RuntimeKeyProbeRequest
+            {
+                Arguments = "-re -f lavfi -i nullsrc=s=1x1:d=600 -f null -",
+                Timeout = TimeSpan.FromSeconds(2)
+            },
+            CancellationToken.None);
+
+        var processId = session.ProcessId;
+
+        try
+        {
+            // Bounded, and deliberately not `await using`: both a bare await and disposing the session
+            // wait on Completion, which does not finish while the process is alive. A TimeoutException
+            // here is the failure this test exists to catch, and the bound is what makes it a failure
+            // rather than a hung run.
+            var result = await session.Completion.WaitAsync(
+                TimeSpan.FromSeconds(30),
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(FFStopReason.TimedOut, result.StopReason);
+            Assert.True(HasReallyExited(processId), "ffmpeg survived termination");
+        }
+        finally
+        {
+            // Reap anything the runner left behind. A process that survives termination is also gone
+            // from _running, so neither the runner's own shutdown nor this class's Dispose collects
+            // it, and a failure here would otherwise leak a real ffmpeg into the rest of the run.
+            KillIfAlive(processId);
+        }
+    }
+
+    private static void KillIfAlive(int processId)
+    {
+        try
+        {
+            using var process = System.Diagnostics.Process.GetProcessById(processId);
+            if (!process.HasExited)
+            {
+                process.Kill(true);
+            }
+        }
+        catch (ArgumentException)
+        {
+            // Already gone, which is the expected case.
+        }
+    }
+
+    /// <summary>
+    /// Whether the process is gone, tolerating the id having been recycled into something else.
+    /// </summary>
+    private static bool HasReallyExited(int processId)
+    {
+        try
+        {
+            using var process = System.Diagnostics.Process.GetProcessById(processId);
+
+            return process.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // No such process, which is the answer we want.
+            return true;
+        }
+    }
+
     private Task<FFResult> RunDumpAsync(string source, int streamIndex, string target)
         => _runner.RunAsync(
             new AttachmentRequest

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFSessionFFmpegTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/FFSessionFFmpegTests.cs
@@ -1,0 +1,192 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
+using MediaBrowser.MediaEncoding.FFProcessing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.FFProcessing;
+
+/// <summary>
+/// Covers the start-and-hold contract that live recording and delivery streaming both rely on.
+/// Every test is <c>Explicit</c> because it needs a real FFmpeg; see "Tests Requiring FFmpeg" in
+/// the repository README.
+/// </summary>
+public sealed class FFSessionFFmpegTests : IClassFixture<SynthesizedMediaFixture>, IDisposable
+{
+    private readonly FFRunner _runner;
+
+    public FFSessionFFmpegTests(SynthesizedMediaFixture media)
+    {
+        var paths = new FFPaths();
+        paths.SetEncoderPath(media.EncoderPath);
+        _runner = new FFRunner(NullLogger<FFRunner>.Instance, paths);
+    }
+
+    /// <summary>A stream that would run for an hour, so it is certainly still going.</summary>
+    private static StreamRequest LongRunning(FFOutputSink? stderr = null) => new()
+    {
+        Delivery = FFDelivery.Progressive,
+        Mode = StreamMode.Transcode,
+        Arguments = "-f lavfi -i testsrc=s=64x64:d=3600 -f null -",
+        Stderr = stderr ?? FFOutputSink.Diagnostic()
+    };
+
+    public void Dispose() => _runner.Dispose();
+
+    [Fact(Explicit = true)]
+    public async Task StartAsync_ReturnsWhileTheProcessIsStillRunning()
+    {
+        await using var session = await _runner.StartAsync(LongRunning(), CancellationToken.None);
+
+        Assert.False(session.Completion.IsCompleted);
+        Assert.True(session.ProcessId > 0);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task StopAsync_EndsItAndReportsCancellationRatherThanFailure()
+    {
+        var session = await _runner.StartAsync(LongRunning(), CancellationToken.None);
+
+        var result = await session.StopAsync(CancellationToken.None);
+
+        Assert.Equal(FFStopReason.Cancelled, result.StopReason);
+
+        // A deliberate stop is not a failed run, and must not be reported as one.
+        Assert.False(result.Succeeded);
+        Assert.True(result.Elapsed > TimeSpan.Zero);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task CancellingTheToken_StopsTheProcess()
+    {
+        using var cts = new CancellationTokenSource();
+        var session = await _runner.StartAsync(LongRunning(), cts.Token);
+
+        await cts.CancelAsync();
+        var result = await session.Completion;
+
+        Assert.Equal(FFStopReason.Cancelled, result.StopReason);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Completion_CarriesTheOutcomeOfAShortRun()
+    {
+        var request = new StreamRequest
+        {
+            Delivery = FFDelivery.Progressive,
+            Mode = StreamMode.Remux,
+            Arguments = "-f lavfi -i testsrc=s=64x64:d=1 -f null -"
+        };
+
+        await using var session = await _runner.StartAsync(request, CancellationToken.None);
+        var result = await session.Completion;
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.Equal(FFStopReason.Exited, result.StopReason);
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Completion_ReportsAFailureWithItsStderr()
+    {
+        var request = new StreamRequest
+        {
+            Delivery = FFDelivery.Progressive,
+            Mode = StreamMode.Transcode,
+            Arguments = "-f lavfi -i testsrc=s=64x64:d=1 -vf nosuchfilter -f null -"
+        };
+
+        await using var session = await _runner.StartAsync(request, CancellationToken.None);
+        var result = await session.Completion;
+
+        Assert.False(result.Succeeded);
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.NotEmpty(result.Stderr);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task ToStreamSink_IsReadableBeforeTheProcessExits()
+    {
+        var logPath = Path.Combine(Path.GetTempPath(), "jf-session-" + Guid.NewGuid().ToString("N") + ".log");
+
+        try
+        {
+            await using (var log = new FileStream(logPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+            {
+                // -loglevel is derived from the logger, so ask FFmpeg for output explicitly.
+                var request = LongRunning(FFOutputSink.ToStream(log)) with
+                {
+                    Arguments = "-v info -f lavfi -i testsrc=s=64x64:d=3600 -f null -"
+                };
+
+                var session = await _runner.StartAsync(request, CancellationToken.None);
+
+                // The whole point of this sink: readable while the process is still running.
+                var deadline = DateTime.UtcNow.AddSeconds(10);
+                long written = 0;
+                while (written == 0 && DateTime.UtcNow < deadline)
+                {
+                    using var reader = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    written = reader.Length;
+                    if (written == 0)
+                    {
+                        await Task.Delay(200, TestContext.Current.CancellationToken);
+                    }
+                }
+
+                Assert.True(written > 0, "nothing was written to the log while the process was running");
+                await session.StopAsync(CancellationToken.None);
+            }
+        }
+        finally
+        {
+            File.Delete(logPath);
+        }
+    }
+
+    [Fact(Explicit = true)]
+    public async Task StreamAction_KeepsProgressStatsAtAQuietLogLevel()
+    {
+        // FFmpeg suppresses its status line below info, and the level here is derived from a
+        // NullLogger, so this only passes because the Stream policy asks for -stats. Progress
+        // reporting and throttling both parse that line.
+        var request = new StreamRequest
+        {
+            Delivery = FFDelivery.Progressive,
+            Mode = StreamMode.Transcode,
+            Arguments = "-f lavfi -i testsrc=s=64x64:d=2 -f null -"
+        };
+
+        await using var session = await _runner.StartAsync(request, CancellationToken.None);
+        var result = await session.Completion;
+
+        Assert.True(result.Succeeded, result.Stderr);
+        Assert.Contains("time=", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task NonStreamAction_StaysQuietWithoutTheStatusLine()
+    {
+        var request = new CapabilitiesRequest { Arguments = "-hwaccels" };
+
+        await using var session = await _runner.StartAsync(request, CancellationToken.None);
+        var result = await session.Completion;
+
+        Assert.DoesNotContain("time=", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task SendKeyAsync_RefusesAnActionThatIsNotSteerable()
+    {
+        var request = new CapabilitiesRequest { Arguments = "-hwaccels" };
+        await using var session = await _runner.StartAsync(request, CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => session.SendKeyAsync("p", CancellationToken.None));
+    }
+}

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
@@ -13,54 +13,28 @@ public sealed class SynthesizedMediaFixture : IDisposable
 {
     private const string DefaultEncoder = "/usr/share/jellyfin-ffmpeg/ffmpeg";
 
-    public SynthesizedMediaFixture()
-    {
-        EncoderPath = ResolveEncoderPath();
+    // xunit builds the class fixture for a test class even when every test in that class is
+    // Explicit and will not run, so the constructor has to stay inert: synthesizing here would
+    // fail the whole class on a machine without ffmpeg, which is what Explicit exists to avoid.
+    // Deferring to first property access keeps the hard failure, but only for a run that asked
+    // for these tests.
+    private readonly Lazy<SynthesizedMedia> _media = new(Synthesize);
 
-        // The server never configures ffprobe separately; MediaEncoder derives it from the encoder
-        // path, so do the same here rather than adding a knob core does not have.
-        ProberPath = Path.Combine(
-            Path.GetDirectoryName(EncoderPath) ?? string.Empty,
-            "ffprobe" + Path.GetExtension(EncoderPath));
+    public string EncoderPath => _media.Value.EncoderPath;
 
-        // These tests are opt-in, so a missing binary is a hard failure rather than a silent skip:
-        // a run that was explicitly asked for must not report green without having run.
-        if (!File.Exists(EncoderPath) || !File.Exists(ProberPath))
-        {
-            throw new InvalidOperationException(
-                $"ffmpeg not found at '{EncoderPath}' / '{ProberPath}'. Point {EnvironmentVariable} "
-                + "at an ffmpeg binary, or install jellyfin-ffmpeg.");
-        }
+    public string ProberPath => _media.Value.ProberPath;
 
-        Root = Directory.CreateTempSubdirectory("jf-ffmpeg-tests-").FullName;
+    public string Root => _media.Value.Root;
 
-        var font = Path.Combine(Root, "TestFont.ttf");
-        File.WriteAllText(font, "not really a font, but ffmpeg only copies the bytes");
-        AttachmentName = Path.GetFileName(font);
+    public string AttachmentName => _media.Value.AttachmentName;
 
-        var srt = Path.Combine(Root, "s.srt");
-        File.WriteAllText(srt, "1\n00:00:00,000 --> 00:00:02,000\nhello\n\n");
+    public string VideoWithAttachment => _media.Value.VideoWithAttachment;
 
-        const string Attach = "-metadata:s:t mimetype=application/x-truetype-font";
+    public string SubtitlesWithAttachment => _media.Value.SubtitlesWithAttachment;
 
-        // Video + audio + one attachment.
-        VideoWithAttachment = Path.Combine(Root, "av_with_attachment.mkv");
-        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -attach \"{font}\" {Attach} "
-            + $"-c:v libx264 -c:a aac -shortest \"{VideoWithAttachment}\"");
+    public string VideoWithoutAttachment => _media.Value.VideoWithoutAttachment;
 
-        // Subtitles + one attachment, no audio or video. This is the shape Jellyfin writes when it
-        // round-trips VobSub.
-        SubtitlesWithAttachment = Path.Combine(Root, "subs_only.mks");
-        Run($"-y -i \"{srt}\" -attach \"{font}\" {Attach} -c:s srt -f matroska \"{SubtitlesWithAttachment}\"");
-
-        // No attachments at all.
-        VideoWithoutAttachment = Path.Combine(Root, "no_attachment.mkv");
-        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -c:v libx264 \"{VideoWithoutAttachment}\"");
-
-        // MP4 carries no attachment streams, so it exercises the same empty-map path.
-        Mp4 = Path.Combine(Root, "video.mp4");
-        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -c:v libx264 -c:a aac -shortest \"{Mp4}\"");
-    }
+    public string Mp4 => _media.Value.Mp4;
 
     /// <summary>
     /// Gets the environment variable the server itself honours for the encoder path, which is what
@@ -69,32 +43,80 @@ public sealed class SynthesizedMediaFixture : IDisposable
     /// </summary>
     private static string EnvironmentVariable => "JELLYFIN_" + ConfigurationExtensions.FfmpegPathKey;
 
-    public string EncoderPath { get; }
-
-    public string ProberPath { get; }
-
-    public string Root { get; }
-
-    public string AttachmentName { get; }
-
-    public string VideoWithAttachment { get; }
-
-    public string SubtitlesWithAttachment { get; }
-
-    public string VideoWithoutAttachment { get; }
-
-    public string Mp4 { get; }
-
     public void Dispose()
     {
+        // Nothing was synthesized if no test touched the fixture, which is the normal case.
+        if (!_media.IsValueCreated)
+        {
+            return;
+        }
+
         try
         {
-            Directory.Delete(Root, true);
+            Directory.Delete(_media.Value.Root, true);
         }
         catch (IOException)
         {
             // A leftover temp directory is not worth failing a test run over.
         }
+    }
+
+    private static SynthesizedMedia Synthesize()
+    {
+        var encoderPath = ResolveEncoderPath();
+
+        // The server never configures ffprobe separately; MediaEncoder derives it from the encoder
+        // path, so do the same here.
+        var proberPath = Path.Combine(
+            Path.GetDirectoryName(encoderPath) ?? string.Empty,
+            "ffprobe" + Path.GetExtension(encoderPath));
+
+        // These tests are opt-in, so a missing binary is a hard failure rather than a silent skip:
+        // a run that was explicitly asked for must not report green without having run.
+        if (!File.Exists(encoderPath) || !File.Exists(proberPath))
+        {
+            throw new InvalidOperationException(
+                $"ffmpeg not found at '{encoderPath}' / '{proberPath}'. Point {EnvironmentVariable} "
+                + "at an ffmpeg binary, or install jellyfin-ffmpeg.");
+        }
+
+        var root = Directory.CreateTempSubdirectory("jf-ffmpeg-tests-").FullName;
+
+        var font = Path.Combine(root, "TestFont.ttf");
+        File.WriteAllText(font, "not really a font, but ffmpeg only copies the bytes");
+
+        var srt = Path.Combine(root, "s.srt");
+        File.WriteAllText(srt, "1\n00:00:00,000 --> 00:00:02,000\nhello\n\n");
+
+        const string Attach = "-metadata:s:t mimetype=application/x-truetype-font";
+
+        // Video + audio + one attachment.
+        var videoWithAttachment = Path.Combine(root, "av_with_attachment.mkv");
+        Run(encoderPath, $"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -attach \"{font}\" {Attach} "
+            + $"-c:v libx264 -c:a aac -shortest \"{videoWithAttachment}\"");
+
+        // Subtitles + one attachment, no audio or video. This is the shape Jellyfin writes when it
+        // round-trips VobSub.
+        var subtitlesWithAttachment = Path.Combine(root, "subs_only.mks");
+        Run(encoderPath, $"-y -i \"{srt}\" -attach \"{font}\" {Attach} -c:s srt -f matroska \"{subtitlesWithAttachment}\"");
+
+        // No attachments at all.
+        var videoWithoutAttachment = Path.Combine(root, "no_attachment.mkv");
+        Run(encoderPath, $"-y -f lavfi -i testsrc=d=1:s=64x64 -c:v libx264 \"{videoWithoutAttachment}\"");
+
+        // MP4 carries no attachment streams, so it exercises the same empty-map path.
+        var mp4 = Path.Combine(root, "video.mp4");
+        Run(encoderPath, $"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -c:v libx264 -c:a aac -shortest \"{mp4}\"");
+
+        return new SynthesizedMedia(
+            encoderPath,
+            proberPath,
+            root,
+            Path.GetFileName(font),
+            videoWithAttachment,
+            subtitlesWithAttachment,
+            videoWithoutAttachment,
+            mp4);
     }
 
     private static string ResolveEncoderPath()
@@ -105,11 +127,11 @@ public sealed class SynthesizedMediaFixture : IDisposable
         return string.IsNullOrWhiteSpace(configured) ? DefaultEncoder : configured;
     }
 
-    private void Run(string arguments)
+    private static void Run(string encoderPath, string arguments)
     {
         using var process = Process.Start(new ProcessStartInfo
         {
-            FileName = EncoderPath,
+            FileName = encoderPath,
             Arguments = "-hide_banner -loglevel error -nostdin " + arguments,
             UseShellExecute = false,
             RedirectStandardError = true
@@ -123,4 +145,14 @@ public sealed class SynthesizedMediaFixture : IDisposable
             throw new InvalidOperationException($"Fixture setup failed ({process.ExitCode}): {stderr}");
         }
     }
+
+    private sealed record SynthesizedMedia(
+        string EncoderPath,
+        string ProberPath,
+        string Root,
+        string AttachmentName,
+        string VideoWithAttachment,
+        string SubtitlesWithAttachment,
+        string VideoWithoutAttachment,
+        string Mp4);
 }

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using MediaBrowser.Controller.Extensions;
+
+namespace Jellyfin.MediaEncoding.Tests.FFProcessing;
+
+/// <summary>
+/// Builds the media these tests run against, so the repository ships no binary fixtures.
+/// Everything is synthesized from lavfi sources plus <c>-attach</c>.
+/// </summary>
+public sealed class SynthesizedMediaFixture : IDisposable
+{
+    private const string DefaultEncoder = "/usr/share/jellyfin-ffmpeg/ffmpeg";
+
+    public SynthesizedMediaFixture()
+    {
+        EncoderPath = ResolveEncoderPath();
+
+        // The server never configures ffprobe separately; MediaEncoder derives it from the encoder
+        // path, so do the same here rather than adding a knob core does not have.
+        ProberPath = Path.Combine(
+            Path.GetDirectoryName(EncoderPath) ?? string.Empty,
+            "ffprobe" + Path.GetExtension(EncoderPath));
+
+        // These tests are opt-in, so a missing binary is a hard failure rather than a silent skip:
+        // a run that was explicitly asked for must not report green without having run.
+        if (!File.Exists(EncoderPath) || !File.Exists(ProberPath))
+        {
+            throw new InvalidOperationException(
+                $"ffmpeg not found at '{EncoderPath}' / '{ProberPath}'. Point {EnvironmentVariable} "
+                + "at an ffmpeg binary, or install jellyfin-ffmpeg.");
+        }
+
+        Root = Directory.CreateTempSubdirectory("jf-ffmpeg-tests-").FullName;
+
+        var font = Path.Combine(Root, "TestFont.ttf");
+        File.WriteAllText(font, "not really a font, but ffmpeg only copies the bytes");
+        AttachmentName = Path.GetFileName(font);
+
+        var srt = Path.Combine(Root, "s.srt");
+        File.WriteAllText(srt, "1\n00:00:00,000 --> 00:00:02,000\nhello\n\n");
+
+        const string Attach = "-metadata:s:t mimetype=application/x-truetype-font";
+
+        // Video + audio + one attachment.
+        VideoWithAttachment = Path.Combine(Root, "av_with_attachment.mkv");
+        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -attach \"{font}\" {Attach} "
+            + $"-c:v libx264 -c:a aac -shortest \"{VideoWithAttachment}\"");
+
+        // Subtitles + one attachment, no audio or video. This is the shape Jellyfin writes when it
+        // round-trips VobSub.
+        SubtitlesWithAttachment = Path.Combine(Root, "subs_only.mks");
+        Run($"-y -i \"{srt}\" -attach \"{font}\" {Attach} -c:s srt -f matroska \"{SubtitlesWithAttachment}\"");
+
+        // No attachments at all.
+        VideoWithoutAttachment = Path.Combine(Root, "no_attachment.mkv");
+        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -c:v libx264 \"{VideoWithoutAttachment}\"");
+
+        // MP4 carries no attachment streams, so it exercises the same empty-map path.
+        Mp4 = Path.Combine(Root, "video.mp4");
+        Run($"-y -f lavfi -i testsrc=d=1:s=64x64 -f lavfi -i sine=d=1 -c:v libx264 -c:a aac -shortest \"{Mp4}\"");
+    }
+
+    /// <summary>
+    /// The environment variable the server itself honours for the encoder path, which is what
+    /// <c>--ffmpeg</c> sets. Configuration keys are matched case-insensitively, so the
+    /// conventional upper-case spelling works too.
+    /// </summary>
+    private static string EnvironmentVariable => "JELLYFIN_" + ConfigurationExtensions.FfmpegPathKey;
+
+    public string EncoderPath { get; }
+
+    public string ProberPath { get; }
+
+    public string Root { get; }
+
+    public string AttachmentName { get; }
+
+    public string VideoWithAttachment { get; }
+
+    public string SubtitlesWithAttachment { get; }
+
+    public string VideoWithoutAttachment { get; }
+
+    public string Mp4 { get; }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(Root, true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test run over.
+        }
+    }
+
+    private static string ResolveEncoderPath()
+    {
+        var configured = Environment.GetEnvironmentVariable(EnvironmentVariable)
+                         ?? Environment.GetEnvironmentVariable(EnvironmentVariable.ToUpperInvariant());
+
+        return string.IsNullOrWhiteSpace(configured) ? DefaultEncoder : configured;
+    }
+
+    private void Run(string arguments)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = EncoderPath,
+            Arguments = "-hide_banner -loglevel error -nostdin " + arguments,
+            UseShellExecute = false,
+            RedirectStandardError = true
+        })!;
+
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Fixture setup failed ({process.ExitCode}): {stderr}");
+        }
+    }
+}

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/SynthesizedMediaFixture.cs
@@ -63,7 +63,7 @@ public sealed class SynthesizedMediaFixture : IDisposable
     }
 
     /// <summary>
-    /// The environment variable the server itself honours for the encoder path, which is what
+    /// Gets the environment variable the server itself honours for the encoder path, which is what
     /// <c>--ffmpeg</c> sets. Configuration keys are matched case-insensitively, so the
     /// conventional upper-case spelling works too.
     /// </summary>

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/TranscodeManagerFFmpegTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/TranscodeManagerFFmpegTests.cs
@@ -1,0 +1,269 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.MediaEncoding.FFProcessing;
+using MediaBrowser.MediaEncoding.Transcoding;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.MediaEncoding.Tests.FFProcessing;
+
+/// <summary>
+/// Drives a real FFmpeg through <see cref="TranscodeManager.StartFfMpeg"/>, which is otherwise
+/// uncovered. The command line is a parameter of that method, so these exercise the spawn, session
+/// and job wiring without involving <c>EncodingHelper</c>'s argument construction.
+/// <para>
+/// Explicit: needs a real FFmpeg. See "Tests Requiring FFmpeg" in the repository README.
+/// </para>
+/// </summary>
+public sealed class TranscodeManagerFFmpegTests : IClassFixture<SynthesizedMediaFixture>, IDisposable
+{
+    private readonly SynthesizedMediaFixture _media;
+    private readonly string _root;
+    private readonly TranscodeManager _manager;
+
+    public TranscodeManagerFFmpegTests(SynthesizedMediaFixture media)
+    {
+        _media = media;
+        _root = Directory.CreateTempSubdirectory("jf-transcode-tests-").FullName;
+
+        var paths = new FFPaths();
+        paths.SetEncoderPath(_media.EncoderPath);
+
+        var appPaths = new Mock<IServerApplicationPaths>();
+        appPaths.SetupGet(p => p.LogDirectoryPath).Returns(Path.Combine(_root, "logs"));
+        appPaths.SetupGet(p => p.CachePath).Returns(Path.Combine(_root, "cache"));
+        Directory.CreateDirectory(Path.Combine(_root, "logs"));
+
+        var config = new Mock<IServerConfigurationManager>();
+        config.SetupGet(c => c.ApplicationPaths).Returns(appPaths.Object);
+        config.SetupGet(c => c.CommonApplicationPaths).Returns(appPaths.Object);
+        config.SetupGet(c => c.Configuration).Returns(new ServerConfiguration());
+        config.Setup(c => c.GetConfiguration("encoding"))
+            .Returns(new EncodingOptions { TranscodingTempPath = Path.Combine(_root, "transcodes") });
+
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder.SetupGet(e => e.EncoderPath).Returns(_media.EncoderPath);
+
+        _manager = new TranscodeManager(
+            NullLoggerFactory.Instance,
+            Mock.Of<IFileSystem>(),
+            appPaths.Object,
+            config.Object,
+            Mock.Of<IUserManager>(),
+            Mock.Of<ISessionManager>(),
+            new EncodingHelper(
+                appPaths.Object,
+                mediaEncoder.Object,
+                Mock.Of<ISubtitleEncoder>(),
+                Mock.Of<IConfiguration>(),
+                config.Object,
+                Mock.Of<IPathManager>()),
+            mediaEncoder.Object,
+            new FFRunner(NullLogger<FFRunner>.Instance, paths),
+            Mock.Of<IMediaSourceManager>(),
+            Mock.Of<IAttachmentExtractor>());
+    }
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch (IOException)
+        {
+            // Best effort; the log files may still be held briefly.
+        }
+    }
+
+    private StreamState NewState() => new(
+        Mock.Of<IMediaSourceManager>(),
+        TranscodingJobType.Progressive,
+        _manager)
+    {
+        // DeviceId stays null so no session progress is reported.
+        Request = new StreamingRequestDto { MediaSourceId = Guid.NewGuid().ToString("N") },
+        MediaSource = new MediaSourceInfo { RequiresOpening = false, Path = _media.Mp4 },
+        OutputVideoCodec = "copy",
+        OutputAudioCodec = "copy"
+    };
+
+    /// <summary>
+    /// The job's session is released as soon as it ends — <c>OnFfMpegProcessExited</c> disposes the
+    /// job — so tests observe the state the rest of the server reads rather than holding the
+    /// session.
+    /// </summary>
+    private static async Task<bool> WaitForExitAsync(TranscodingJob job, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!job.HasExited && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+        }
+
+        return job.HasExited;
+    }
+
+    [Fact(Explicit = true)]
+    public async Task StartFfMpeg_ProducesTheOutputAndRecordsACleanExit()
+    {
+        var state = NewState();
+        var output = Path.Combine(_root, "out.mp4");
+        using var cts = new CancellationTokenSource();
+
+        var job = await _manager.StartFfMpeg(
+            state,
+            output,
+            $"-f lavfi -i testsrc=s=64x64:d=1 -c:v libx264 \"{output}\"",
+            Guid.Empty,
+            TranscodingJobType.Progressive,
+            cts);
+
+        Assert.True(await WaitForExitAsync(job, TimeSpan.FromSeconds(30)), "ffmpeg did not finish");
+
+        Assert.Equal(0, job.ExitCode);
+        Assert.True(File.Exists(output));
+        Assert.True(new FileInfo(output).Length > 0);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task StartFfMpeg_WritesTheCommandLineIntoAJobLog()
+    {
+        var state = NewState();
+        var output = Path.Combine(_root, "logged.mp4");
+        using var cts = new CancellationTokenSource();
+
+        var job = await _manager.StartFfMpeg(
+            state,
+            output,
+            $"-f lavfi -i testsrc=s=64x64:d=1 -c:v libx264 \"{output}\"",
+            Guid.Empty,
+            TranscodingJobType.Progressive,
+            cts);
+
+        Assert.True(await WaitForExitAsync(job, TimeSpan.FromSeconds(30)), "ffmpeg did not finish");
+
+        // Remux because both codecs are copy, which decides the log filename.
+        var logs = Directory.GetFiles(Path.Combine(_root, "logs"), "FFmpeg.Remux-*.log");
+        Assert.NotEmpty(logs);
+
+        var log = await File.ReadAllTextAsync(logs[0], TestContext.Current.CancellationToken);
+
+        // Assert against the header line as a unit rather than the whole file. FFmpeg's own stderr is
+        // appended to the same log, so a substring search across all of it could be satisfied by
+        // something the encoder printed rather than by the header actually being complete.
+        var header = Assert.Single(
+            log.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+            line => line.Contains("-hide_banner", StringComparison.Ordinal));
+
+        // People paste this line out of bug reports to reproduce a failure, so it has to be the whole
+        // command — the caller's arguments *and* every flag the runner supplies. A header missing
+        // them sends someone chasing a command that behaves differently from the one that ran.
+        Assert.Contains(_media.EncoderPath, header, StringComparison.Ordinal);
+        Assert.Contains("testsrc", header, StringComparison.Ordinal);
+        Assert.Contains("-loglevel", header, StringComparison.Ordinal);
+        Assert.Contains("-stats", header, StringComparison.Ordinal);
+
+        // Specifically the overwrite flag, which the argument builders no longer emit themselves.
+        Assert.Contains("-y", header, StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task StartFfMpeg_DeliversHlsSegmentsAndAPlaylist()
+    {
+        var state = NewState();
+        var hlsDir = Path.Combine(_root, "hls");
+        Directory.CreateDirectory(hlsDir);
+        var playlist = Path.Combine(hlsDir, "main.m3u8");
+
+        using var cts = new CancellationTokenSource();
+
+        var job = await _manager.StartFfMpeg(
+            state,
+            playlist,
+            $"-f lavfi -i testsrc=s=64x64:d=4 -c:v libx264 -g 24 -f hls -hls_time 1 "
+                + $"-hls_segment_filename \"{Path.Combine(hlsDir, "seg%d.ts")}\" \"{playlist}\"",
+            Guid.Empty,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.True(await WaitForExitAsync(job, TimeSpan.FromSeconds(60)), "ffmpeg did not finish");
+
+        Assert.Equal(0, job.ExitCode);
+        Assert.True(File.Exists(playlist));
+        Assert.NotEmpty(Directory.GetFiles(hlsDir, "seg*.ts"));
+        Assert.Contains("#EXTM3U", await File.ReadAllTextAsync(playlist, TestContext.Current.CancellationToken), StringComparison.Ordinal);
+    }
+
+    [Fact(Explicit = true)]
+    public async Task Throttler_PausesAndResumesARunningTranscodeThroughTheSession()
+    {
+        var state = NewState();
+        var output = Path.Combine(_root, "throttled.mp4");
+        using var cts = new CancellationTokenSource();
+
+        var job = await _manager.StartFfMpeg(
+            state,
+            output,
+            $"-f lavfi -i testsrc=s=64x64:d=3600 -c:v libx264 \"{output}\"",
+            Guid.Empty,
+            TranscodingJobType.Progressive,
+            cts);
+
+        Assert.NotNull(job.Session);
+
+        // The throttler steers the process by writing runtime keys to the session, which is the
+        // path that replaced writing to Process.StandardInput directly.
+        await job.Session!.SendKeyAsync("p", TestContext.Current.CancellationToken);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        Assert.False(job.HasExited);
+
+        await job.Session!.SendKeyAsync("u", TestContext.Current.CancellationToken);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
+        Assert.False(job.HasExited);
+
+        job.Stop();
+        Assert.True(await WaitForExitAsync(job, TimeSpan.FromSeconds(30)), "the job did not stop");
+    }
+
+    [Fact(Explicit = true)]
+    public async Task KillTranscodingJob_StopsALongRunningTranscode()
+    {
+        var state = NewState();
+        var output = Path.Combine(_root, "killed.mp4");
+        using var cts = new CancellationTokenSource();
+
+        var job = await _manager.StartFfMpeg(
+            state,
+            output,
+            $"-f lavfi -i testsrc=s=64x64:d=3600 -c:v libx264 \"{output}\"",
+            Guid.Empty,
+            TranscodingJobType.Progressive,
+            cts);
+
+        // An hour-long source, so it is certainly still running.
+        Assert.False(job.HasExited);
+        Assert.NotNull(job.Session);
+
+        job.Stop();
+
+        Assert.True(await WaitForExitAsync(job, TimeSpan.FromSeconds(30)), "the job did not stop");
+    }
+}

--- a/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/TranscodeManagerFFmpegTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/FFProcessing/TranscodeManagerFFmpegTests.cs
@@ -181,7 +181,7 @@ public sealed class TranscodeManagerFFmpegTests : IClassFixture<SynthesizedMedia
         Assert.Contains("-loglevel", header, StringComparison.Ordinal);
         Assert.Contains("-stats", header, StringComparison.Ordinal);
 
-        // Specifically the overwrite flag, which the argument builders no longer emit themselves.
+        // Specifically the overwrite flag, which only the runner emits.
         Assert.Contains("-y", header, StringComparison.Ordinal);
     }
 

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing;
+using MediaBrowser.Controller.MediaEncoding.FFProcessing.Requests;
 using MediaBrowser.MediaEncoding.Encoder;
+using MediaBrowser.MediaEncoding.FFProcessing;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.MediaInfo;
@@ -24,7 +27,9 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
                 Mock.Of<IBlurayExaminer>(),
                 Mock.Of<ILocalizationManager>(),
                 new ConfigurationBuilder().Build(),
-                Mock.Of<IServerConfigurationManager>());
+                Mock.Of<IServerConfigurationManager>(),
+                new FFPaths(),
+                Mock.Of<IFFRunner>());
 
             var userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
             var req = new MediaBrowser.Controller.MediaEncoding.MediaInfoRequest()


### PR DESCRIPTION
**Changes**
FFmpeg and FFprobe processes were started from eleven hand-rolled ProcessStartInfo blocks; each with different process hygiene (and resulting bugs), refactored for code quality and correctness.

Every run of **ffmpeg** or **ffprobe** now gets _stdin_ closed unless the action is steerable (pause/resume/quit), _stdout_ is drained, _stderr_ is drained and captured, a wall clock timeout plus an idle watchdog (where a progress signal exists), and cancellation correctly kills the external process.

Added:
- `FFProcessing` to _MediaBrowser.Controller.MediaEncoding_:
- `FFAction` per operation to ensure arguments are type-correct
-  Typed request records that control argument construction
- `FFActionPolicy` to codify the operations and the request parameters
- `FFRunner` as the only place a process is started.
- Fully documents what the flags being passed to ffmpeg/ffprobe _mean_ and what they're driven by in the `*Request` objects

Breaking: 
- `IKeyframeExtractor.TryExtractKeyframes` becomes `ExtractKeyframesAsync` which returns `null` rather than `false` when it cannot handle a file
- `IDynamicHlsPlaylistGenerator.CreateMainPlaylist` becomes _async_ because it consumes _ExtractKeyframesAsync_
- `EncoderValidator`'s interrogations become _async_.
- `IMediaEncoder` adds `SetFFmpegPathAsync`; the old sync `SetFFmpegPath` remains as an `[Obsolete]` default interface member, so out-of-tree callers and implementers keep compiling.

Incidental fixes: 
- Live TV recording and delivery streams killed only FFmpeg itself, orphaning any child processes
- Stopping playback or hitting a recording's duration cap was logged as an FFmpeg error rather than a cancellation
- A failed start leaked the transcode log file handle
- Any transient priority-setting failure disabled server-wide until restart
- Two extraneous `-threads` flags that could not affect anything (on trickplay's encoder side, and on Live TV recording's) are dropped.

**Code assistance**
Claude Code used for analysis of all call sites and creation of unit tests. Some audit of the completed code conducted by both Claude and CoPilot.

**Issues**
- Fixes the 3rd code-path where `-copyts` wasn't cleaned up in PR #16440
- Generalizes the fix in PR #17429 that ensures we don't hang on a full pipe, so that it can't come back when new actions are added.
- Cleans up `PriorityClass` issues introduced in PR #15287