### PR TITLE
fix(images): disambiguate progress overlay cache keys

### DIFF
--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -252,22 +252,33 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
     /// Gets the cache file path based on a set of parameters.
     /// </summary>
     /// <param name="originalPath">The original image path.</param>
-    /// <param name="width">The requested width.</param>
-    /// <param name="height">The requested height.</param>
-    /// <param name="maxWidth">The maximum width.</param>
-    /// <param name="maxHeight">The maximum height.</param>
-    /// <param name="fillWidth">The fill width.</param>
-    /// <param name="fillHeight">The fill height.</param>
-    /// <param name="quality">The image quality.</param>
     /// <param name="dateModified">The source image modification date.</param>
     /// <param name="format">The output format.</param>
-    /// <param name="percentPlayed">The played percentage overlay value.</param>
-    /// <param name="unwatchedCount">The unwatched count overlay value.</param>
-    /// <param name="blur">The blur amount.</param>
-    /// <param name="backgroundColor">The background color.</param>
-    /// <param name="foregroundLayer">The foreground layer.</param>
+    /// <param name="options">The image processing options.</param>
     /// <returns>The transformed image cache path.</returns>
     internal string GetCacheFilePath(
+        string originalPath,
+        DateTime dateModified,
+        ImageFormat format,
+        ImageProcessingOptions options)
+        => GetCacheFilePath(
+            originalPath,
+            options.Width,
+            options.Height,
+            options.MaxWidth,
+            options.MaxHeight,
+            options.FillWidth,
+            options.FillHeight,
+            options.Quality,
+            dateModified,
+            format,
+            options.PercentPlayed,
+            options.UnplayedCount,
+            options.Blur,
+            options.BackgroundColor,
+            options.ForegroundLayer);
+
+    private string GetCacheFilePath(
         string originalPath,
         int? width,
         int? height,

--- a/src/Jellyfin.Drawing/ImageProcessor.cs
+++ b/src/Jellyfin.Drawing/ImageProcessor.cs
@@ -31,7 +31,7 @@ namespace Jellyfin.Drawing;
 public sealed class ImageProcessor : IImageProcessor, IDisposable
 {
     // Increment this when there's a change requiring caches to be invalidated
-    private const char Version = '3';
+    private const char Version = '4';
 
     private static readonly HashSet<string> _transparentImageTypes
         = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".png", ".webp", ".gif", ".svg" };
@@ -251,7 +251,23 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
     /// <summary>
     /// Gets the cache file path based on a set of parameters.
     /// </summary>
-    private string GetCacheFilePath(
+    /// <param name="originalPath">The original image path.</param>
+    /// <param name="width">The requested width.</param>
+    /// <param name="height">The requested height.</param>
+    /// <param name="maxWidth">The maximum width.</param>
+    /// <param name="maxHeight">The maximum height.</param>
+    /// <param name="fillWidth">The fill width.</param>
+    /// <param name="fillHeight">The fill height.</param>
+    /// <param name="quality">The image quality.</param>
+    /// <param name="dateModified">The source image modification date.</param>
+    /// <param name="format">The output format.</param>
+    /// <param name="percentPlayed">The played percentage overlay value.</param>
+    /// <param name="unwatchedCount">The unwatched count overlay value.</param>
+    /// <param name="blur">The blur amount.</param>
+    /// <param name="backgroundColor">The background color.</param>
+    /// <param name="foregroundLayer">The foreground layer.</param>
+    /// <returns>The transformed image cache path.</returns>
+    internal string GetCacheFilePath(
         string originalPath,
         int? width,
         int? height,
@@ -318,13 +334,13 @@ public sealed class ImageProcessor : IImageProcessor, IDisposable
 
         if (percentPlayed > 0)
         {
-            filename.Append(",p=");
-            filename.Append(percentPlayed);
+            filename.Append(",pp=");
+            filename.Append(percentPlayed.ToString(CultureInfo.InvariantCulture));
         }
 
         if (unwatchedCount.HasValue)
         {
-            filename.Append(",p=");
+            filename.Append(",uc=");
             filename.Append(unwatchedCount.Value);
         }
 

--- a/src/Jellyfin.Drawing/Properties/AssemblyInfo.cs
+++ b/src/Jellyfin.Drawing/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -12,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2019 Jellyfin Contributors. Code released under the GNU General Public License")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Jellyfin.Server.Integration.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/tests/Jellyfin.Server.Integration.Tests/ImageProcessorTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/ImageProcessorTests.cs
@@ -105,20 +105,27 @@ public sealed class ImageProcessorTests : IDisposable
     }
 
     private string GetCacheFilePath(double percentPlayed = 0, int? unwatchedCount = null)
-        => _imageProcessor.GetCacheFilePath(
+    {
+        var options = new ImageProcessingOptions
+        {
+            Width = 200,
+            Height = 300,
+            MaxWidth = 400,
+            MaxHeight = 500,
+            FillWidth = 600,
+            FillHeight = 700,
+            Quality = 90,
+            PercentPlayed = percentPlayed,
+            UnplayedCount = unwatchedCount,
+            Blur = 2,
+            BackgroundColor = "000000",
+            ForegroundLayer = "layer"
+        };
+
+        return _imageProcessor.GetCacheFilePath(
             OriginalPath,
-            width: 200,
-            height: 300,
-            maxWidth: 400,
-            maxHeight: 500,
-            fillWidth: 600,
-            fillHeight: 700,
-            quality: 90,
-            dateModified: _dateModified,
-            format: ImageFormat.Jpg,
-            percentPlayed,
-            unwatchedCount,
-            blur: 2,
-            backgroundColor: "000000",
-            foregroundLayer: "layer");
+            _dateModified,
+            ImageFormat.Jpg,
+            options);
+    }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/ImageProcessorTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/ImageProcessorTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Globalization;
+using System.IO;
+using Jellyfin.Drawing;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Drawing;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests;
+
+public sealed class ImageProcessorTests : IDisposable
+{
+    private const string CacheRoot = "image-cache";
+    private const string OriginalPath = "/media/poster.jpg";
+    private const string NoOverlayCacheKey = "/media/poster.jpg,quality=90,datemodified=638800000000000000,f=Jpg,width=200,height=300,maxwidth=400,maxheight=500,fillwidth=600,fillheight=700,blur=2,b=000000,fl=layer,v=4";
+    private static readonly DateTime _dateModified = new(638800000000000000, DateTimeKind.Utc);
+    private readonly ImageProcessor _imageProcessor;
+
+    public ImageProcessorTests()
+    {
+        var applicationPaths = new Mock<IServerApplicationPaths>();
+        applicationPaths.SetupGet(paths => paths.ImageCachePath).Returns(CacheRoot);
+
+        var configurationManager = new Mock<IServerConfigurationManager>();
+        configurationManager
+            .SetupGet(manager => manager.Configuration)
+            .Returns(new ServerConfiguration { ParallelImageEncodingLimit = 1 });
+
+        _imageProcessor = new ImageProcessor(
+            NullLogger<ImageProcessor>.Instance,
+            applicationPaths.Object,
+            Mock.Of<IFileSystem>(),
+            Mock.Of<IImageEncoder>(),
+            configurationManager.Object);
+    }
+
+    [Fact]
+    public void GetCacheFilePath_DifferentOverlayTypes_ReturnDifferentPaths()
+    {
+        var percentPlayedPath = GetCacheFilePath(percentPlayed: 1);
+        var unwatchedCountPath = GetCacheFilePath(unwatchedCount: 1);
+
+        Assert.NotEqual(percentPlayedPath, unwatchedCountPath);
+    }
+
+    [Fact]
+    public void GetCacheFilePath_DifferentPercentPlayedValues_ReturnDifferentPaths()
+    {
+        var firstPath = GetCacheFilePath(percentPlayed: 12.5);
+        var secondPath = GetCacheFilePath(percentPlayed: 75.5);
+
+        Assert.NotEqual(firstPath, secondPath);
+    }
+
+    [Fact]
+    public void GetCacheFilePath_DifferentUnwatchedCountValues_ReturnDifferentPaths()
+    {
+        var firstPath = GetCacheFilePath(unwatchedCount: 1);
+        var secondPath = GetCacheFilePath(unwatchedCount: 2);
+
+        Assert.NotEqual(firstPath, secondPath);
+    }
+
+    [Fact]
+    public void GetCacheFilePath_DifferentCultures_ReturnSamePath()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            var expectedPath = GetCacheFilePath(percentPlayed: 12.5);
+
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var actualPath = GetCacheFilePath(percentPlayed: 12.5);
+
+            Assert.Equal(expectedPath, actualPath);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Fact]
+    public void GetCacheFilePath_NoOverlay_UsesVersionFourWithExistingSerialization()
+    {
+        var expectedPath = _imageProcessor.GetCachePath(
+            Path.Combine(CacheRoot, "resized-images"),
+            NoOverlayCacheKey,
+            ".jpg");
+
+        Assert.Equal(expectedPath, GetCacheFilePath());
+    }
+
+    public void Dispose()
+    {
+        _imageProcessor.Dispose();
+    }
+
+    private string GetCacheFilePath(double percentPlayed = 0, int? unwatchedCount = null)
+        => _imageProcessor.GetCacheFilePath(
+            OriginalPath,
+            width: 200,
+            height: 300,
+            maxWidth: 400,
+            maxHeight: 500,
+            fillWidth: 600,
+            fillHeight: 700,
+            quality: 90,
+            dateModified: _dateModified,
+            format: ImageFormat.Jpg,
+            percentPlayed,
+            unwatchedCount,
+            blur: 2,
+            backgroundColor: "000000",
+            foregroundLayer: "layer");
+}


### PR DESCRIPTION
## Changes

Fix derivative image cache-key collisions between percent-played and unwatched-count overlays.

### Problem

`ImageProcessor.GetCacheFilePath` serialized both overlay types using the same
`p=` component. Two otherwise identical transformations with the same numeric
value could therefore produce the same derivative path even though they render
different overlays.

A focused regression test reproduces the collision on current master.

### Implementation

- Serialize percent played with `pp=`.
- Serialize unwatched count with `uc=`.
- Format percent-played values using invariant culture.
- Increment transformed-image cache version from 3 to 4.
- Expose cache-path construction only internally for direct regression tests.

### Scope and non-goals

This change does not modify:

- overlay rendering;
- HTTP cache headers;
- image encoding or format negotiation;
- source-image handling;
- cache directory layout;
- cache cleanup behavior.

### Validation

Focused baseline against old key behavior:

- 2 passed, 3 failed, 0 skipped.
- Expected failures covered overlay-type collision, culture variance, and the
  new cache-version snapshot.

After the fix:

- Focused cache-path tests: 5 passed, 0 failed, 0 skipped.
- Jellyfin.Server.Integration.Tests Release: 108 passed, 0 failed, 3 skipped.
- Full Jellyfin.sln Release gate with XPlat coverage: 3,161 passed, 0 failed,
  10 skipped.
- `dotnet format --verify-no-changes --verbosity minimal`: passed.
- `git diff --check`: passed.

Tests cover:

- percent-played and unwatched-count requests produce different paths;
- different percent-played values produce different paths;
- different unwatched-count values produce different paths;
- culture changes do not alter paths;
- no-overlay serialization remains unchanged except for cache version 4.

No performance benchmark was run because this is a correctness fix. No
performance improvement is claimed.

### Compatibility and cache migration

No public API or plugin interface changes.

The version bump causes one-time regeneration of transformed-image cache
entries after upgrade. Existing version-3 entries are no longer reused and
will eventually be removed by the existing daily cache cleanup.

### Related work

PR #17420 also touches transformed-image caching but addresses atomic cache
publication and does not overlap this key-serialization fix.

No exact tracking issue was found during overlap searches.

## Code assistance

An AI coding agent was used for repository navigation, implementation
assistance, test authoring, validation, and drafting. All changes and command
results were reviewed and verified before submission.