### PR TITLE
Add ContinueWatching home section type

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Enums/HomeSectionType.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Enums/HomeSectionType.cs
@@ -53,5 +53,10 @@ public enum HomeSectionType
     /// <summary>
     /// Continue Reading.
     /// </summary>
-    ResumeBook = 9
+    ResumeBook = 9,
+
+    /// <summary>
+    /// Continue Watching (combined resume and next up).
+    /// </summary>
+    ContinueWatching = 10
 }


### PR DESCRIPTION
**Changes**
Adds a `ContinueWatching` value to `HomeSectionType` for a combined "Continue Watching" home section that mixes in-progress items and next-up episodes in a single row.

Some background: I proposed this section for the web client in jellyfin-web#8316 and it was closed because home screen sections must be universally supported — the section type is stored server-side and read by all clients. This adds that server-side type, so the section can become a first-class option. I'll follow up with the web implementation in jellyfin-web once this is in.

Right now `DisplayPreferencesController` coerces unknown section strings back to the slot defaults on save, so no client can persist a section the enum doesn't know. With the new value the string round-trips cleanly (verified on my 12.0-rc3 instance: saving `continuewatching` survives, invalid strings still get coerced). No DB migration is needed since the type is stored as an integer, and the OpenAPI surface doesn't change because sections travel as plain strings in `CustomPrefs`.

This also picks up an old thread: the combined row was requested in [features.jellyfin.org/posts/1055](https://features.jellyfin.org/posts/1055/give-the-option-to-combine-next-up-and-continue-watching), and #10200 added `enableResumable` as groundwork for exactly this section type — the plan stalled back then because next up alone can't include movies. The web implementation I'll submit solves that by combining the resume query (movies + episodes) with next up (`enableResumable=false`) and deduplicating, which is also what Emby and third-party Jellyfin clients like Plezy ship today.

Happy to rename the value (e.g. `ResumeCombined`) if `ContinueWatching` is too close to the existing `Resume` doc label.

**Code assistance**
Used an LLM to trace how DisplayPreferencesController handles the section strings and to help verify the round-trip behaviour on my own server. The change itself is one enum value; reviewed and tested by me.

**Issues**
N/A
