### PR TITLE
Pr/livetv reconnect q1

### DIFF
--- a/src/Jellyfin.LiveTv/IO/DirectRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/DirectRecorder.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -16,6 +17,19 @@ namespace Jellyfin.LiveTv.IO
 {
     public sealed class DirectRecorder : IRecorder
     {
+        // Number of consecutive empty reads (~50ms apart) tolerated on the shared-stream path before
+        // treating the source as ended so the caller can reconnect. Large enough to ride out brief
+        // buffer-empty hiccups on a live stream.
+        private const int EmptyReadLimit = 1000;
+
+        // Direct HTTP reads return 0 only on a real connection close, so recover quickly (~2s) to let
+        // the caller reconnect and resume appending instead of stalling on a dead socket.
+        private const int HttpEmptyReadLimit = 40;
+
+        // IPTV providers commonly redirect an HTTPS front URL to an HTTP CDN edge. HttpClient will not
+        // auto-follow an HTTPS->HTTP downgrade, so we follow a bounded number of redirects ourselves.
+        private const int MaxManualRedirects = 5;
+
         private readonly ILogger _logger;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IStreamHelper _streamHelper;
@@ -32,23 +46,23 @@ namespace Jellyfin.LiveTv.IO
             return targetFile;
         }
 
-        public Task Record(IDirectStreamProvider? directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
+        public Task Record(IDirectStreamProvider? directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, bool append, CancellationToken cancellationToken)
         {
             if (directStreamProvider is not null)
             {
-                return RecordFromDirectStreamProvider(directStreamProvider, targetFile, duration, onStarted, cancellationToken);
+                return RecordFromDirectStreamProvider(directStreamProvider, targetFile, duration, onStarted, append, cancellationToken);
             }
 
-            return RecordFromMediaSource(mediaSource, targetFile, duration, onStarted, cancellationToken);
+            return RecordFromMediaSource(mediaSource, targetFile, duration, onStarted, append, cancellationToken);
         }
 
-        private async Task RecordFromDirectStreamProvider(IDirectStreamProvider directStreamProvider, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
+        private async Task RecordFromDirectStreamProvider(IDirectStreamProvider directStreamProvider, string targetFile, TimeSpan duration, Action onStarted, bool append, CancellationToken cancellationToken)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(targetFile) ?? throw new ArgumentException("Path can't be a root directory.", nameof(targetFile)));
 
             var output = new FileStream(
                 targetFile,
-                FileMode.CreateNew,
+                append ? FileMode.Append : FileMode.CreateNew,
                 FileAccess.Write,
                 FileShare.Read,
                 IODefaults.FileStreamBufferSize,
@@ -71,7 +85,7 @@ namespace Jellyfin.LiveTv.IO
                         fileStream,
                         output,
                         IODefaults.CopyToBufferSize,
-                        1000,
+                        EmptyReadLimit,
                         linkedCancellationToken).ConfigureAwait(false);
                 }
             }
@@ -79,35 +93,87 @@ namespace Jellyfin.LiveTv.IO
             _logger.LogInformation("Recording completed: {FilePath}", targetFile);
         }
 
-        private async Task RecordFromMediaSource(MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
+        private async Task RecordFromMediaSource(MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, bool append, CancellationToken cancellationToken)
         {
-            using var response = await _httpClientFactory.CreateClient(NamedClient.Default)
-                .GetAsync(mediaSource.Path, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            using var response = await OpenStreamResponseAsync(mediaSource, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation("Opened recording stream from tuner provider");
 
             Directory.CreateDirectory(Path.GetDirectoryName(targetFile) ?? throw new ArgumentException("Path can't be a root directory.", nameof(targetFile)));
 
-            var output = new FileStream(targetFile, FileMode.CreateNew, FileAccess.Write, FileShare.Read, IODefaults.CopyToBufferSize, FileOptions.Asynchronous);
+            var output = new FileStream(targetFile, append ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read, IODefaults.CopyToBufferSize, FileOptions.Asynchronous);
             await using (output.ConfigureAwait(false))
             {
                 onStarted();
 
                 _logger.LogInformation("Copying recording stream to file {0}", targetFile);
 
-                // The media source if infinite so we need to handle stopping ourselves
+                // The media source is infinite so we need to handle stopping ourselves
                 using var durationToken = new CancellationTokenSource(duration);
                 using var linkedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, durationToken.Token);
                 cancellationToken = linkedCancellationToken.Token;
 
-                await _streamHelper.CopyUntilCancelled(
+                // Copy until the source stops delivering data (a dropped/ended connection) or the
+                // scheduled duration elapses. Returning on end-of-stream (rather than spinning until
+                // the duration is up) lets the caller reconnect and resume appending, so a flaky IPTV
+                // source still yields a complete recording instead of a truncated one.
+                await _streamHelper.CopyToAsync(
                     await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false),
                     output,
                     IODefaults.CopyToBufferSize,
+                    HttpEmptyReadLimit,
                     cancellationToken).ConfigureAwait(false);
 
                 _logger.LogInformation("Recording completed to file {0}", targetFile);
             }
+        }
+
+        /// <summary>
+        /// Opens the recording HTTP stream, applying the source's required headers and manually
+        /// following redirects that <see cref="HttpClient"/> refuses to follow automatically
+        /// (notably HTTPS-&gt;HTTP downgrades used by many IPTV CDNs). Without this the recorder would
+        /// capture the empty redirect body and write a 0-byte recording.
+        /// </summary>
+        private async Task<HttpResponseMessage> OpenStreamResponseAsync(MediaSourceInfo mediaSource, CancellationToken cancellationToken)
+        {
+            var client = _httpClientFactory.CreateClient(NamedClient.Default);
+            var url = mediaSource.Path;
+
+            for (var hop = 0; hop <= MaxManualRedirects; hop++)
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+                // Apply provider-specific headers (User-Agent/Referer/etc.) so sources that require
+                // them deliver data to the recorder just like they do to the player and transcoder.
+                if (mediaSource.RequiredHttpHeaders is not null)
+                {
+                    foreach (var header in mediaSource.RequiredHttpHeaders)
+                    {
+                        if (!string.IsNullOrWhiteSpace(header.Key) && !string.IsNullOrWhiteSpace(header.Value))
+                        {
+                            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                        }
+                    }
+                }
+
+                var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+                var status = (int)response.StatusCode;
+                if (status is >= 300 and < 400 && response.Headers.Location is not null)
+                {
+                    var location = response.Headers.Location;
+                    var next = location.IsAbsoluteUri ? location : new Uri(new Uri(url), location);
+                    _logger.LogInformation("Following recording stream redirect to {Scheme}://{Host}", next.Scheme, next.Host);
+                    url = next.ToString();
+                    response.Dispose();
+                    continue;
+                }
+
+                return response;
+            }
+
+            throw new HttpRequestException(
+                string.Format(CultureInfo.InvariantCulture, "Too many redirects opening recording stream from {0}", mediaSource.Path));
         }
 
         /// <inheritdoc />

--- a/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/EncodedRecorder.cs
@@ -58,15 +58,73 @@ namespace Jellyfin.LiveTv.IO
             return Path.ChangeExtension(targetFile, ".ts");
         }
 
-        public async Task Record(IDirectStreamProvider directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken)
+        public async Task Record(IDirectStreamProvider directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, bool append, CancellationToken cancellationToken)
         {
             // The media source is infinite so we need to handle stopping ourselves
             using var durationToken = new CancellationTokenSource(duration);
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, durationToken.Token);
 
-            await RecordFromFile(mediaSource, mediaSource.Path, targetFile, onStarted, cancellationTokenSource.Token).ConfigureAwait(false);
+            if (!append)
+            {
+                await RecordFromFile(mediaSource, mediaSource.Path, targetFile, onStarted, cancellationTokenSource.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                // ffmpeg cannot append to an existing container in-process, so capture this reconnect
+                // segment to a sibling file and binary-append it to the target afterwards. MPEG-TS
+                // concatenates cleanly, so the resulting recording plays back as one continuous file.
+                var segmentFile = targetFile + "." + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + ".part.ts";
+                try
+                {
+                    await RecordFromFile(mediaSource, mediaSource.Path, segmentFile, onStarted, cancellationTokenSource.Token).ConfigureAwait(false);
+                }
+                finally
+                {
+                    await AppendSegmentAsync(segmentFile, targetFile).ConfigureAwait(false);
+                }
+            }
 
             _logger.LogInformation("Recording completed to file {Path}", targetFile);
+        }
+
+        private async Task AppendSegmentAsync(string segmentFile, string targetFile)
+        {
+            try
+            {
+                if (!File.Exists(segmentFile) || new FileInfo(segmentFile).Length == 0)
+                {
+                    return;
+                }
+
+                var input = new FileStream(segmentFile, FileMode.Open, FileAccess.Read, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+                await using (input.ConfigureAwait(false))
+                {
+                    var output = new FileStream(targetFile, FileMode.Append, FileAccess.Write, FileShare.Read, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+                    await using (output.ConfigureAwait(false))
+                    {
+                        // Copy regardless of the recording cancellation so the captured segment is not lost.
+                        await input.CopyToAsync(output, CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error appending recording segment {Segment} to {Target}", segmentFile, targetFile);
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(segmentFile))
+                    {
+                        File.Delete(segmentFile);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error deleting recording segment {Segment}", segmentFile);
+                }
+            }
         }
 
         private async Task RecordFromFile(MediaSourceInfo mediaSource, string inputFile, string targetFile, Action onStarted, CancellationToken cancellationToken)
@@ -169,6 +227,20 @@ namespace Jellyfin.LiveTv.IO
             if (mediaSource.RequiresLooping)
             {
                 inputModifier += " -stream_loop -1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_delay_max 2";
+            }
+            else if (inputTempFile.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || inputTempFile.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                // Flaky IPTV/M3U providers routinely close the connection mid-stream (often every few
+                // seconds) and expect the client to reconnect. Let ffmpeg transparently reconnect the
+                // HTTP(S) input within this single process - including on a clean end-of-stream close -
+                // so the capture continues into one continuous, seamless file instead of being truncated
+                // or stitched together from many fragments (which breaks playback at each seam).
+                inputModifier += " -reconnect 1 -reconnect_streamed 1 -reconnect_at_eof 1 -reconnect_delay_max 4";
+                if (_mediaEncoder.EncoderVersion >= new Version(4, 3))
+                {
+                    inputModifier += " -reconnect_on_network_error 1";
+                }
             }
 
             var analyzeDurationSeconds = 5;

--- a/src/Jellyfin.LiveTv/IO/IRecorder.cs
+++ b/src/Jellyfin.LiveTv/IO/IRecorder.cs
@@ -18,9 +18,14 @@ namespace Jellyfin.LiveTv.IO
         /// <param name="targetFile">The target file.</param>
         /// <param name="duration">The duration to record.</param>
         /// <param name="onStarted">An action to perform when recording starts.</param>
+        /// <param name="append">
+        /// When <c>true</c>, the captured data is appended to <paramref name="targetFile"/> instead of
+        /// creating a new file. Used to resume a recording after a stream drop so a flaky source still
+        /// produces a single, complete recording.
+        /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A <see cref="Task"/> that represents the recording operation.</returns>
-        Task Record(IDirectStreamProvider? directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, CancellationToken cancellationToken);
+        Task Record(IDirectStreamProvider? directStreamProvider, MediaSourceInfo mediaSource, string targetFile, TimeSpan duration, Action onStarted, bool append, CancellationToken cancellationToken);
 
         string GetOutputPath(MediaSourceInfo mediaSource, string targetFile);
     }

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -55,6 +55,16 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     private static readonly TimeSpan StreamOpenInitialRetryDelay = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan StreamOpenMaxRetryDelay = TimeSpan.FromSeconds(10);
 
+    // A source that opens but delivers no data across this many consecutive reconnects is treated as
+    // unusable and the recording is aborted (instead of reconnecting forever on an empty stream).
+    private const int MaxEmptyReconnects = 5;
+    private static readonly TimeSpan StreamReconnectInitialDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan StreamReconnectMaxDelay = TimeSpan.FromSeconds(10);
+
+    // Don't bother reconnecting when this little of the scheduled recording remains; the reconnect
+    // overhead isn't worth it and the recording is effectively complete.
+    private static readonly TimeSpan MinRecordingRemaining = TimeSpan.FromSeconds(10);
+
     private readonly ConcurrentDictionary<string, ActiveRecordingInfo> _activeRecordings = new(StringComparer.OrdinalIgnoreCase);
     private readonly AsyncNonKeyedLocker _recordingDeleteSemaphore = new();
     private bool _disposed;
@@ -314,70 +324,120 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         var remoteMetadata = await FetchInternetMetadata(timer, CancellationToken.None).ConfigureAwait(false);
         var recordingPath = GetRecordingPath(timer, remoteMetadata, out var seriesPath);
 
-        string? liveStreamId = null;
         RecordingStatus recordingStatus;
-        try
+
+        // Runs exactly once, when the first connection actually starts producing the recording file.
+        async void OnStarted()
+        {
+            recordingInfo.Path = recordingPath;
+            _activeRecordings.TryAdd(timer.Id, recordingInfo);
+
+            timer.Status = RecordingStatus.InProgress;
+            _timerManager.AddOrUpdate(timer, false);
+
+            // Metadata is intentionally NOT written here. Writing it on "start" (before any video
+            // data is confirmed) left an orphaned .nfo and no video whenever an IPTV/M3U source
+            // failed to open. It is written in the finalize step below, only once a non-empty
+            // recording actually exists.
+            await CreateRecordingFolders().ConfigureAwait(false);
+
+            TriggerRefresh(recordingPath);
+            await EnforceKeepUpTo(timer, seriesPath).ConfigureAwait(false);
+        }
+
+        // Records a single connection to the source, appending to the same file on reconnects. A
+        // dropped/ended stream returns here so the reconnect loop can resume; the scheduled end
+        // (or a user stop) surfaces as an OperationCanceledException and ends the recording.
+        async Task RecordSegmentAsync(bool append, TimeSpan remaining, CancellationToken segmentToken)
         {
             var allMediaSources = await _mediaSourceManager
                 .GetPlaybackMediaSources(channel, null, true, false, CancellationToken.None).ConfigureAwait(false);
 
             var mediaStreamInfo = allMediaSources[0];
             IDirectStreamProvider? directStreamProvider = null;
+            string? segmentLiveStreamId = null;
             if (mediaStreamInfo.RequiresOpening)
             {
-                // Retry the stream open with exponential backoff so a transient IPTV/tuner hiccup
-                // doesn't lose the whole recording before the recorder even starts.
+                // Flaky IPTV/M3U sources frequently fail to open on the first attempt. Retry with
+                // backoff before starting the recorder so a transient hiccup doesn't lose the segment.
+                var openToken = mediaStreamInfo.OpenToken;
                 var liveStreamResponse = await OpenWithRetryAsync(
                     ct => _mediaSourceManager.OpenLiveStreamInternal(
                         new LiveStreamRequest
                         {
                             ItemId = channel.Id,
-                            OpenToken = mediaStreamInfo.OpenToken
+                            OpenToken = openToken
                         },
                         ct),
                     StreamOpenMaxAttempts,
                     StreamOpenInitialRetryDelay,
                     StreamOpenMaxRetryDelay,
                     _logger,
-                    recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
+                    segmentToken).ConfigureAwait(false);
 
                 mediaStreamInfo = liveStreamResponse.Item1.MediaSource;
-                liveStreamId = mediaStreamInfo.LiveStreamId;
+                segmentLiveStreamId = mediaStreamInfo.LiveStreamId;
                 directStreamProvider = liveStreamResponse.Item2;
             }
 
-            using var recorder = GetRecorder(mediaStreamInfo);
-
-            recordingPath = recorder.GetOutputPath(mediaStreamInfo, recordingPath);
-            recordingPath = EnsureFileUnique(recordingPath, timer.Id);
-
-            _libraryMonitor.ReportFileSystemChangeBeginning(recordingPath);
-
-            var duration = recordingEndDate - DateTime.UtcNow;
-
-            _logger.LogInformation("Beginning recording. Will record for {Duration} minutes.", duration.TotalMinutes);
-            _logger.LogInformation("Writing file to: {Path}", recordingPath);
-
-            async void OnStarted()
+            try
             {
-                recordingInfo.Path = recordingPath;
-                _activeRecordings.TryAdd(timer.Id, recordingInfo);
+                using var recorder = GetRecorder(mediaStreamInfo, directStreamProvider);
 
-                timer.Status = RecordingStatus.InProgress;
-                _timerManager.AddOrUpdate(timer, false);
+                if (!append)
+                {
+                    recordingPath = recorder.GetOutputPath(mediaStreamInfo, recordingPath);
+                    recordingPath = EnsureFileUnique(recordingPath, timer.Id);
 
-                await CreateRecordingFolders().ConfigureAwait(false);
+                    _libraryMonitor.ReportFileSystemChangeBeginning(recordingPath);
 
-                TriggerRefresh(recordingPath);
-                await EnforceKeepUpTo(timer, seriesPath).ConfigureAwait(false);
+                    _logger.LogInformation("Beginning recording. Will record for {Duration} minutes.", remaining.TotalMinutes);
+                    _logger.LogInformation("Writing file to: {Path}", recordingPath);
+                }
+                else
+                {
+                    _logger.LogInformation("Resuming recording after stream drop; appending to {Path}", recordingPath);
+                }
+
+                await recorder.Record(
+                    directStreamProvider,
+                    mediaStreamInfo,
+                    recordingPath,
+                    remaining,
+                    append ? () => { } : OnStarted,
+                    append,
+                    segmentToken).ConfigureAwait(false);
             }
+            finally
+            {
+                if (!string.IsNullOrWhiteSpace(segmentLiveStreamId))
+                {
+                    try
+                    {
+                        await _mediaSourceManager.CloseLiveStream(segmentLiveStreamId).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error closing live stream");
+                    }
+                }
+            }
+        }
 
-            await recorder.Record(
-                directStreamProvider,
-                mediaStreamInfo,
-                recordingPath,
-                duration,
-                OnStarted,
+        try
+        {
+            // Record across reconnects so a laggy/dropping IPTV source still produces a single,
+            // complete file: each dropped connection is reopened and recording resumes by appending
+            // until the scheduled end is reached (or the user stops the recording).
+            await RecordWithReconnectAsync(
+                RecordSegmentAsync,
+                () => recordingEndDate - DateTime.UtcNow,
+                () => File.Exists(recordingPath) ? new FileInfo(recordingPath).Length : 0,
+                MaxEmptyReconnects,
+                MinRecordingRemaining,
+                StreamReconnectInitialDelay,
+                StreamReconnectMaxDelay,
+                _logger,
                 recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
 
             recordingStatus = RecordingStatus.Completed;
@@ -392,18 +452,6 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         {
             _logger.LogError(ex, "Error recording to {RecordPath}", recordingPath);
             recordingStatus = RecordingStatus.Error;
-        }
-
-        if (!string.IsNullOrWhiteSpace(liveStreamId))
-        {
-            try
-            {
-                await _mediaSourceManager.CloseLiveStream(liveStreamId).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error closing live stream");
-            }
         }
 
         // Remove any empty/failed capture and its orphaned .nfo/folder so a recording that never
@@ -685,6 +733,97 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     }
 
     /// <summary>
+    /// Records a source across reconnects so a laggy/dropping stream still produces a single,
+    /// complete recording. Each call to <paramref name="recordSegmentAsync"/> records one connection;
+    /// when it returns before the scheduled end (the stream dropped), the source is reopened after a
+    /// backoff delay and recording resumes by appending to the same file. The loop ends when the
+    /// remaining time falls to <paramref name="minRemaining"/> or the segment throws
+    /// <see cref="OperationCanceledException"/> (scheduled end reached or the recording was stopped).
+    /// </summary>
+    /// <param name="recordSegmentAsync">
+    /// Records a single connection. The first argument is <c>true</c> when the segment should append
+    /// to the existing recording (i.e. this is a reconnect), the second is the time left to record.
+    /// </param>
+    /// <param name="getRemaining">Returns the time remaining until the scheduled recording end.</param>
+    /// <param name="getBytesWritten">Returns the number of bytes captured to the recording so far.</param>
+    /// <param name="maxEmptyReconnects">
+    /// The number of consecutive reconnects that may capture no new data before the recording is
+    /// aborted. Prevents an unusable source (e.g. one that opens but never delivers data) from
+    /// reconnecting forever and producing an endless empty recording.
+    /// </param>
+    /// <param name="minRemaining">The smallest remaining time worth (re)connecting for.</param>
+    /// <param name="initialReconnectDelay">The delay before the first reconnect attempt.</param>
+    /// <param name="maxReconnectDelay">The upper bound for the reconnect backoff delay.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A <see cref="Task"/> that completes when the recording reaches its scheduled end.</returns>
+    internal static async Task RecordWithReconnectAsync(
+        Func<bool, TimeSpan, CancellationToken, Task> recordSegmentAsync,
+        Func<TimeSpan> getRemaining,
+        Func<long> getBytesWritten,
+        int maxEmptyReconnects,
+        TimeSpan minRemaining,
+        TimeSpan initialReconnectDelay,
+        TimeSpan maxReconnectDelay,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recordSegmentAsync);
+        ArgumentNullException.ThrowIfNull(getRemaining);
+        ArgumentNullException.ThrowIfNull(getBytesWritten);
+
+        var appending = false;
+        var reconnectDelay = initialReconnectDelay;
+        var emptyReconnects = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var remaining = getRemaining();
+            if (remaining <= minRemaining)
+            {
+                break;
+            }
+
+            var bytesBefore = getBytesWritten();
+
+            await recordSegmentAsync(appending, remaining, cancellationToken).ConfigureAwait(false);
+
+            // The segment returned without cancellation, which means the source stopped delivering
+            // data before the scheduled end. If there's still meaningful time left, reconnect and
+            // keep appending so the recording finishes.
+            appending = true;
+
+            if (getRemaining() <= minRemaining)
+            {
+                break;
+            }
+
+            // Guard against a source that repeatedly opens but delivers nothing (e.g. an unusable
+            // URL or a redirect that yields an empty body): abort instead of reconnecting forever.
+            if (getBytesWritten() > bytesBefore)
+            {
+                emptyReconnects = 0;
+            }
+            else if (++emptyReconnects >= maxEmptyReconnects)
+            {
+                throw new InvalidOperationException(
+                    FormattableString.Invariant($"Recording captured no data across {emptyReconnects} consecutive reconnect attempts; aborting."));
+            }
+
+            logger.LogWarning(
+                "Recording stream ended with ~{RemainingSeconds:F0}s left before the scheduled end; reconnecting in {DelaySeconds:F0}s to finish the recording.",
+                getRemaining().TotalSeconds,
+                reconnectDelay.TotalSeconds);
+
+            await Task.Delay(reconnectDelay, cancellationToken).ConfigureAwait(false);
+
+            var nextDelayMs = Math.Min(reconnectDelay.TotalMilliseconds * 2, maxReconnectDelay.TotalMilliseconds);
+            reconnectDelay = TimeSpan.FromMilliseconds(nextDelayMs);
+        }
+    }
+
+    /// <summary>
     /// Deletes the given directory only when it exists and contains no entries. Used to remove the
     /// leftover recording folder after a failed (empty) capture has been cleaned up.
     /// </summary>
@@ -912,11 +1051,23 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         return path;
     }
 
-    private IRecorder GetRecorder(MediaSourceInfo mediaSource)
+    private IRecorder GetRecorder(MediaSourceInfo mediaSource, IDirectStreamProvider? directStreamProvider)
     {
         if (mediaSource.RequiresLooping
             || !(mediaSource.Container ?? string.Empty).EndsWith("ts", StringComparison.OrdinalIgnoreCase)
             || (mediaSource.Protocol != MediaProtocol.File && mediaSource.Protocol != MediaProtocol.Http))
+        {
+            return new EncodedRecorder(_logger, _mediaEncoder, _config.ApplicationPaths, _config);
+        }
+
+        // For infinite HTTP live streams consumed directly from the source URL (no shared-stream pipe),
+        // record through ffmpeg so it can transparently reconnect on the frequent connection drops of
+        // flaky IPTV/M3U providers, producing one continuous file. The raw DirectRecorder can only
+        // byte-append across reconnects, which stitches fragments from different edge servers and breaks
+        // playback at each seam.
+        if (directStreamProvider is null
+            && mediaSource.IsInfiniteStream
+            && mediaSource.Protocol == MediaProtocol.Http)
         {
             return new EncodedRecorder(_logger, _mediaEncoder, _config.ApplicationPaths, _config);
         }

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -51,6 +51,10 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
     private readonly SeriesTimerManager _seriesTimerManager;
     private readonly RecordingsMetadataManager _recordingsMetadataManager;
 
+    private const int StreamOpenMaxAttempts = 3;
+    private static readonly TimeSpan StreamOpenInitialRetryDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan StreamOpenMaxRetryDelay = TimeSpan.FromSeconds(10);
+
     private readonly ConcurrentDictionary<string, ActiveRecordingInfo> _activeRecordings = new(StringComparer.OrdinalIgnoreCase);
     private readonly AsyncNonKeyedLocker _recordingDeleteSemaphore = new();
     private bool _disposed;
@@ -321,13 +325,21 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             IDirectStreamProvider? directStreamProvider = null;
             if (mediaStreamInfo.RequiresOpening)
             {
-                var liveStreamResponse = await _mediaSourceManager.OpenLiveStreamInternal(
-                    new LiveStreamRequest
-                    {
-                        ItemId = channel.Id,
-                        OpenToken = mediaStreamInfo.OpenToken
-                    },
-                    CancellationToken.None).ConfigureAwait(false);
+                // Retry the stream open with exponential backoff so a transient IPTV/tuner hiccup
+                // doesn't lose the whole recording before the recorder even starts.
+                var liveStreamResponse = await OpenWithRetryAsync(
+                    ct => _mediaSourceManager.OpenLiveStreamInternal(
+                        new LiveStreamRequest
+                        {
+                            ItemId = channel.Id,
+                            OpenToken = mediaStreamInfo.OpenToken
+                        },
+                        ct),
+                    StreamOpenMaxAttempts,
+                    StreamOpenInitialRetryDelay,
+                    StreamOpenMaxRetryDelay,
+                    _logger,
+                    recordingInfo.CancellationTokenSource.Token).ConfigureAwait(false);
 
                 mediaStreamInfo = liveStreamResponse.Item1.MediaSource;
                 liveStreamId = mediaStreamInfo.LiveStreamId;
@@ -354,7 +366,6 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
                 timer.Status = RecordingStatus.InProgress;
                 _timerManager.AddOrUpdate(timer, false);
 
-                await _recordingsMetadataManager.SaveRecordingMetadata(timer, recordingPath, seriesPath).ConfigureAwait(false);
                 await CreateRecordingFolders().ConfigureAwait(false);
 
                 TriggerRefresh(recordingPath);
@@ -395,7 +406,9 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             }
         }
 
-        DeleteFileIfEmpty(recordingPath);
+        // Remove any empty/failed capture and its orphaned .nfo/folder so a recording that never
+        // produced video doesn't leave a metadata-only phantom item in the library.
+        DeleteOrphanedRecordingArtifacts(recordingPath, _logger);
         TriggerRefresh(recordingPath);
         _libraryMonitor.ReportFileSystemChangeComplete(recordingPath, false);
         _activeRecordings.TryRemove(timer.Id, out _);
@@ -411,11 +424,15 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
             timer.RetryCount++;
             _timerManager.AddOrUpdate(timer);
         }
-        else if (File.Exists(recordingPath))
+        else if (HasUsableRecording(recordingPath))
         {
             timer.RecordingPath = recordingPath;
             timer.Status = RecordingStatus.Completed;
             _timerManager.AddOrUpdate(timer, false);
+
+            // Write the .nfo sidecar only now that a usable (non-empty) recording exists, so a
+            // failed/empty capture never leaves an orphaned metadata file behind.
+            await _recordingsMetadataManager.SaveRecordingMetadata(timer, recordingPath, seriesPath).ConfigureAwait(false);
             await PostProcessRecording(recordingPath).ConfigureAwait(false);
         }
         else
@@ -584,20 +601,127 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
         return Path.Combine(recordingPath, recordingFileName);
     }
 
-    private void DeleteFileIfEmpty(string path)
+    /// <summary>
+    /// Removes a failed/empty recording capture and any artifacts it left behind (an empty video
+    /// file, an orphaned <c>.nfo</c> sidecar and the now-empty recording folder).
+    /// </summary>
+    /// <param name="recordingPath">The recording output path.</param>
+    /// <param name="logger">The logger.</param>
+    /// <returns><c>true</c> if the recording produced no usable video and artifacts were cleaned up; otherwise <c>false</c>.</returns>
+    internal static bool DeleteOrphanedRecordingArtifacts(string recordingPath, ILogger logger)
     {
-        var file = _fileSystem.GetFileInfo(path);
-
-        if (file.Exists && file.Length == 0)
+        if (HasUsableRecording(recordingPath))
         {
+            return false;
+        }
+
+        TryDeleteFile(recordingPath, logger);
+        TryDeleteFile(Path.ChangeExtension(recordingPath, ".nfo"), logger);
+
+        // A failed capture still created the series/movie subfolder for the output file. Remove it
+        // when empty so a recording that produced no video doesn't leave a phantom folder behind.
+        TryDeleteEmptyDirectory(Path.GetDirectoryName(recordingPath), logger);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether a recording output file exists and contains data. Used to gate metadata
+    /// writing and orphan cleanup so a failed/empty capture never persists a <c>.nfo</c> sidecar.
+    /// </summary>
+    /// <param name="recordingPath">The recording output path.</param>
+    /// <returns><c>true</c> if the file exists and is non-empty; otherwise <c>false</c>.</returns>
+    internal static bool HasUsableRecording(string recordingPath)
+        => File.Exists(recordingPath) && new FileInfo(recordingPath).Length > 0;
+
+    /// <summary>
+    /// Attempts an asynchronous open operation, retrying transient failures with exponential
+    /// backoff. Retries every exception except <see cref="OperationCanceledException"/> (which is
+    /// propagated immediately). The exception from the final attempt is re-thrown to the caller.
+    /// </summary>
+    /// <typeparam name="T">The result type of the open operation.</typeparam>
+    /// <param name="openAsync">The open operation to attempt.</param>
+    /// <param name="maxAttempts">The maximum number of attempts (must be at least 1).</param>
+    /// <param name="initialDelay">The delay before the first retry.</param>
+    /// <param name="maxDelay">The upper bound for the backoff delay.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result of the first successful attempt.</returns>
+    internal static async Task<T> OpenWithRetryAsync<T>(
+        Func<CancellationToken, Task<T>> openAsync,
+        int maxAttempts,
+        TimeSpan initialDelay,
+        TimeSpan maxDelay,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(openAsync);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxAttempts, 1);
+
+        var attempt = 0;
+        var delay = initialDelay;
+        while (true)
+        {
+            attempt++;
             try
             {
-                _fileSystem.DeleteFile(path);
+                return await openAsync(cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException && attempt < maxAttempts)
             {
-                _logger.LogError(ex, "Error deleting 0-byte failed recording file {Path}", path);
+                logger.LogWarning(
+                    ex,
+                    "Stream open attempt {Attempt}/{MaxAttempts} failed; retrying in {DelaySeconds}s",
+                    attempt,
+                    maxAttempts,
+                    delay.TotalSeconds);
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+
+                var nextDelayMs = Math.Min(delay.TotalMilliseconds * 2, maxDelay.TotalMilliseconds);
+                delay = TimeSpan.FromMilliseconds(nextDelayMs);
             }
+        }
+    }
+
+    /// <summary>
+    /// Deletes the given directory only when it exists and contains no entries. Used to remove the
+    /// leftover recording folder after a failed (empty) capture has been cleaned up.
+    /// </summary>
+    /// <param name="path">The directory to remove if empty.</param>
+    /// <param name="logger">The logger.</param>
+    private static void TryDeleteEmptyDirectory(string? path, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(path) && Directory.GetFileSystemEntries(path).Length == 0)
+            {
+                Directory.Delete(path, false);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Error deleting empty recording folder {Path}", path);
+        }
+    }
+
+    private static void TryDeleteFile(string path, ILogger logger)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting orphaned recording artifact {Path}", path);
         }
     }
 

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerOrphanCleanupTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerOrphanCleanupTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.IO;
+using Jellyfin.LiveTv.Recordings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings
+{
+    public sealed class RecordingsManagerOrphanCleanupTests : IDisposable
+    {
+        private readonly string _dir;
+
+        public RecordingsManagerOrphanCleanupTests()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "jf-rec-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_RemovesVideoAndNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(recordingPath));
+            Assert.False(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_MissingVideo_RemovesOrphanedNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_NonEmptyVideo_KeepsVideoAndNfo()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            var nfoPath = Path.Combine(_dir, "show.nfo");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+            File.WriteAllText(nfoPath, "<episodedetails></episodedetails>");
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.False(cleaned);
+            Assert.True(File.Exists(recordingPath));
+            Assert.True(File.Exists(nfoPath));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_RemovesEmptyRecordingFolder()
+        {
+            var folder = Path.Combine(_dir, "Scooby-Doo and Scrappy-Doo");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "episode.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(Directory.Exists(folder));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_NonEmptyVideo_KeepsRecordingFolder()
+        {
+            var folder = Path.Combine(_dir, "Some Show");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "episode.ts");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.False(cleaned);
+            Assert.True(Directory.Exists(folder));
+        }
+
+        [Fact]
+        public void DeleteOrphanedRecordingArtifacts_EmptyVideo_KeepsFolderWithOtherRecordings()
+        {
+            var folder = Path.Combine(_dir, "Series With Episodes");
+            Directory.CreateDirectory(folder);
+            var recordingPath = Path.Combine(folder, "failed.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+            var goodEpisode = Path.Combine(folder, "good.ts");
+            File.WriteAllBytes(goodEpisode, new byte[] { 1, 2, 3, 4 });
+
+            var cleaned = RecordingsManager.DeleteOrphanedRecordingArtifacts(recordingPath, NullLogger.Instance);
+
+            Assert.True(cleaned);
+            Assert.False(File.Exists(recordingPath));
+            Assert.True(Directory.Exists(folder));
+            Assert.True(File.Exists(goodEpisode));
+        }
+
+        [Fact]
+        public void HasUsableRecording_NonEmptyFile_ReturnsTrue()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            File.WriteAllBytes(recordingPath, new byte[] { 1, 2, 3, 4 });
+
+            Assert.True(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        [Fact]
+        public void HasUsableRecording_EmptyFile_ReturnsFalse()
+        {
+            var recordingPath = Path.Combine(_dir, "show.ts");
+            File.WriteAllBytes(recordingPath, Array.Empty<byte>());
+
+            Assert.False(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        [Fact]
+        public void HasUsableRecording_MissingFile_ReturnsFalse()
+        {
+            var recordingPath = Path.Combine(_dir, "does-not-exist.ts");
+
+            Assert.False(RecordingsManager.HasUsableRecording(recordingPath));
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(_dir, true);
+            }
+            catch (IOException)
+            {
+                // best effort cleanup
+            }
+        }
+    }
+}

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerReconnectTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerReconnectTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.LiveTv.Recordings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings
+{
+    public class RecordingsManagerReconnectTests
+    {
+        private const int MaxEmptyReconnects = 5;
+        private static readonly TimeSpan _fastDelay = TimeSpan.FromMilliseconds(1);
+        private static readonly TimeSpan _minRemaining = TimeSpan.FromSeconds(10);
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_CompletesFirstConnection_RecordsOnceWithoutAppend()
+        {
+            var appends = new List<bool>();
+            var done = false;
+
+            await RecordingsManager.RecordWithReconnectAsync(
+                (append, remaining, ct) =>
+                {
+                    appends.Add(append);
+                    done = true;
+                    return Task.CompletedTask;
+                },
+                () => done ? TimeSpan.Zero : TimeSpan.FromMinutes(30),
+                () => 1,
+                MaxEmptyReconnects,
+                _minRemaining,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(new[] { false }, appends);
+        }
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_StreamDropsBeforeEnd_ReconnectsAndAppendsUntilEnd()
+        {
+            var appends = new List<bool>();
+            var elapsedSeconds = 0;
+            var bytes = 0L;
+            const int TotalSeconds = 100;
+
+            await RecordingsManager.RecordWithReconnectAsync(
+                (append, remaining, ct) =>
+                {
+                    appends.Add(append);
+
+                    // Simulate each connection recording ~30s of data before the source drops.
+                    elapsedSeconds += 30;
+                    bytes += 1_000_000;
+                    return Task.CompletedTask;
+                },
+                () => TimeSpan.FromSeconds(TotalSeconds - elapsedSeconds),
+                () => bytes,
+                MaxEmptyReconnects,
+                _minRemaining,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            // First connection creates the file; every reconnect appends until the scheduled end.
+            Assert.Equal(new[] { false, true, true }, appends);
+        }
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_NoTimeRemaining_DoesNotRecord()
+        {
+            var calls = 0;
+
+            await RecordingsManager.RecordWithReconnectAsync(
+                (append, remaining, ct) =>
+                {
+                    calls++;
+                    return Task.CompletedTask;
+                },
+                () => TimeSpan.FromSeconds(5),
+                () => 1,
+                MaxEmptyReconnects,
+                _minRemaining,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(0, calls);
+        }
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_SegmentCancelled_PropagatesAndStops()
+        {
+            var calls = 0;
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                RecordingsManager.RecordWithReconnectAsync(
+                    (append, remaining, ct) =>
+                    {
+                        calls++;
+                        throw new OperationCanceledException();
+                    },
+                    () => TimeSpan.FromMinutes(30),
+                    () => 1,
+                    MaxEmptyReconnects,
+                    _minRemaining,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    CancellationToken.None));
+
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_CancelledDuringReconnect_Stops()
+        {
+            var calls = 0;
+            using var cts = new CancellationTokenSource();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                RecordingsManager.RecordWithReconnectAsync(
+                    async (append, remaining, ct) =>
+                    {
+                        calls++;
+                        if (calls >= 2)
+                        {
+                            await cts.CancelAsync();
+                        }
+                    },
+                    () => TimeSpan.FromMinutes(30),
+                    () => calls,
+                    MaxEmptyReconnects,
+                    _minRemaining,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    cts.Token));
+
+            Assert.Equal(2, calls);
+        }
+
+        [Fact]
+        public async Task RecordWithReconnectAsync_NeverCapturesData_AbortsAfterMaxEmptyReconnects()
+        {
+            var calls = 0;
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                RecordingsManager.RecordWithReconnectAsync(
+                    (append, remaining, ct) =>
+                    {
+                        calls++;
+                        return Task.CompletedTask;
+                    },
+                    () => TimeSpan.FromMinutes(30),
+                    () => 0,
+                    MaxEmptyReconnects,
+                    _minRemaining,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    CancellationToken.None));
+
+            // Aborts once MaxEmptyReconnects consecutive connections have each captured no data.
+            Assert.Equal(MaxEmptyReconnects, calls);
+        }
+    }
+}

--- a/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerRetryTests.cs
+++ b/tests/Jellyfin.LiveTv.Tests/Recordings/RecordingsManagerRetryTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.LiveTv.Recordings;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Jellyfin.LiveTv.Tests.Recordings
+{
+    public class RecordingsManagerRetryTests
+    {
+        private static readonly TimeSpan _fastDelay = TimeSpan.FromMilliseconds(1);
+
+        [Fact]
+        public async Task OpenWithRetryAsync_SucceedsFirstTry_CallsOnce()
+        {
+            var calls = 0;
+
+            var result = await RecordingsManager.OpenWithRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    return Task.FromResult(42);
+                },
+                maxAttempts: 3,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(42, result);
+            Assert.Equal(1, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_FailsThenSucceeds_RetriesUntilSuccess()
+        {
+            var calls = 0;
+
+            var result = await RecordingsManager.OpenWithRetryAsync(
+                _ =>
+                {
+                    calls++;
+                    if (calls < 3)
+                    {
+                        throw new InvalidOperationException("transient open failure");
+                    }
+
+                    return Task.FromResult("ok");
+                },
+                maxAttempts: 3,
+                _fastDelay,
+                _fastDelay,
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal("ok", result);
+            Assert.Equal(3, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_AlwaysFails_ThrowsAfterMaxAttempts()
+        {
+            var calls = 0;
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                RecordingsManager.OpenWithRetryAsync<int>(
+                    _ =>
+                    {
+                        calls++;
+                        throw new InvalidOperationException("always fails");
+                    },
+                    maxAttempts: 4,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    CancellationToken.None));
+
+            Assert.Equal("always fails", ex.Message);
+            Assert.Equal(4, calls);
+        }
+
+        [Fact]
+        public async Task OpenWithRetryAsync_Cancelled_DoesNotRetry()
+        {
+            var calls = 0;
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                RecordingsManager.OpenWithRetryAsync<int>(
+                    _ =>
+                    {
+                        calls++;
+                        throw new OperationCanceledException();
+                    },
+                    maxAttempts: 5,
+                    _fastDelay,
+                    _fastDelay,
+                    NullLogger.Instance,
+                    cts.Token));
+
+            Assert.Equal(1, calls);
+        }
+    }
+}


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->
Flaky IPTV/M3U sources routinely drop the connection mid-stream, which previously truncated the recording at the first drop. This records across reconnects (exponential backoff, append/resume to the same file) so a laggy/dropping source still produces a single, complete file. Adds append mode to IRecorder, ffmpeg -reconnect for HTTP inputs, HTTPS→HTTP redirect + required-header handling on the direct path, and RecordWithReconnectAsync with unit tests. Stacked on #17477 (DVR retry + orphaned-artifact cleanup); until that merges this PR's diff includes that commit too.
**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
