### PR TITLE
Fix database lock contentions

### DIFF
--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -134,6 +134,9 @@ public static class ServiceCollectionExtensions
             case DatabaseLockingBehaviorTypes.Optimistic:
                 serviceCollection.AddSingleton<IEntityFrameworkCoreLockingBehavior, OptimisticLockBehavior>();
                 break;
+            case DatabaseLockingBehaviorTypes.SerializedWrites:
+                serviceCollection.AddSingleton<IEntityFrameworkCoreLockingBehavior, SerializedWriteLockBehavior>();
+                break;
         }
 
         serviceCollection.AddPooledDbContextFactory<JellyfinDbContext>((serviceProvider, opt) =>

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -259,6 +259,16 @@ public class ItemPersistenceService : IItemPersistenceService
         var ids = tuples.Select(f => f.Item.Id).ToArray();
         var existingItems = context.BaseItems.Where(e => ids.Contains(e.Id)).Select(f => f.Id).ToHashSet();
 
+        // Owned rows of updated items are rewritten wholesale, so clear them in one statement per
+        // table rather than three per item.
+        if (existingItems.Count > 0)
+        {
+            var updatedIds = existingItems.ToArray();
+            context.BaseItemProviders.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
+            context.BaseItemImageInfos.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
+            context.BaseItemMetadataFields.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
+        }
+
         foreach (var item in tuples)
         {
             var entity = BaseItemMapper.Map(item.Item, _appHost);
@@ -397,18 +407,6 @@ public class ItemPersistenceService : IItemPersistenceService
 
                 context.AncestorIds.RemoveRange(existingAncestorIds);
             }
-        }
-
-        // Owned rows of updated items are rewritten wholesale. Issued here, immediately before the
-        // first flush, because a DELETE is what takes SQLite's single write lock: everything above
-        // is reads and change tracking, and holding the lock across it would block all other
-        // writers for the duration. Batched rather than per-item to keep this to three statements.
-        if (existingItems.Count > 0)
-        {
-            var updatedIds = existingItems.ToArray();
-            context.BaseItemProviders.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
-            context.BaseItemImageInfos.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
-            context.BaseItemMetadataFields.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
         }
 
         context.SaveChanges();

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -257,14 +257,14 @@ public class ItemPersistenceService : IItemPersistenceService
         using var transaction = context.Database.BeginTransaction();
 
         var ids = tuples.Select(f => f.Item.Id).ToArray();
-        var existingItems = context.BaseItems.Where(e => ids.Contains(e.Id)).Select(f => f.Id).ToArray();
+        var existingItems = context.BaseItems.Where(e => ids.Contains(e.Id)).Select(f => f.Id).ToHashSet();
 
         foreach (var item in tuples)
         {
             var entity = BaseItemMapper.Map(item.Item, _appHost);
             entity.TopParentId = item.TopParent?.Id;
 
-            if (!existingItems.Any(e => e == entity.Id))
+            if (!existingItems.Contains(entity.Id))
             {
                 context.BaseItems.Add(entity);
             }

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -270,10 +270,6 @@ public class ItemPersistenceService : IItemPersistenceService
             }
             else
             {
-                context.BaseItemProviders.Where(e => e.ItemId == entity.Id).ExecuteDelete();
-                context.BaseItemImageInfos.Where(e => e.ItemId == entity.Id).ExecuteDelete();
-                context.BaseItemMetadataFields.Where(e => e.ItemId == entity.Id).ExecuteDelete();
-
                 if (entity.Images is { Count: > 0 })
                 {
                     context.BaseItemImageInfos.AddRange(entity.Images);
@@ -401,6 +397,18 @@ public class ItemPersistenceService : IItemPersistenceService
 
                 context.AncestorIds.RemoveRange(existingAncestorIds);
             }
+        }
+
+        // Owned rows of updated items are rewritten wholesale. Issued here, immediately before the
+        // first flush, because a DELETE is what takes SQLite's single write lock: everything above
+        // is reads and change tracking, and holding the lock across it would block all other
+        // writers for the duration. Batched rather than per-item to keep this to three statements.
+        if (existingItems.Count > 0)
+        {
+            var updatedIds = existingItems.ToArray();
+            context.BaseItemProviders.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
+            context.BaseItemImageInfos.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
+            context.BaseItemMetadataFields.WhereOneOrMany(updatedIds, e => e.ItemId).ExecuteDelete();
         }
 
         context.SaveChanges();

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -259,8 +259,7 @@ public class ItemPersistenceService : IItemPersistenceService
         var ids = tuples.Select(f => f.Item.Id).ToArray();
         var existingItems = context.BaseItems.Where(e => ids.Contains(e.Id)).Select(f => f.Id).ToHashSet();
 
-        // Owned rows of updated items are rewritten wholesale, so clear them in one statement per
-        // table rather than three per item.
+        // Owned rows of updated items are rewritten wholesale; cleared in one statement per table.
         if (existingItems.Count > 0)
         {
             var updatedIds = existingItems.ToArray();

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -314,9 +314,11 @@ public class ItemPersistenceService : IItemPersistenceService
         }).ToArray();
         context.ItemValues.AddRange(missingItemValues);
 
-        var itemValuesStore = existingValues.Concat(missingItemValues).ToArray();
+        var itemValuesStore = existingValues
+            .Concat(missingItemValues)
+            .ToDictionary(e => (e.Type, e.Value));
         var valueMap = itemValueMaps
-            .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore.First(g => g.Value == e.Value && g.Type == e.MagicNumber)).DistinctBy(e => e.ItemValueId).ToArray()))
+            .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore[(e.MagicNumber, e.Value)]).DistinctBy(e => e.ItemValueId).ToArray()))
             .ToArray();
 
         var mappedValues = context.ItemValuesMap.Where(e => ids.Contains(e.ItemId)).ToList();

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -18,7 +18,7 @@ public class DatabaseConfigurationOptions
     public CustomDatabaseOptions? CustomProviderOptions { get; set; }
 
     /// <summary>
-    /// Gets or Sets the kind of locking behavior jellyfin should perform. Possible options are "NoLock", "Pessimistic", "Optimistic".
+    /// Gets or Sets the kind of locking behavior jellyfin should perform. Possible options are "NoLock", "Pessimistic", "Optimistic", "SerializedWrites".
     /// Defaults to "NoLock".
     /// </summary>
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseLockingBehaviorTypes.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseLockingBehaviorTypes.cs
@@ -18,5 +18,11 @@ public enum DatabaseLockingBehaviorTypes
     /// <summary>
     /// Defines that all writes should be attempted and when fail should be retried.
     /// </summary>
-    Optimistic = 2
+    Optimistic = 2,
+
+    /// <summary>
+    /// Defines a behavior that queues writers so only one runs at a time, while leaving reads
+    /// unsynchronized.
+    /// </summary>
+    SerializedWrites = 3
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
@@ -88,13 +88,15 @@ public class OptimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
     /// <inheritdoc/>
     public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
     {
-        _writePolicy.ExecuteAndCapture(saveChanges);
+        // Execute rethrows once retries are exhausted; ExecuteAndCapture would return the failure
+        // as a PolicyResult, making a dropped write look like a successful save.
+        _writePolicy.Execute(saveChanges);
     }
 
     /// <inheritdoc/>
     public async Task OnSaveChangesAsync(JellyfinDbContext context, Func<Task> saveChanges)
     {
-        await _writeAsyncPolicy.ExecuteAndCaptureAsync(saveChanges).ConfigureAwait(false);
+        await _writeAsyncPolicy.ExecuteAsync(saveChanges).ConfigureAwait(false);
     }
 
     private sealed class TransactionLockingInterceptor : DbTransactionInterceptor

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
@@ -88,8 +88,7 @@ public class OptimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
     /// <inheritdoc/>
     public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
     {
-        // Execute rethrows once retries are exhausted; ExecuteAndCapture would return the failure
-        // as a PolicyResult, making a dropped write look like a successful save.
+        // Rethrows once retries are exhausted; a captured failure would surface as a successful save.
         _writePolicy.Execute(saveChanges);
     }
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
@@ -17,6 +17,15 @@ namespace Jellyfin.Database.Implementations.Locking;
 /// <summary>
 /// A locking behavior that will always block any operation while a write is requested. Mimicks the old SqliteRepository behavior.
 /// </summary>
+/// <remarks>
+/// Unsafe with asynchronous transactions; superseded by <see cref="SerializedWriteLockBehavior"/>.
+/// The <see cref="ReaderWriterLockSlim"/> is held from <c>TransactionStarting</c> to
+/// <c>TransactionCommitted</c>, but is thread-affine and cannot be held across an
+/// <see langword="await"/>. This holds only while continuations resume inline, as they do when
+/// Microsoft.Data.Sqlite completes synchronously. Any genuinely-async continuation inside a
+/// transaction releases on a different thread, throwing <see cref="SynchronizationLockException"/>
+/// or deadlocking a later write that cannot re-enter a lock it does not own.
+/// </remarks>
 public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
 {
     private readonly ILogger<PessimisticLockBehavior> _logger;
@@ -47,7 +56,8 @@ public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
     /// <inheritdoc/>
     public void Initialise(DbContextOptionsBuilder optionsBuilder)
     {
-        _logger.LogInformation("The database locking mode has been set to: Pessimistic.");
+        _logger.LogWarning(
+            "The database locking mode has been set to: Pessimistic. This mode is not safe with asynchronous transactions and can deadlock; prefer SerializedWrites.");
         optionsBuilder.AddInterceptors(new CommandLockingInterceptor(_loggerFactory.CreateLogger<CommandLockingInterceptor>()));
         optionsBuilder.AddInterceptors(new TransactionLockingInterceptor(_loggerFactory.CreateLogger<TransactionLockingInterceptor>()));
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/PessimisticLockBehavior.cs
@@ -19,12 +19,10 @@ namespace Jellyfin.Database.Implementations.Locking;
 /// </summary>
 /// <remarks>
 /// Unsafe with asynchronous transactions; superseded by <see cref="SerializedWriteLockBehavior"/>.
-/// The <see cref="ReaderWriterLockSlim"/> is held from <c>TransactionStarting</c> to
-/// <c>TransactionCommitted</c>, but is thread-affine and cannot be held across an
-/// <see langword="await"/>. This holds only while continuations resume inline, as they do when
-/// Microsoft.Data.Sqlite completes synchronously. Any genuinely-async continuation inside a
-/// transaction releases on a different thread, throwing <see cref="SynchronizationLockException"/>
-/// or deadlocking a later write that cannot re-enter a lock it does not own.
+/// <see cref="ReaderWriterLockSlim"/> is thread-affine, so holding it from
+/// <c>TransactionStarting</c> to <c>TransactionCommitted</c> works only while continuations resume
+/// inline. A genuinely-async continuation inside a transaction releases on another thread, throwing
+/// <see cref="SynchronizationLockException"/> or deadlocking a later write.
 /// </remarks>
 public class PessimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
 {

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+/// <summary>
+/// A locking behavior that serializes writers in-process while leaving readers unsynchronized.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQLite permits one writer at a time, so queueing writers in-process lets each take the database
+/// lock uncontended instead of racing for it and generating SQLITE_BUSY retries.
+/// </para>
+/// <para>
+/// Reads are left unsynchronized: in WAL mode they neither block nor are blocked by writers.
+/// </para>
+/// <para>
+/// Uses <see cref="SemaphoreSlim"/> rather than <see cref="ReaderWriterLockSlim"/> so the lock can
+/// be held across an <see langword="await"/>.
+/// </para>
+/// </remarks>
+public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBehavior, IDisposable
+{
+    /// <summary>
+    /// How long to queue for the in-process write lock before giving up and letting SQLite's own
+    /// busy handler arbitrate instead. This is a deadlock backstop, not a normal code path.
+    /// </summary>
+    private static readonly TimeSpan _acquireTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Set for the duration of an operation that owns the write lock. Propagates down into that
+    /// operation's EF internals, making the nested interceptors no-ops.
+    /// </summary>
+    private static readonly AsyncLocal<bool> _holdsWriteLock = new();
+
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    /// <summary>
+    /// The explicit transaction owning the write lock, mapped to the connection it was opened on.
+    /// Keyed by transaction because a transaction's lifetime spans separate async flows, and to make
+    /// releasing idempotent across the several end-of-transaction callbacks EF raises. Holds at most
+    /// one entry, since the semaphore admits one writer.
+    /// </summary>
+    private readonly ConcurrentDictionary<DbTransaction, DbConnection> _lockedTransactions = new();
+
+    private readonly ILogger<SerializedWriteLockBehavior> _logger;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializedWriteLockBehavior"/> class.
+    /// </summary>
+    /// <param name="logger">The application logger.</param>
+    public SerializedWriteLockBehavior(ILogger<SerializedWriteLockBehavior> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public void Initialise(DbContextOptionsBuilder optionsBuilder)
+    {
+        _logger.LogInformation("The database locking mode has been set to: SerializedWrites.");
+        optionsBuilder.AddInterceptors(new WriteSerializingCommandInterceptor(this));
+        optionsBuilder.AddInterceptors(new WriteSerializingTransactionInterceptor(this));
+        optionsBuilder.AddInterceptors(new WriteLockReleasingConnectionInterceptor(this));
+    }
+
+    /// <inheritdoc/>
+    public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
+    {
+        if (AlreadyHoldsLock(context))
+        {
+            saveChanges();
+            return;
+        }
+
+        var acquired = Acquire();
+        _holdsWriteLock.Value = true;
+        try
+        {
+            saveChanges();
+        }
+        finally
+        {
+            _holdsWriteLock.Value = false;
+            Release(acquired);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnSaveChangesAsync(JellyfinDbContext context, Func<Task> saveChanges)
+    {
+        if (AlreadyHoldsLock(context))
+        {
+            await saveChanges().ConfigureAwait(false);
+            return;
+        }
+
+        var acquired = await AcquireAsync(CancellationToken.None).ConfigureAwait(false);
+        _holdsWriteLock.Value = true;
+        try
+        {
+            await saveChanges().ConfigureAwait(false);
+        }
+        finally
+        {
+            _holdsWriteLock.Value = false;
+            Release(acquired);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _writeLock.Dispose();
+    }
+
+    /// <summary>
+    /// Whether an enclosing operation or an explicit transaction on this context holds the lock.
+    /// </summary>
+    private bool AlreadyHoldsLock(JellyfinDbContext context)
+    {
+        if (_holdsWriteLock.Value)
+        {
+            return true;
+        }
+
+        var current = context.Database.CurrentTransaction?.GetDbTransaction();
+        return current is not null && _lockedTransactions.ContainsKey(current);
+    }
+
+    private bool Acquire()
+    {
+        if (_writeLock.Wait(_acquireTimeout))
+        {
+            return true;
+        }
+
+        LogAcquireTimeout();
+        return false;
+    }
+
+    private async ValueTask<bool> AcquireAsync(CancellationToken cancellationToken)
+    {
+        if (await _writeLock.WaitAsync(_acquireTimeout, cancellationToken).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        LogAcquireTimeout();
+        return false;
+    }
+
+    private void LogAcquireTimeout()
+    {
+        _logger.LogWarning(
+            "Timed out after {Timeout}s waiting for the in-process database write lock; proceeding without it. This means some write is holding the lock far too long, or that writes are nested across separate connections.",
+            _acquireTimeout.TotalSeconds);
+    }
+
+    private void Release(bool acquired)
+    {
+        if (acquired)
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private void TrackTransaction(DbTransaction transaction, DbConnection connection)
+    {
+        _lockedTransactions[transaction] = connection;
+    }
+
+    private void ReleaseTransaction(DbTransaction transaction)
+    {
+        if (_lockedTransactions.TryRemove(transaction, out _))
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Releases a lock still attributed to a transaction on a connection being closed.
+    /// EF disposes the underlying transaction directly, without raising a commit, rollback or
+    /// failure callback, so a transaction abandoned by an exception has no other release point.
+    /// </summary>
+    private void ReleaseTransactionsOn(DbConnection connection)
+    {
+        foreach (var (transaction, owner) in _lockedTransactions)
+        {
+            if (ReferenceEquals(owner, connection))
+            {
+                ReleaseTransaction(transaction);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serializes writes issued outside <c>SaveChanges</c> and outside an explicit transaction:
+    /// ExecuteDelete, ExecuteUpdate, raw SQL and migrations. All execute as non-queries; reads pass
+    /// straight through.
+    /// </summary>
+    private sealed class WriteSerializingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteSerializingCommandInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            if (!NeedsLock(command, eventData))
+            {
+                return base.NonQueryExecuting(command, eventData, result);
+            }
+
+            var acquired = _owner.Acquire();
+            try
+            {
+                return InterceptionResult<int>.SuppressWithResult(command.ExecuteNonQuery());
+            }
+            finally
+            {
+                _owner.Release(acquired);
+            }
+        }
+
+        public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            if (!NeedsLock(command, eventData))
+            {
+                return await base.NonQueryExecutingAsync(command, eventData, result, cancellationToken).ConfigureAwait(false);
+            }
+
+            var acquired = await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return InterceptionResult<int>.SuppressWithResult(await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false));
+            }
+            finally
+            {
+                _owner.Release(acquired);
+            }
+        }
+
+        private bool NeedsLock(DbCommand command, CommandEventData eventData)
+        {
+            if (!IsWrite(eventData.CommandSource))
+            {
+                return false;
+            }
+
+            // The semaphore is not reentrant; taking it again under an owning operation deadlocks.
+            if (_holdsWriteLock.Value)
+            {
+                return false;
+            }
+
+            return command.Transaction is null || !_owner._lockedTransactions.ContainsKey(command.Transaction);
+        }
+
+        private static bool IsWrite(CommandSource source) => source switch
+        {
+            CommandSource.SaveChanges => true,
+            CommandSource.Migrations => true,
+            CommandSource.ExecuteSqlRaw => true,
+            CommandSource.ExecuteUpdate => true,
+            CommandSource.ExecuteDelete => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Holds the write lock for the lifetime of an explicit transaction. Acquires on
+    /// <c>TransactionStarted</c>, where the transaction object exists, so the lock is never held
+    /// without a key to release it by.
+    /// </summary>
+    private sealed class WriteSerializingTransactionInterceptor : DbTransactionInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteSerializingTransactionInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override DbTransaction TransactionStarted(DbConnection connection, TransactionEndEventData eventData, DbTransaction result)
+        {
+            if (!_holdsWriteLock.Value && _owner.Acquire())
+            {
+                _owner.TrackTransaction(result, connection);
+            }
+
+            return base.TransactionStarted(connection, eventData, result);
+        }
+
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(DbConnection connection, TransactionEndEventData eventData, DbTransaction result, CancellationToken cancellationToken = default)
+        {
+            if (!_holdsWriteLock.Value && await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false))
+            {
+                _owner.TrackTransaction(result, connection);
+            }
+
+            return await base.TransactionStartedAsync(connection, eventData, result, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void TransactionCommitted(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionCommitted(transaction, eventData);
+        }
+
+        public override Task TransactionCommittedAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionCommittedAsync(transaction, eventData, cancellationToken);
+        }
+
+        public override void TransactionRolledBack(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionRolledBack(transaction, eventData);
+        }
+
+        public override Task TransactionRolledBackAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionRolledBackAsync(transaction, eventData, cancellationToken);
+        }
+
+        public override void TransactionFailed(DbTransaction transaction, TransactionErrorEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionFailed(transaction, eventData);
+        }
+
+        public override Task TransactionFailedAsync(DbTransaction transaction, TransactionErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionFailedAsync(transaction, eventData, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Backstop release for transactions abandoned without a commit or rollback callback.
+    /// </summary>
+    private sealed class WriteLockReleasingConnectionInterceptor : DbConnectionInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteLockReleasingConnectionInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override void ConnectionClosed(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            _owner.ReleaseTransactionsOn(connection);
+            base.ConnectionClosed(connection, eventData);
+        }
+
+        public override Task ConnectionClosedAsync(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            _owner.ReleaseTransactionsOn(connection);
+            return base.ConnectionClosedAsync(connection, eventData);
+        }
+    }
+}

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
@@ -15,24 +15,30 @@ namespace Jellyfin.Database.Implementations.Locking;
 /// </summary>
 /// <remarks>
 /// <para>
-/// SQLite permits one writer at a time, so queueing writers in-process lets each take the database
-/// lock uncontended instead of racing for it and generating SQLITE_BUSY retries.
+/// SQLite permits one writer at a time; queueing them in-process lets each take the database lock
+/// uncontended instead of racing for it and generating SQLITE_BUSY retries.
 /// </para>
 /// <para>
-/// Reads are left unsynchronized: in WAL mode they neither block nor are blocked by writers.
+/// Reads are unsynchronized: in WAL mode they neither block nor are blocked by writers.
 /// </para>
 /// <para>
-/// Uses <see cref="SemaphoreSlim"/> rather than <see cref="ReaderWriterLockSlim"/> so the lock can
-/// be held across an <see langword="await"/>.
+/// Held via <see cref="SemaphoreSlim"/> so it survives an <see langword="await"/>.
+/// </para>
+/// <para>
+/// The permit spans an explicit transaction's whole lifetime, matching SQLite: Microsoft.Data.Sqlite
+/// issues BEGIN IMMEDIATE for every isolation level except ReadUncommitted, so the database write
+/// lock is held from BEGIN to commit.
 /// </para>
 /// </remarks>
 public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBehavior, IDisposable
 {
     /// <summary>
-    /// How long to queue for the in-process write lock before giving up and letting SQLite's own
-    /// busy handler arbitrate instead. This is a deadlock backstop, not a normal code path.
+    /// How long to queue for the permit before proceeding without it and leaving busy_timeout to
+    /// arbitrate. Reached whenever the holder is slow, not just on nested writes: a write that
+    /// stalls for its full CommandTimeout holds the permit for that whole time, so every queued
+    /// writer times out and then hits the database unsynchronized.
     /// </summary>
-    private static readonly TimeSpan _acquireTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan _acquireTimeout = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Set while this instance owns the permit. Propagates into the guarded call's EF internals so
@@ -43,10 +49,9 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
     /// <summary>
-    /// The explicit transaction owning the write lock, mapped to the connection it was opened on.
-    /// Keyed by transaction because a transaction's lifetime spans separate async flows, and to make
-    /// releasing idempotent across the several end-of-transaction callbacks EF raises. Holds at most
-    /// one entry, since the semaphore admits one writer.
+    /// Explicit transactions owning the permit, mapped to their connection. Keyed by transaction
+    /// because its lifetime spans async flows; removal doubles as the release guard against the
+    /// several end-of-transaction callbacks EF raises. Holds at most one entry.
     /// </summary>
     private readonly ConcurrentDictionary<DbTransaction, DbConnection> _lockedTransactions = new();
 
@@ -192,9 +197,9 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
     }
 
     /// <summary>
-    /// Releases a lock still attributed to a transaction on a connection being closed.
-    /// EF disposes the underlying transaction directly, without raising a commit, rollback or
-    /// failure callback, so a transaction abandoned by an exception has no other release point.
+    /// Releases a permit still held by a transaction on a closing connection. EF disposes the
+    /// underlying transaction without a commit, rollback or failure callback, leaving this the only
+    /// release point for a transaction abandoned by an exception.
     /// </summary>
     private void ReleaseTransactionsOn(DbConnection connection)
     {
@@ -209,8 +214,8 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
 
     /// <summary>
     /// Serializes writes issued outside <c>SaveChanges</c> and outside an explicit transaction:
-    /// ExecuteDelete, ExecuteUpdate, raw SQL and migrations. All execute as non-queries; reads pass
-    /// straight through.
+    /// ExecuteDelete, ExecuteUpdate, raw SQL and migrations, all of which execute as non-queries.
+    /// Reads pass through.
     /// </summary>
     private sealed class WriteSerializingCommandInterceptor : DbCommandInterceptor
     {
@@ -285,9 +290,8 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
     }
 
     /// <summary>
-    /// Holds the write lock for the lifetime of an explicit transaction. Acquires on
-    /// <c>TransactionStarted</c>, where the transaction object exists, so the lock is never held
-    /// without a key to release it by.
+    /// Holds the permit for an explicit transaction's lifetime. Acquires on
+    /// <c>TransactionStarted</c>, where the transaction object exists to key the release on.
     /// </summary>
     private sealed class WriteSerializingTransactionInterceptor : DbTransactionInterceptor
     {

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
@@ -35,10 +35,10 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
     private static readonly TimeSpan _acquireTimeout = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// Set for the duration of an operation that owns the write lock. Propagates down into that
-    /// operation's EF internals, making the nested interceptors no-ops.
+    /// Set while this instance owns the permit. Propagates into the guarded call's EF internals so
+    /// the nested interceptors skip re-acquiring.
     /// </summary>
-    private static readonly AsyncLocal<bool> _holdsWriteLock = new();
+    private readonly AsyncLocal<bool> _holdsWriteLock = new();
 
     private readonly SemaphoreSlim _writeLock = new(1, 1);
 
@@ -265,7 +265,7 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
             }
 
             // The semaphore is not reentrant; taking it again under an owning operation deadlocks.
-            if (_holdsWriteLock.Value)
+            if (_owner._holdsWriteLock.Value)
             {
                 return false;
             }
@@ -300,7 +300,7 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
 
         public override DbTransaction TransactionStarted(DbConnection connection, TransactionEndEventData eventData, DbTransaction result)
         {
-            if (!_holdsWriteLock.Value && _owner.Acquire())
+            if (!_owner._holdsWriteLock.Value && _owner.Acquire())
             {
                 _owner.TrackTransaction(result, connection);
             }
@@ -310,7 +310,7 @@ public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBeh
 
         public override async ValueTask<DbTransaction> TransactionStartedAsync(DbConnection connection, TransactionEndEventData eventData, DbTransaction result, CancellationToken cancellationToken = default)
         {
-            if (!_holdsWriteLock.Value && await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false))
+            if (!_owner._holdsWriteLock.Value && await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false))
             {
                 _owner.TrackTransaction(result, connection);
             }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -84,8 +84,8 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     {
         var sb = new StringBuilder();
 
-        // First, so the remaining pragmas are covered by it. SQLite defaults to 0, which makes any
-        // lock conflict fall through to Microsoft.Data.Sqlite's 150ms poll until CommandTimeout.
+        // First, so the remaining pragmas are covered. SQLite defaults to 0, dropping lock conflicts
+        // through to Microsoft.Data.Sqlite's 150ms poll until CommandTimeout.
         if (_busyTimeout > 0)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"PRAGMA busy_timeout={_busyTimeout};");

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -20,6 +20,7 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private readonly int? _journalSizeLimit;
     private readonly int _tempStoreMode;
     private readonly int _syncMode;
+    private readonly int _busyTimeout;
     private readonly IDictionary<string, string> _customPragma;
 
     /// <summary>
@@ -31,8 +32,9 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     /// <param name="journalSizeLimit">Journal Size.</param>
     /// <param name="tempStoreMode">The https://sqlite.org/pragma.html#pragma_temp_store pragma.</param>
     /// <param name="syncMode">The https://sqlite.org/pragma.html#pragma_synchronous pragma.</param>
+    /// <param name="busyTimeout">The https://sqlite.org/pragma.html#pragma_busy_timeout pragma, in milliseconds.</param>
     /// <param name="customPragma">A list of custom provided Pragma in the list of CustomOptions starting with "#PRAGMA:".</param>
-    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, IDictionary<string, string> customPragma)
+    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, int busyTimeout, IDictionary<string, string> customPragma)
     {
         _logger = logger;
         _cacheSize = cacheSize;
@@ -40,6 +42,7 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         _journalSizeLimit = journalSizeLimit;
         _tempStoreMode = tempStoreMode;
         _syncMode = syncMode;
+        _busyTimeout = busyTimeout;
         _customPragma = customPragma;
 
         InitialCommand = BuildCommandText();
@@ -80,6 +83,14 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private string BuildCommandText()
     {
         var sb = new StringBuilder();
+
+        // First, so the remaining pragmas are covered by it. SQLite defaults to 0, which makes any
+        // lock conflict fall through to Microsoft.Data.Sqlite's 150ms poll until CommandTimeout.
+        if (_busyTimeout > 0)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"PRAGMA busy_timeout={_busyTimeout};");
+        }
+
         if (_cacheSize.HasValue)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"PRAGMA cache_size={_cacheSize.Value};");

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -32,7 +32,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     /// Outer bound on the driver's lock-wait fallback, in seconds. Kept above
     /// <see cref="DefaultBusyTimeoutMs"/> so SQLite's busy handler does the waiting.
     /// </summary>
-    private const int DefaultCommandTimeoutSeconds = 30;
+    private const int DefaultCommandTimeoutSeconds = 60;
 
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -77,7 +77,12 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
             DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
-            Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Default),
+
+            // Private, not Default: sqlite3_enable_shared_cache is process-global, so a plugin
+            // enabling it makes these connections share a cache too. Contention then surfaces as
+            // SQLITE_LOCKED ("database table is locked"), which the busy handler does not cover,
+            // so busy_timeout is skipped and the command fails at CommandTimeout instead.
+            Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Private),
             Pooling = GetOption(customOptions, "pooling", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => true),
 
             // Bounds only the driver's lock-wait poll, not the runtime of an executing query.

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -22,6 +22,18 @@ namespace Jellyfin.Database.Providers.Sqlite;
 public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 {
     private const string BackupFolderName = "SQLiteBackups";
+
+    /// <summary>
+    /// Time SQLite waits on a locked database before returning SQLITE_BUSY, in milliseconds.
+    /// </summary>
+    private const int DefaultBusyTimeoutMs = 10_000;
+
+    /// <summary>
+    /// Outer bound on the driver's lock-wait fallback, in seconds. Kept above
+    /// <see cref="DefaultBusyTimeoutMs"/> so SQLite's busy handler does the waiting.
+    /// </summary>
+    private const int DefaultCommandTimeoutSeconds = 30;
+
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;
 
@@ -60,12 +72,16 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         var customOptions = databaseConfiguration.CustomProviderOptions?.Options;
 
+        var busyTimeout = GetOption(customOptions, "busytimeout", int.Parse, () => DefaultBusyTimeoutMs);
+
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
             DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
             Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Default),
             Pooling = GetOption(customOptions, "pooling", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => true),
-            DefaultTimeout = GetOption(customOptions, "command-timeout", int.Parse, () => 60)
+
+            // Bounds only the driver's lock-wait poll, not the runtime of an executing query.
+            DefaultTimeout = GetOption(customOptions, "command-timeout", int.Parse, () => DefaultCommandTimeoutSeconds)
         };
 
         var connectionString = sqliteConnectionBuilder.ToString();
@@ -88,6 +104,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                 GetOption(customOptions, "journalsizelimit", int.Parse, () => 134_217_728),
                 GetOption(customOptions, "tempstoremode", int.Parse, () => 2),
                 GetOption(customOptions, "syncmode", int.Parse, () => 1),
+                busyTimeout,
                 customOptions?.Where(e => e.Key.StartsWith("#PRAGMA:", StringComparison.OrdinalIgnoreCase)).ToDictionary(e => e.Key["#PRAGMA:".Length..], e => e.Value) ?? []));
 
         var enableSensitiveDataLogging = GetOption(customOptions, "EnableSensitiveDataLogging", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => false);

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
@@ -6,6 +6,7 @@ using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Locking;
 using Jellyfin.Database.Providers.Sqlite;
 using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -25,9 +26,14 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
     private readonly ItemPersistenceService _service;
+    private readonly IApplicationPaths _applicationPaths;
+    private readonly ILibraryManager? _previousLibraryManager;
+    private readonly IServerConfigurationManager? _previousConfigurationManager;
 
     public ItemPersistenceOwnedRowTests()
     {
+        _applicationPaths = new Mock<IApplicationPaths>().Object;
+
         _connection = new SqliteConnection("Data Source=:memory:");
         _connection.Open();
 
@@ -39,6 +45,11 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
         {
             ctx.Database.EnsureCreated();
         }
+
+        // BaseItem resolves these through process-wide statics, so capture whatever is already
+        // installed and put it back in Dispose rather than leaving the mocks behind for other tests.
+        _previousLibraryManager = BaseItem.LibraryManager;
+        _previousConfigurationManager = BaseItem.ConfigurationManager;
 
         var libraryManager = new Mock<ILibraryManager>();
         libraryManager.Setup(l => l.GetCollectionFolders(It.IsAny<BaseItem>()))
@@ -58,7 +69,12 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
             NullLogger<ItemPersistenceService>.Instance);
     }
 
-    public void Dispose() => _connection.Dispose();
+    public void Dispose()
+    {
+        BaseItem.LibraryManager = _previousLibraryManager!;
+        BaseItem.ConfigurationManager = _previousConfigurationManager!;
+        _connection.Dispose();
+    }
 
     [Fact]
     public void SaveItems_UpdateExistingItem_ReplacesOwnedRows()
@@ -130,6 +146,6 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
     private JellyfinDbContext CreateDbContext() => new(
         _dbOptions,
         NullLogger<JellyfinDbContext>.Instance,
-        new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+        new SqliteDatabaseProvider(_applicationPaths, NullLogger<SqliteDatabaseProvider>.Instance),
         new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
@@ -46,8 +46,7 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
             ctx.Database.EnsureCreated();
         }
 
-        // BaseItem resolves these through process-wide statics, so capture whatever is already
-        // installed and put it back in Dispose rather than leaving the mocks behind for other tests.
+        // BaseItem resolves these through process-wide statics; restored in Dispose.
         _previousLibraryManager = BaseItem.LibraryManager;
         _previousConfigurationManager = BaseItem.ConfigurationManager;
 
@@ -92,8 +91,7 @@ public sealed class ItemPersistenceOwnedRowTests : IDisposable
             Assert.Equal(1, ctx.BaseItemMetadataFields.Count(e => e.ItemId.Equals(id)));
         }
 
-        // Re-save the same, already-existing item with different owned rows: the update path
-        // rewrites all three child tables wholesale rather than merging.
+        // Re-save with different owned rows: the update path rewrites all three tables wholesale.
         _service.SaveItems(
             [CreateBook(id, new() { ["Imdb"] = "tt9999" }, [MetadataField.Name, MetadataField.Genres])],
             CancellationToken.None);

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceOwnedRowTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class ItemPersistenceOwnedRowTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly ItemPersistenceService _service;
+
+    public ItemPersistenceOwnedRowTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(l => l.GetCollectionFolders(It.IsAny<BaseItem>()))
+            .Returns([]);
+        BaseItem.LibraryManager = libraryManager.Object;
+
+        var configurationManager = new Mock<IServerConfigurationManager>();
+        configurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        BaseItem.ConfigurationManager = configurationManager.Object;
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+        _service = new ItemPersistenceService(
+            factory.Object,
+            new Mock<IServerApplicationHost>().Object,
+            NullLogger<ItemPersistenceService>.Instance);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public void SaveItems_UpdateExistingItem_ReplacesOwnedRows()
+    {
+        var id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+        _service.SaveItems(
+            [CreateBook(id, new() { ["Imdb"] = "tt0001", ["Tmdb"] = "555" }, [MetadataField.Name])],
+            CancellationToken.None);
+
+        using (var ctx = CreateDbContext())
+        {
+            Assert.Equal(2, ctx.BaseItemProviders.Count(e => e.ItemId.Equals(id)));
+            Assert.Equal(1, ctx.BaseItemImageInfos.Count(e => e.ItemId.Equals(id)));
+            Assert.Equal(1, ctx.BaseItemMetadataFields.Count(e => e.ItemId.Equals(id)));
+        }
+
+        // Re-save the same, already-existing item with different owned rows: the update path
+        // rewrites all three child tables wholesale rather than merging.
+        _service.SaveItems(
+            [CreateBook(id, new() { ["Imdb"] = "tt9999" }, [MetadataField.Name, MetadataField.Genres])],
+            CancellationToken.None);
+
+        using (var ctx = CreateDbContext())
+        {
+            var providers = ctx.BaseItemProviders.Where(e => e.ItemId.Equals(id)).ToList();
+            Assert.Equal("tt9999", Assert.Single(providers).ProviderValue);
+
+            Assert.Equal(1, ctx.BaseItemImageInfos.Count(e => e.ItemId.Equals(id)));
+            Assert.Equal(2, ctx.BaseItemMetadataFields.Count(e => e.ItemId.Equals(id)));
+        }
+    }
+
+    [Fact]
+    public void SaveItems_MixedNewAndExistingBatch_ReplacesOnlyExistingOwnedRows()
+    {
+        var existing = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        var fresh = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+
+        _service.SaveItems([CreateBook(existing, new() { ["Imdb"] = "tt0001" }, [])], CancellationToken.None);
+
+        // One already-persisted item and one brand new item in the same batch.
+        _service.SaveItems(
+            [
+                CreateBook(existing, new() { ["Imdb"] = "tt0002" }, []),
+                CreateBook(fresh, new() { ["Tmdb"] = "777" }, [])
+            ],
+            CancellationToken.None);
+
+        using var ctx = CreateDbContext();
+        Assert.Equal("tt0002", Assert.Single(ctx.BaseItemProviders.Where(e => e.ItemId.Equals(existing))).ProviderValue);
+        Assert.Equal("777", Assert.Single(ctx.BaseItemProviders.Where(e => e.ItemId.Equals(fresh))).ProviderValue);
+    }
+
+    private static Book CreateBook(Guid id, Dictionary<string, string> providerIds, MetadataField[] lockedFields)
+    {
+        var book = new Book
+        {
+            Id = id,
+            Name = "Book",
+            ProviderIds = providerIds,
+            LockedFields = lockedFields
+        };
+
+        book.SetImage(new ItemImageInfo { Path = "/img/primary.jpg", Type = ImageType.Primary }, 0);
+        return book;
+    }
+
+    private JellyfinDbContext CreateDbContext() => new(
+        _dbOptions,
+        NullLogger<JellyfinDbContext>.Instance,
+        new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+        new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+}


### PR DESCRIPTION
There are frequent database locked errors thrown, or excessively long contention intervals that end up degrading the entire system performance. This is especially prevalent in the Scheduled Activities runs, like rebuilding QuickPlay images or Extracting Attachments.

Issues exist in the SQLite layer, due to the busy_timeout PRAGMA not being sent (so it defaults to 0). This results in the driver immediately returning SQLITE_BUSY instead of spinning a bit internally. Then the SQLite .Net driver just sleeps for 150ms, and tries again and then eventually timing out when CommandTimeout expires (60s). This is compounded by the fact that the thread is stalled in the thread pool for the entire time, so waits just keep stacking up.

Another issue causing database locks is that the UpdateOrInsertItems method does a deletion of the related Provider, Image, and Metadata subitems one-by-one for each existing BaseItem. This is done too early in the method, so the database takes a transaction lock on the very first BaseItem and holds it until ALL the items in the batch are computed and processed. Later the changes are actually saved with a SaveChanges() call, but all the intermediate time should have been done without any form of lock active. The fix here is to do the delete in bulk (for all updated BaseItemIds at once) and do it right before the SaveChanges().

Other minor speed ups can be had by switching to Hashset / Dictionary instead of arrays for the processing in the UpdateOrInsertItems method.

Finally, the various locking modes are actually unsafe as coded. The PessimisticLockBehavior tries to hold locks using ReadWriteLockSlim, which CANNOT be held across await calls. OptimisticLockBehavior uses ExecuteAndCapture/ExecuteAndCaptureAsync, but doesn't actually do anything with the captured exception, so the updates act as if they succeeded and the provider layer spins.

**Changes**

Add support for the `busy_timeout` PRAGMA for SQLite and pass it through the database options. By setting this to 10s (by default), the SQLite library can spin internally and not block the thread-pool. If the command timeout expires then the normal .Net SQLite Provider will kick in, but at that point we've already given the database/connection time to decongest.

Use a HashSet for the existing items in the UpdateOrInsertItems to speed up the processing by doing a Contains instead of an Any() linear search O(n) -> O(log n).

Use a Dictionary for the existing item's values to speed up the processing by doing a dictionary lookup instead of a .First() linear scan O(n) -> O(log n).

Make the deletion of the related items (BaseItemProviders, BaseItemImageInfos, BaseItemMetadataFields) to just before the save to hold the lock for far less time.

Use bulk deletion of those related items using WhereOneOrMany() against all the IDs instead of Where() _on each item_

Added unit test to ensure the same set of rows is DELETE and INSERT as before.

Add SerializeWriteLockBehavior to work like the SQLite WAL in-transaction works. Waits using SemaphoreSlime, which IS await compatible. Blocks other writes but allow reads (as they are outside the transaction). Add to the ServiceCollectionExtensions.

Add ability to set the DatabaseLockingBehaviorType via the DatabaseConfigurationOptions.

Add warning to the PessimisticLockBehavior (as it's really not safe to use in a multi-transaction environment)

Fixed OptimisticLockBehavior to actually let the lock exceptions through to the SQLite Provider library where it can be retried instead of just dropping the error on the floor.

**Code assistance**

Claude Code to build unit test and diagnose where blocks were occuring in the bulk processing of QuickPlay images. Also used to derive why the pessimistic lock mode was so broken when I tried it.

**Issues**

Pretty much every database locked error, and a lot of "my system go slow while Scheduled Tasks were running"