### PR TITLE
Return the created API key from POST /Auth/Keys

### DIFF
--- a/Jellyfin.Api/Controllers/ApiKeyController.cs
+++ b/Jellyfin.Api/Controllers/ApiKeyController.cs
@@ -47,16 +47,14 @@ public class ApiKeyController : BaseJellyfinApiController
     /// Create a new api key.
     /// </summary>
     /// <param name="app">Name of the app using the authentication key.</param>
-    /// <response code="204">Api key created.</response>
-    /// <returns>A <see cref="NoContentResult"/>.</returns>
+    /// <response code="200">Api key created.</response>
+    /// <returns>An <see cref="AuthenticationInfo"/> with the created key.</returns>
     [HttpPost("Keys")]
     [Authorize(Policy = Policies.RequiresElevation)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> CreateKey([FromQuery, Required] string app)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AuthenticationInfo>> CreateKey([FromQuery, Required] string app)
     {
-        await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
-
-        return NoContent();
+        return await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
@@ -23,14 +23,25 @@ namespace Jellyfin.Server.Implementations.Security
         }
 
         /// <inheritdoc />
-        public async Task CreateApiKey(string name)
+        public async Task<AuthenticationInfo> CreateApiKey(string name)
         {
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                dbContext.ApiKeys.Add(new ApiKey(name));
+                var key = new ApiKey(name);
+                dbContext.ApiKeys.Add(key);
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                return new AuthenticationInfo
+                {
+                    AppName = key.Name,
+                    AccessToken = key.AccessToken,
+                    DateCreated = key.DateCreated,
+                    DeviceId = string.Empty,
+                    DeviceName = string.Empty,
+                    AppVersion = string.Empty
+                };
             }
         }
 

--- a/MediaBrowser.Controller/Security/IAuthenticationManager.cs
+++ b/MediaBrowser.Controller/Security/IAuthenticationManager.cs
@@ -12,8 +12,8 @@ namespace MediaBrowser.Controller.Security
         /// Creates an API key.
         /// </summary>
         /// <param name="name">The name of the key.</param>
-        /// <returns>A task representing the creation of the key.</returns>
-        Task CreateApiKey(string name);
+        /// <returns>A task representing the creation of the key, containing the created key.</returns>
+        Task<AuthenticationInfo> CreateApiKey(string name);
 
         /// <summary>
         /// Gets the API keys.


### PR DESCRIPTION
**Changes**

`POST /Auth/Keys` previously returned `204 No Content`, so after creating a key a client had to call `GET /Auth/Keys` and filter by app name — which is not necessarily unique — to find the token it just created.

The endpoint now returns `200 OK` with the created key as an `AuthenticationInfo` payload (same shape as the items returned by `GET /Auth/Keys`):

- `IAuthenticationManager.CreateApiKey` now returns `Task<AuthenticationInfo>`
- `AuthenticationManager.CreateApiKey` maps the created `ApiKey` entity to `AuthenticationInfo` after saving
- `ApiKeyController.CreateKey` returns the created key

Clients that only check for a 2xx status are unaffected.

**Issues**
Fixes #16258