### PR TITLE
Store date-only metadata as midnight UTC instead of server-local time

### DIFF
--- a/MediaBrowser.Providers/Extensions/DateTimeExtensions.cs
+++ b/MediaBrowser.Providers/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace MediaBrowser.Providers.Extensions;
+
+/// <summary>
+/// Extensions for normalizing dates returned by metadata providers.
+/// </summary>
+internal static class DateTimeExtensions
+{
+    /// <summary>
+    /// Anchors a date-only metadata value to midnight UTC.
+    /// </summary>
+    /// <param name="value">The date reported by the provider.</param>
+    /// <returns>The same calendar date, with <see cref="DateTimeKind.Utc"/>.</returns>
+    public static DateTime AsCalendarDate(this DateTime value)
+    {
+        return DateTime.SpecifyKind(value, DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    /// Anchors an optional date-only metadata value to midnight UTC.
+    /// </summary>
+    /// <param name="value">The date reported by the provider, if any.</param>
+    /// <returns>The same calendar date with <see cref="DateTimeKind.Utc"/>, or <c>null</c>.</returns>
+    public static DateTime? AsCalendarDate(this DateTime? value)
+    {
+        return value.HasValue ? value.Value.AsCalendarDate() : null;
+    }
+}

--- a/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
+++ b/MediaBrowser.Providers/MediaInfo/AudioFileProber.cs
@@ -20,6 +20,7 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Extensions;
 using MediaBrowser.Model.MediaInfo;
+using MediaBrowser.Providers.Extensions;
 using Microsoft.Extensions.Logging;
 using static Jellyfin.Extensions.StringExtensions;
 
@@ -387,7 +388,7 @@ namespace MediaBrowser.Providers.MediaInfo
 
             if (track.Date.HasValue)
             {
-                audio.PremiereDate = track.Date;
+                audio.PremiereDate = track.Date.AsCalendarDate();
             }
 
             if (trackYear.HasValue)
@@ -400,7 +401,7 @@ namespace MediaBrowser.Providers.MediaInfo
                 {
                     try
                     {
-                        audio.PremiereDate = new DateTime(year, 01, 01);
+                        audio.PremiereDate = new DateTime(year, 01, 01, 0, 0, 0, DateTimeKind.Utc);
                     }
                     catch (ArgumentOutOfRangeException ex)
                     {

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzAlbumProvider.cs
@@ -10,6 +10,7 @@ using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Extensions;
 using MediaBrowser.Providers.Music;
 using MetaBrainz.MusicBrainz;
 using MetaBrainz.MusicBrainz.Interfaces.Entities;
@@ -113,7 +114,7 @@ public class MusicBrainzAlbumProvider : IRemoteMetadataProvider<MusicAlbum, Albu
         {
             Name = releaseSearchResult.Title,
             ProductionYear = releaseSearchResult.Date?.Year,
-            PremiereDate = releaseSearchResult.Date?.NearestDate,
+            PremiereDate = releaseSearchResult.Date?.NearestDate.AsCalendarDate(),
             SearchProviderName = Name
         };
 
@@ -256,7 +257,7 @@ public class MusicBrainzAlbumProvider : IRemoteMetadataProvider<MusicAlbum, Albu
         var date = releaseGroup?.FirstReleaseDate ?? release?.Date;
         if (date is not null)
         {
-            item.PremiereDate = date.NearestDate;
+            item.PremiereDate = date.NearestDate.AsCalendarDate();
             item.ProductionYear = date.Year;
         }
 

--- a/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
+++ b/MediaBrowser.Providers/Plugins/MusicBrainz/MusicBrainzArtistProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Extensions;
 using MediaBrowser.Providers.Music;
 using MetaBrainz.MusicBrainz;
 using MetaBrainz.MusicBrainz.Interfaces.Entities;
@@ -85,7 +86,7 @@ public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, Ar
         {
             Name = artist.Name,
             ProductionYear = artist.LifeSpan?.Begin?.Year,
-            PremiereDate = artist.LifeSpan?.Begin?.NearestDate,
+            PremiereDate = artist.LifeSpan?.Begin?.NearestDate.AsCalendarDate(),
             SearchProviderName = Name,
         };
 
@@ -131,13 +132,13 @@ public class MusicBrainzArtistProvider : IRemoteMetadataProvider<MusicArtist, Ar
 
         if (artist.LifeSpan?.Begin is not null)
         {
-            result.Item.PremiereDate = artist.LifeSpan.Begin.NearestDate;
+            result.Item.PremiereDate = artist.LifeSpan.Begin.NearestDate.AsCalendarDate();
             result.Item.ProductionYear = artist.LifeSpan.Begin.Year;
         }
 
         if (artist.LifeSpan?.End is not null)
         {
-            result.Item.EndDate = artist.LifeSpan.End.NearestDate;
+            result.Item.EndDate = artist.LifeSpan.End.NearestDate.AsCalendarDate();
         }
 
         var location = string.IsNullOrWhiteSpace(artist.Area?.Name) ? artist.Country : artist.Area!.Name;

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Extensions;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.People
 {
@@ -120,8 +121,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
                     Name = info.Name,
                     HomePageUrl = person.Homepage,
                     Overview = person.Biography,
-                    PremiereDate = person.Birthday?.ToUniversalTime(),
-                    EndDate = person.Deathday?.ToUniversalTime()
+                    PremiereDate = person.Birthday.AsCalendarDate(),
+                    EndDate = person.Deathday.AsCalendarDate()
                 };
 
                 if (!string.IsNullOrWhiteSpace(person.PlaceOfBirth))

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using MediaBrowser.Providers.Extensions;
 using TMDbLib.Objects.TvShows;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV
@@ -181,9 +182,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 ParentIndexNumber = seasonNumber,
                 IndexNumberEnd = info.IndexNumberEnd,
                 Name = episodeResult.Name,
-                PremiereDate = episodeResult.AirDate.HasValue
-                    ? DateTime.SpecifyKind(episodeResult.AirDate.Value, DateTimeKind.Local).ToUniversalTime()
-                    : null,
+                PremiereDate = episodeResult.AirDate.AsCalendarDate(),
                 ProductionYear = episodeResult.AirDate?.Year,
                 Overview = episodeResult.Overview,
                 CommunityRating = Convert.ToSingle(episodeResult.VoteAverage)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbMissingEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbMissingEpisodeProvider.cs
@@ -10,6 +10,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
+using MediaBrowser.Providers.Extensions;
 using Microsoft.Extensions.Logging;
 using TMDbLib.Objects.Search;
 
@@ -543,9 +544,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
         internal static DateTime? GetPremiereDate(TvSeasonEpisode tmdbEpisode)
         {
-            return tmdbEpisode.AirDate.HasValue
-                ? DateTime.SpecifyKind(tmdbEpisode.AirDate.Value, DateTimeKind.Local).ToUniversalTime()
-                : null;
+            return tmdbEpisode.AirDate.AsCalendarDate();
         }
 
         internal static bool UpdateVirtualEpisode(Episode episode, TvSeasonEpisode tmdbEpisode, DateTime? premiereDate)

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbMissingEpisodeProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbMissingEpisodeProviderTests.cs
@@ -125,7 +125,7 @@ public class TmdbMissingEpisodeProviderTests
     }
 
     [Fact]
-    public void GetPremiereDate_AirDate_ReturnsUtc()
+    public void GetPremiereDate_AirDate_ReturnsUtcMidnightOnSameCalendarDay()
     {
         var airDate = new DateTime(2026, 7, 28);
 
@@ -133,7 +133,10 @@ public class TmdbMissingEpisodeProviderTests
 
         Assert.NotNull(result);
         Assert.Equal(DateTimeKind.Utc, result!.Value.Kind);
-        Assert.Equal(DateTime.SpecifyKind(airDate, DateTimeKind.Local).ToUniversalTime(), result.Value);
+
+        // The calendar day must survive regardless of the server's timezone, otherwise clients that read
+        // the date components straight off the wire render the air date a day early or late.
+        Assert.Equal(new DateTime(2026, 7, 28, 0, 0, 0, DateTimeKind.Utc), result.Value);
     }
 
     [Fact]
@@ -172,7 +175,7 @@ public class TmdbMissingEpisodeProviderTests
     {
         var episode = new Episode { Name = "X", PremiereDate = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc) };
         var newAirDate = new DateTime(2026, 8, 15);
-        var newPremiere = DateTime.SpecifyKind(newAirDate, DateTimeKind.Local).ToUniversalTime();
+        var newPremiere = DateTime.SpecifyKind(newAirDate, DateTimeKind.Utc);
         var tmdbEpisode = new TvSeasonEpisode { Name = "X", AirDate = newAirDate };
 
         Assert.True(TmdbMissingEpisodeProvider.UpdateVirtualEpisode(episode, tmdbEpisode, newPremiere));


### PR DESCRIPTION
**Changes**
Air dates, release dates and birth/death dates are calendar dates, but several metadata providers anchored them to the server's timezone, either via `SpecifyKind(Local).ToUniversalTime()` or by leaving `Kind` as `Unspecified`, which the SQLite `DateTimeKindValueConverter` then converts as local on save. On a `UTC+2` server an episode airing `2026-08-02` was stored as `2026-08-01 22:00:00Z`, so clients that read the date components off the wire rendered it a day early (and the offset shifted again with DST).
This PR adds `AsCalendarDate()` and applies it in the included providers, matching what the NFO parser already does via `AssumeUniversal | AdjustToUniversal`. Existing rows are corrected on the next metadata refresh.

**Code assistance**
Claude Opus 5 was used for tracing the issue across providers once I found the initial culprit.

**Issues**
