### PR TITLE
docs: fix 'though' → 'through' and capitalize sentence start in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This creates a container that has everything to run and debug the Jellyfin Media
 > Keep in mind that as this has no web client you have to connect to it via an external client. This can be just another codespace container running the WebUI. vuejs does not work from the get-go as it does not support the setup steps.
 
 #### Development Jellyfin Server ffmpeg
-this extends the default server with a default installation of ffmpeg6 though the means described here: https://jellyfin.org/docs/general/installation/linux#repository-manual
+This extends the default server with a default installation of ffmpeg6 through the means described here: https://jellyfin.org/docs/general/installation/linux#repository-manual
 If you want to install a specific ffmpeg version, follow the comments embedded in the `.devcontainer/Dev - Server Ffmpeg/install.ffmpeg.sh` file.
 
 Use the `ghcs .NET Launch (nowebclient, ffmpeg)` launch config to run with the jellyfin-ffmpeg enabled.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 146).

## Problem

Sentence begins with lowercase "this" (should be capitalized), and "though" is the wrong word — should be "through" (meaning "by means of").

The problematic text:

```
this extends the default server with a default installation of ffmpeg6 though the means described here
```

## Fix

Replaced with:

```
This extends the default server with a default installation of ffmpeg6 through the means described here
```

## Type of Change

- [x] Documentation fix (grammar)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text