### PR TITLE
docs: fix 'entity frameworks multi provider' → "Entity Framework's multi-provider" in readme.md

### DIFF
--- a/src/Jellyfin.Database/readme.md
+++ b/src/Jellyfin.Database/readme.md
@@ -1,6 +1,6 @@
 # How to run EFCore migrations
 
-This shall provide context on how to work with entity frameworks multi provider migration feature.
+This shall provide context on how to work with Entity Framework's multi-provider migration feature.
 
 Jellyfin will support multiple database providers in the future, namely SQLite as its default and the experimental PostgreSQL.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `src/Jellyfin.Database/readme.md` (line 3).

## Problem

Proper noun 'Entity Framework' is lowercased and not possessive; compound adjective 'multi provider' should be hyphenated.

The problematic text:

```
This shall provide context on how to work with entity frameworks multi provider migration feature.
```

## Fix

Replaced with:

```
This shall provide context on how to work with Entity Framework's multi-provider migration feature.
```

## Type of Change

- [x] Documentation fix (grammar)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text