### PR TITLE
Use CleanName when sorting by name

### DIFF
--- a/Jellyfin.Server.Implementations/Item/OrderMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/OrderMapper.cs
@@ -68,7 +68,7 @@ public static class OrderMapper
             (ItemSortBy.DateCreated, _) => e => e.DateCreated,
             (ItemSortBy.PremiereDate, _) => e => e.PremiereDate ?? (e.ProductionYear.HasValue ? DateTime.MinValue.AddYears(e.ProductionYear.Value - 1) : null),
             (ItemSortBy.StartDate, _) => e => e.StartDate,
-            (ItemSortBy.Name, _) => e => e.SortName,
+            (ItemSortBy.Name, _) => e => e.CleanName,
             (ItemSortBy.CommunityRating, _) => e => e.CommunityRating,
             (ItemSortBy.ProductionYear, _) => e => e.ProductionYear,
             (ItemSortBy.CriticRating, _) => e => e.CriticRating,


### PR DESCRIPTION
In #16804 we changed  `ItemSortBy.Name` to use` SortName` instead of `CleanName` to fix an issue with album sorting. That solved the issue at the time, but caused some regressions (see below). The original issue is no longer reproducible with `CleanName` being used, so it is safe to revert the change.

**Code assistance**
N/A

**Issues**
Tracks being sorted by name in the songs tab:

CleanName: 
<img width="233" height="219" alt="1a" src="https://github.com/user-attachments/assets/daf5b79a-1aa3-4f70-a7a2-991e234625c2" />

SortName:
<img width="276" height="227" alt="2a" src="https://github.com/user-attachments/assets/0c505892-4778-4e0f-918e-eefaab541bb5" />

