### PR TITLE
Skip SIDX in fMP4 HLS segments

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1607,8 +1607,9 @@ public class DynamicHlsController : BaseJellyfinApiController
 
             if (state.VideoStream is not null && state.IsOutputVideo)
             {
-                // fMP4 needs this flag to write the audio packet DTS/PTS including the initial delay into MOOF::TRAF::TFDT
-                hlsArguments += $" {(useLegacySegmentOption ? "-hls_ts_options" : "-hls_segment_options")} movflags=+frag_discont";
+                // fMP4 needs frag_discont to write the audio packet DTS/PTS including the initial delay into MOOF::TRAF::TFDT
+                // HLS does not use SIDX, and skipping it avoids FFmpeg rewriting open-GOP boundary packet PTS
+                hlsArguments += $" {(useLegacySegmentOption ? "-hls_ts_options" : "-hls_segment_options")} movflags=+frag_discont+skip_sidx";
             }
 
             segmentFormat = "fmp4" + outputFmp4HeaderArg;


### PR DESCRIPTION
Prevent FFmpeg's SIDX path from rewriting open-GOP boundary packet timestamps. HLS uses the media playlist for segment indexing and does not require the SIDX box.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Add `skip_sidx` to the MOV flags used for fMP4 HLS video segments:

```text
-hls_segment_options movflags=+frag_discont+skip_sidx
```

FFmpeg’s HLS muxer subsequently appends `+frag_custom+dash+delay_moov`, making the effective set:

```text
+frag_discont+skip_sidx+frag_custom+dash+delay_moov
```

This preserves the existing `frag_discont` behavior and DASH-compatible fragmented MP4 layout while omitting the unnecessary top-level `sidx` box.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

GPT5.6-Sol was used for testing and validation.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

I did not find any pre-existing issues about this.

<br>
<br>
<br>

### Background

Some open-GOP H.264 streams exhibit periodic dropped frames when Jellyfin remuxes them into fMP4 HLS. The affected fragments contain incorrect presentation timestamps before they reach the browser or hls.js.

At one reproduced segment boundary, the packet timing was:

```
Source keyframe:       PTS 18.477, DTS 18.227
Generated fMP4 sample: PTS 18.393, DTS 18.226
Another fMP4 sample:   PTS 18.393
```

FFmpeg moved the segment-opening sample backward by approximately two frames, placing it at the same presentation timestamp as another sample. Chrome rendered one sample and reported the other as dropped. A 165-second playback baseline contained 16 such drops, all aligned with affected segment boundaries.

The problem also reproduced when the generated init segment and fragments were appended as a native fragmented-MP4 Blob, without Jellyfin Web or hls.js processing. This isolates the timestamp corruption to the generated FFmpeg output.

### FFmpeg behavior

For fMP4 HLS output, FFmpeg’s HLS muxer enables:

```
+frag_custom+dash+delay_moov
```

When DASH output is enabled and SIDX generation is not disabled, `movenc` rewrites a boundary packet’s PTS while calculating index timing:

```
pkt->pts = pkt->dts + trk->end_pts - trk->cluster[trk->entry].dts;
```

This is incorrect for certain open-GOP boundaries. The first decode-order sample can present after leading pictures that follow it in decode order. Moving that sample backward can make its PTS collide with one of those leading pictures.

Adding `skip_sidx` bypasses this SIDX-specific timestamp rewrite and preserves the source packet timing.

### Why SIDX can be skipped

Jellyfin’s HLS clients obtain segment locations and durations from the media playlist. They do not require a top-level `sidx` box in each media segment.

This change does not disable FFmpeg’s `dash` MOV flag or alter the `moof`, `traf`, `trun`, `tfdt`, or media payload structure required for fragmented MP4 playback. It only suppresses SIDX generation.

The change is limited to the existing fMP4 video path. MPEG-TS and audio-only fMP4 outputs are unchanged.

### Verification

The workaround was tested by generating both video-only and video+FLAC fMP4 HLS output with:

```
-hls_segment_options movflags=+frag_discont+skip_sidx
```

Compared with the existing output:

- Segment boundaries were unchanged.
- Playlist `EXTINF` durations were unchanged.
- The affected opening samples retained their source PTS.
- The duplicate presentation timestamps were no longer generated.
- Valid fragmented MP4 HLS output was produced without SIDX boxes.

The underlying timestamp rewrite remains an FFmpeg issue and should ultimately be corrected upstream. Skipping SIDX avoids a Jellyfin-FFmpeg or upstream FFmpeg patch for the time being.