### PR TITLE
Fix: cycle-guard the parent-chain walks (GetParents / GetCollectionFolders)

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2703,8 +2703,17 @@ namespace Emby.Server.Implementations.Library
 
         public List<Folder> GetCollectionFolders(BaseItem item, IEnumerable<Folder> allUserRootChildren)
         {
+            var visited = new HashSet<Guid>();
             while (item is not null)
             {
+                // Guard against a cyclic parent chain (e.g. ParentId set before the parent is
+                // registered during concurrent scans). Without this the loop never terminates
+                // and re-enters the item-id cache forever — the trickplay/segment ~75%/95% freeze.
+                if (!visited.Add(item.Id))
+                {
+                    break;
+                }
+
                 var parent = item.GetParent();
 
                 if (parent is AggregateFolder)

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -1040,9 +1040,16 @@ namespace MediaBrowser.Controller.Entities
         public IEnumerable<BaseItem> GetParents()
         {
             var parent = GetParent();
+            var visited = new HashSet<Guid>();
 
             while (parent is not null)
             {
+                // Guard against a cyclic parent chain; stop instead of spinning forever.
+                if (!visited.Add(parent.Id))
+                {
+                    break;
+                }
+
                 yield return parent;
 
                 parent = parent.GetParent();

--- a/tests/Jellyfin.Controller.Tests/BaseItemStaticStateCollection.cs
+++ b/tests/Jellyfin.Controller.Tests/BaseItemStaticStateCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace Jellyfin.Controller.Tests;
+
+/// <summary>
+/// Test classes that mutate the static <c>BaseItem.LibraryManager</c> /
+/// <c>BaseItem.MediaSourceManager</c>. Grouped into one collection so xUnit
+/// runs them sequentially and they cannot clobber each other's shared state.
+/// </summary>
+[CollectionDefinition("BaseItem static state")]
+public class BaseItemStaticStateCollection
+{
+}

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemParentsTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemParentsTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("BaseItem static state")]
 public class BaseItemParentsTests
 {
     [Fact]

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemParentsTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemParentsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.Entities;
+
+public class BaseItemParentsTests
+{
+    [Fact]
+    public async Task GetParents_CyclicParentChain_Terminates()
+    {
+        var saved = BaseItem.LibraryManager;
+        try
+        {
+            var a = new Video { Id = Guid.NewGuid() };
+            var b = new Video { Id = Guid.NewGuid() };
+            a.ParentId = b.Id;
+            b.ParentId = a.Id; // cycle: a -> b -> a
+
+            BaseItem.LibraryManager = BuildFakeLibraryManager(a, b);
+
+            // Before the cycle guard, this enumeration never ends (WaitAsync would time out).
+            // With the guard it yields b, then a, then stops — count == 2.
+            var count = await Task.Run(() => a.GetParents().Count()).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Equal(2, count);
+        }
+        finally
+        {
+            BaseItem.LibraryManager = saved;
+        }
+    }
+
+    [Fact]
+    public async Task GetParents_NonCyclicChain_ReturnsAllAncestors()
+    {
+        var saved = BaseItem.LibraryManager;
+        try
+        {
+            var root = new Video { Id = Guid.NewGuid() };
+            var grand = new Video { Id = Guid.NewGuid(), ParentId = root.Id };
+            var parent = new Video { Id = Guid.NewGuid(), ParentId = grand.Id };
+            var child = new Video { Id = Guid.NewGuid(), ParentId = parent.Id };
+
+            BaseItem.LibraryManager = BuildFakeLibraryManager(root, grand, parent);
+
+            var ancestors = await Task.Run(() => child.GetParents().ToList()).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            // child -> parent -> grand -> root (root.ParentId empty -> stop)
+            Assert.Equal(new[] { parent.Id, grand.Id, root.Id }, ancestors.Select(p => p.Id).ToArray());
+        }
+        finally
+        {
+            BaseItem.LibraryManager = saved;
+        }
+    }
+
+    private static ILibraryManager BuildFakeLibraryManager(params BaseItem[] items)
+    {
+        var lookup = new Dictionary<Guid, BaseItem>();
+        foreach (var item in items)
+        {
+            lookup[item.Id] = item;
+        }
+
+        var mock = new Mock<ILibraryManager>();
+        mock.Setup(x => x.GetItemById(It.IsAny<Guid>()))
+            .Returns((Guid id) => lookup.TryGetValue(id, out var item) ? item : null);
+        return mock.Object;
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -19,6 +19,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("BaseItem static state")]
 public class BaseItemTests
 {
     [Theory]


### PR DESCRIPTION
## What
Fixes a silent freeze of the **Trickplay** (~75%) and **Media Segment Scan** (~95%) scheduled tasks caused by an unguarded cyclic parent/owner chain — same bug class as #7891.

## Root cause
`BaseItem.GetParents()` and `LibraryManager.GetCollectionFolders(BaseItem, IEnumerable<Folder>)` are unguarded ancestor-walk `while` loops. On a cyclic parent/owner chain they never terminate, re-entering `GetParent() → GetItemById → _cache.TryGet` each iteration. A process dump shows a worker spinning forever (Cooperative GC, zero monitors held):

```
BitFaster…ConcurrentLruCore.TryGet ← LibraryManager.GetItemById ← BaseItem.GetParent ← LibraryManager.GetCollectionFolders ← GetLibraryOptions ← TrickplayImagesTask / MediaSegmentExtractionTask
```

Both affected tasks call `_libraryManager.GetLibraryOptions(item)` per item → `GetCollectionFolders`.

**BitFaster is not the cause** — for `FastConcurrentLru<Guid, BaseItem>` (reference-type value), `TryGet` is a lock-free `ConcurrentDictionary.TryGetValue` and cannot spin; the spin is Jellyfin's loop re-entering it.

Symptoms: frozen at a %, no error in logs, no ffmpeg/ffprobe spawned (hangs before the encoder), and the server won't shut down gracefully (hard kill required).

## Fix
Add a `HashSet<Guid>` visited-set (the idiom already used in `BaseItem.GetCustomRatingForComparision`, see #7891) to both loops — break on revisit. This also protects all other ancestor-walk callers (`GetTopParent`, `GetAncestorIds`, `GetInheritedTags`, `IsVisibleStandalone`, etc.).

## Changes
- `MediaBrowser.Controller/Entities/BaseItem.cs` — guard `GetParents()`.
- `Emby.Server.Implementations/Library/LibraryManager.cs` — guard `GetCollectionFolders(BaseItem, IEnumerable<Folder>)`.
- `tests/Jellyfin.Controller.Tests/Entities/BaseItemParentsTests.cs` — cyclic a→b→a graph asserts `GetParents()` terminates (hangs pre-patch); plus a non-cyclic chain returns all ancestors.

## Related
- #7891 — same class; the precedent fix (`callstack` guard in `GetCustomRatingForComparision`).
- #16083 — sibling symptom (scan stuck at 87%, infinite `BaseItem` loop); possibly mis-triaged as a dup of #14386.
- #17180 — nearest symptom relative (frozen at 76%, silent), different cause (DB deadlock).
- Not the ffmpeg-side trickplay hangs #11828 / #17294 / #17494 (those spawn ffmpeg / log errors).
