### PR TITLE
Reduce correlated subqueries and parallelize deserialization on the query hot path

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -283,6 +283,15 @@ public sealed partial class BaseItemRepository
             return ApplySeriesDatePlayedOrder(query, filter, context, orderBy);
         }
 
+        // DatePlayed has the same problem as SeriesDatePlayed: the OrderMapper fallback runs a
+        // correlated MAX(LastPlayedDate) subquery per outer row, which is catastrophic on large
+        // result sets. Pre-aggregate the max played date per item in a single grouped query
+        // and left-join it instead.
+        if (!hasSearch && orderBy.Any(o => o.OrderBy == ItemSortBy.DatePlayed))
+        {
+            return ApplyDatePlayedOrder(query, filter, context, orderBy);
+        }
+
         IOrderedQueryable<BaseItemEntity>? orderedQuery = null;
 
         if (hasSearch)
@@ -373,6 +382,43 @@ public sealed partial class BaseItemRepository
         return seriesSort.SortOrder == SortOrder.Ascending
             ? joined.OrderBy(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item)
             : joined.OrderByDescending(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item);
+    }
+
+    private IQueryable<BaseItemEntity> ApplyDatePlayedOrder(
+        IQueryable<BaseItemEntity> query,
+        InternalItemsQuery filter,
+        JellyfinDbContext context,
+        (ItemSortBy OrderBy, SortOrder SortOrder)[] orderBy)
+    {
+
+        // Pre-aggregate max played date per presentation key in ONE query.
+        // This generates a single: SELECT PresentationUniqueKey, MAX(LastPlayedDate) ... GROUP BY
+        // instead of a correlated subquery per outer row.
+        IQueryable<UserData> userDataQuery = filter.User is not null
+        ? context.UserData.Where(ud => ud.UserId == filter.User.Id)
+        : context.UserData;
+
+        var itemMaxDates = userDataQuery
+        .Join(
+            context.BaseItems,
+            ud => ud.ItemId,
+            bi => bi.Id,
+            (ud, bi) => new { bi.PresentationUniqueKey, ud.LastPlayedDate })
+        .Where(x => x.PresentationUniqueKey != null)
+        .GroupBy(x => x.PresentationUniqueKey)
+        .Select(g => new { ItemKey = g.Key!, MaxDate = g.Max(x => x.LastPlayedDate) });
+
+        var joined = query.LeftJoin(
+            itemMaxDates,
+            e => e.PresentationUniqueKey,
+            s => s.ItemKey,
+            (e, s) => new { Item = e, MaxDate = s != null ? s.MaxDate : (DateTime?)null });
+
+        var dateSort = orderBy.First(o => o.OrderBy == ItemSortBy.DatePlayed);
+
+        return dateSort.SortOrder == SortOrder.Ascending
+        ? joined.OrderBy(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item)
+        : joined.OrderByDescending(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -58,7 +58,7 @@ public sealed partial class BaseItemRepository
         dbQuery = ApplyQueryPaging(dbQuery, filter);
         dbQuery = ApplyNavigations(dbQuery, filter);
 
-        result.Items = dbQuery.AsEnumerable().Where(e => e != null).Select(w => DeserializeBaseItem(w, filter.SkipDeserialization)).Where(dto => dto != null).ToArray()!;
+        result.Items = dbQuery.AsEnumerable().Where(e => e != null).AsParallel().AsOrdered().Select(w => DeserializeBaseItem(w, filter.SkipDeserialization)).Where(dto => dto != null).ToArray()!;
         result.StartIndex = filter.StartIndex ?? 0;
         return result;
     }
@@ -89,6 +89,7 @@ public sealed partial class BaseItemRepository
             var itemsById = ApplyNavigations(context.BaseItems.AsNoTracking().WhereOneOrMany(orderedIds, e => e.Id), filter)
                 .AsSplitQuery()
                 .AsEnumerable()
+                .AsParallel()
                 .Select(w => DeserializeBaseItem(w, filter.SkipDeserialization))
                 .Where(dto => dto != null)
                 .ToDictionary(i => i!.Id);
@@ -98,7 +99,7 @@ public sealed partial class BaseItemRepository
 
         dbQuery = ApplyNavigations(dbQuery, filter);
 
-        return dbQuery.AsEnumerable().Where(e => e != null).Select(w => DeserializeBaseItem(w, filter.SkipDeserialization)).Where(dto => dto != null).ToArray()!;
+        return dbQuery.AsEnumerable().Where(e => e != null).AsParallel().AsOrdered().Select(w => DeserializeBaseItem(w, filter.SkipDeserialization)).Where(dto => dto != null).ToArray()!;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
**Changes**
Two changes to the item query. First, ItemSortBy.DatePlayed fell through to a per-row correlated MAX(LastPlayedDate) subquery, which becomes very expensive on large libraries (e.g. /UserItems/Resume, which sorts by DatePlayed). This adds ApplyDatePlayedOrder, mirroring the existing ApplySeriesDatePlayedOrder pattern: pre-aggregate the max played date per PresentationUniqueKey in one grouped query and LEFT JOIN it, instead of a correlated subquery per outer row ([#17422](https://github.com/jellyfin/jellyfin/issues/17422) made that fallback subquery more index-friendly but didn't remove it for the common non-search case; the search + DatePlayed combination still uses the #17422 path). Second, GetItems and GetItemList now spread the per-row JSON deserialization of BaseItemEntity across CPU cores using PLINQ (AsParallel/AsOrdered) instead of deserializing large result sets on a single thread. AsOrdered preserves the database-issued sort order on the list paths, and the random-sort branch is unaffected since it builds a lookup dictionary afterward.

**Code assistance**
Used Claude to profile the query pipeline, diagnose both bottlenecks, and verify them with before/after timing measurements against a live server.

**Issues**
No issue just general performance improvements
