### PR TITLE
Clear metadata provider cache when provider parts are registered

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -163,6 +163,8 @@ namespace MediaBrowser.Providers.Manager
             _externalUrlProviders = externalUrlProviders.OrderBy(i => i.Name).ToArray();
 
             _savers = metadataSavers.ToArray();
+
+            ClearMetadataProviderCache();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**Changes**

`AddParts` replaces `_metadataProviders` but never invalidated `_metadataProviderCache`, so a second call would keep serving provider arrays from the previous registration. `ClearMetadataProviderCache()` was added for this but had no callers. This calls it at the end of `AddParts`. Not a problem during normal startup, where `AddParts` runs once before anything populates the cache, but nothing enforces that single-call assumption.

**Code assistance**

No.

**Issues**

N/A
