### PR TITLE
docs: fix 'than' → 'then' in docker-templates/README.md

### DIFF
--- a/deployment/unraid/docker-templates/README.md
+++ b/deployment/unraid/docker-templates/README.md
@@ -10,6 +10,6 @@ Add the following line under "Template Repositories"
 
 https://github.com/jellyfin/jellyfin/tree/master/deployment/unraid/docker-templates
 
-Click save than click on Add Container and select jellyfin.
+Click save then click on Add Container and select jellyfin.
 
 Adjust to your paths to your liking and off you go!


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `deployment/unraid/docker-templates/README.md` (line 13).

## Problem

"than" should be "then" — indicates sequence, not comparison.

The problematic text:

```
Click save than click on Add Container and select jellyfin.
```

## Fix

Replaced with:

```
Click save then click on Add Container and select jellyfin.
```

## Type of Change

- [x] Documentation fix (grammar)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text