### PR TITLE
fix(search): match accented People names in NameContains query

### DIFF
--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -284,8 +284,17 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!string.IsNullOrWhiteSpace(filter.NameContains))
         {
-            var nameContainsUpper = filter.NameContains.ToUpper();
-            query = query.Where(e => e.Name.ToUpper().Contains(nameContainsUpper));
+            // The previous code compared SQLite's UPPER(name) against a .NET-uppercased search
+            // term. SQLite's UPPER() only folds ASCII letters, so "René" -> "RENé", whereas .NET's
+            // ToUpper() folds accented letters too, so "René" -> "RENÉ". The mismatch meant
+            // searching for an accented name failed to match the identical stored name, even though
+            // searching without the accent ("Ren") matched. Use EF.Functions.Like so the match is
+            // handled by SQLite's case-insensitive LIKE on UPPER(name); LIKE folds ASCII case but
+            // compares non-ASCII characters exactly, so the accented letter lines up on both sides
+            // and "Ren", "René", "ren" and "rené" all match a person named "René".
+            query = query.Where(e => EF.Functions.Like(
+                e.Name.ToUpper(),
+                "%" + filter.NameContains + "%"));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.NameStartsWith))

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/PeopleRepositorySearchTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/PeopleRepositorySearchTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class PeopleRepositorySearchTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly PeopleRepository _repository;
+
+    public PeopleRepositorySearchTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Peoples.Add(new People { Id = Guid.NewGuid(), Name = "René Zellweger", PersonType = "Actor" });
+            ctx.Peoples.Add(new People { Id = Guid.NewGuid(), Name = "Jean Dujardin", PersonType = "Actor" });
+            ctx.SaveChanges();
+        }
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+        _repository = new PeopleRepository(factory.Object, new ItemTypeLookup());
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    [Theory]
+    [InlineData("René")] // exact accented term — this failed before the fix
+    [InlineData("Ren")] // accented name matched without the accent already
+    [InlineData("rené")] // case-insensitive accented term
+    [InlineData("ren")]
+    public void GetPeople_NameContains_MatchesAccentedName(string searchTerm)
+    {
+        var result = _repository.GetPeople(new InternalPeopleQuery
+        {
+            NameContains = searchTerm
+        });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal("René Zellweger", item.Name);
+    }
+
+    [Fact]
+    public void GetPeople_NameContains_DoesNotReturnUnrelatedPeople()
+    {
+        var result = _repository.GetPeople(new InternalPeopleQuery
+        {
+            NameContains = "René"
+        });
+
+        Assert.All(result.Items, p => Assert.NotEqual("Jean Dujardin", p.Name));
+    }
+
+    private JellyfinDbContext CreateDbContext()
+    {
+        return new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+    }
+}


### PR DESCRIPTION
Searching for a Person whose name contains diacritics (e.g. "René") failed even though searching without the accent ("Ren") worked fine. The root cause was a mismatch between how SQLite and .NET fold case: UPPER(name) on the SQLite side only folds ASCII letters (é stays é), while filter.NameContains.ToUpper() in .NET folds full Unicode (é → É). The Contains comparison between these two differently-folded strings never lined up for accented characters.

This replaces the Contains call with EF.Functions.Like on UPPER(name) and drops the .NET ToUpper() on the search term. SQLite LIKE is ASCII case-insensitive and compares non-ASCII bytes exactly, so the accent matches on both sides. The net effect is that "Ren", "René", "ren", and "rené" all find a person named "René", consistent with how item title search already behaves after #15435.

Added unit tests covering accented, unaccented, and mixed-case search terms against the PeopleRepository.

Fixes #17483