### PR TITLE
Fix storage info lookup for Windows

### DIFF
--- a/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
+++ b/Jellyfin.Server.Implementations/StorageHelpers/StorageHelper.cs
@@ -87,8 +87,9 @@ public static class StorageHelper
     /// </summary>
     private static string ResolvePath(string path)
     {
-        var parts = path.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
-        var current = Path.DirectorySeparatorChar.ToString();
+        var root = Path.GetPathRoot(path) ?? Path.DirectorySeparatorChar.ToString();
+        var parts = path.Substring(root.Length).Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        var current = root;
         foreach (var part in parts)
         {
             current = Path.Combine(current, part);


### PR DESCRIPTION
When a user running Windows had the program folder on a drive besides `C:\`, the storage info would rebuild the path incorrectly (e.g., `D:Jellyfin` instead of `D:\Jellyfin`) due to how `Path.Combine` handles drive letters. This broke drive matching, so no storage info could be found, and as a result the backup feature would not work.

**Changes**
Use `Path.GetPathRoot()` to get the drive root instead of combining it manually.


**Code assistance**
N/A

**Issues**
Fixes: #17497
