### PR TITLE
Fix video version links being read from stale serialised item data instead of the LinkedChildren table

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemMapper.cs
@@ -134,6 +134,21 @@ public static class BaseItemMapper
         if (dto is Video video)
         {
             video.PrimaryVersionId = entity.PrimaryVersionId;
+
+            // The LinkedChildren table is the source of truth for version links
+            if (entity.LinkedChildEntities is not null)
+            {
+                video.LinkedAlternateVersions = entity.LinkedChildEntities
+                    .Where(e => e.ChildType is Database.Implementations.Entities.LinkedChildType.LinkedAlternateVersion
+                        or Database.Implementations.Entities.LinkedChildType.AutoLinkedAlternateVersion)
+                    .OrderBy(e => e.SortOrder)
+                    .Select(e => new LinkedChild
+                    {
+                        ItemId = e.ChildId,
+                        Type = (MediaBrowser.Controller.Entities.LinkedChildType)e.ChildType
+                    })
+                    .ToArray();
+            }
         }
 
         if (dto is IHasSeries hasSeriesName)

--- a/Jellyfin.Server.Implementations/Item/BaseItemMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemMapper.cs
@@ -139,8 +139,8 @@ public static class BaseItemMapper
             if (entity.LinkedChildEntities is not null)
             {
                 video.LinkedAlternateVersions = entity.LinkedChildEntities
-                    .Where(e => e.ChildType is Database.Implementations.Entities.LinkedChildType.LinkedAlternateVersion
-                        or Database.Implementations.Entities.LinkedChildType.AutoLinkedAlternateVersion)
+                    // LocalAlternateVersion links belong to Video.LocalAlternateVersions, not here
+                    .Where(e => e.ChildType == Database.Implementations.Entities.LinkedChildType.LinkedAlternateVersion)
                     .OrderBy(e => e.SortOrder)
                     .Select(e => new LinkedChild
                     {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -244,8 +244,8 @@ public sealed partial class BaseItemRepository
             dbQuery = dbQuery.Include(e => e.Images);
         }
 
-        // Include LinkedChildEntities for container types and videos that use them
-        // (BoxSet, Playlist, CollectionFolder for manual linking; Video, Movie for alternate versions).
+        // Include LinkedChildEntities for container types and videos that use them (BoxSet, Playlist,
+        // CollectionFolder for manual linking; every video type for alternate versions).
         // When IncludeItemTypes is empty (any type may be returned), always include them to ensure
         // LinkedChildren are loaded before items are saved back, preventing accidental deletion.
         var linkedChildTypes = new[]
@@ -254,7 +254,10 @@ public sealed partial class BaseItemRepository
             BaseItemKind.Playlist,
             BaseItemKind.CollectionFolder,
             BaseItemKind.Video,
-            BaseItemKind.Movie
+            BaseItemKind.Movie,
+            BaseItemKind.Episode,
+            BaseItemKind.MusicVideo,
+            BaseItemKind.Trailer
         };
         if (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Any(linkedChildTypes.Contains))
         {


### PR DESCRIPTION
**Changes**
`Video.LinkedAlternateVersions` had two disagreeing sources of truth: version group membership was read from the `LinkedChildren` table, while the link type (user-merged vs. scan-merged) came from the copy serialised into the item's data blob, which `BaseItemMapper` only rehydrated for folders.
Videos now rehydrate `LinkedAlternateVersions` from `LinkedChildEntities` like folders do.

**Code assistance**
None

**Issues**
