### PR TITLE
Fix DLNA clients that percent-encode the query separator as %3F

### DIFF
--- a/Jellyfin.Api/Middleware/QueryStringDecodingMiddleware.cs
+++ b/Jellyfin.Api/Middleware/QueryStringDecodingMiddleware.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -27,6 +28,24 @@ public class QueryStringDecodingMiddleware
     /// <returns>The async task.</returns>
     public async Task Invoke(HttpContext httpContext)
     {
+        // Some clients (e.g. certain DLNA set-top boxes) percent-encode their own query
+        // separator as %3F instead of sending a literal '?'. ASP.NET Core decodes that
+        // into a literal '?' embedded inside Request.Path, leaving QueryString empty and
+        // every [FromQuery] parameter silently defaulted. Left uncorrected, this corrupts
+        // downstream logic that assumes Path and QueryString are properly split (e.g. the
+        // transcode output file path). Split it out before routing/binding runs.
+        var path = httpContext.Request.Path.Value;
+        if (!string.IsNullOrEmpty(path))
+        {
+            var queryIndex = path.IndexOf('?', StringComparison.Ordinal);
+            if (queryIndex >= 0)
+            {
+                var embeddedQuery = path[(queryIndex + 1)..];
+                httpContext.Request.Path = new PathString(path[..queryIndex]);
+                httpContext.Request.QueryString = new QueryString("?" + embeddedQuery);
+            }
+        }
+
         var feature = httpContext.Features.Get<IQueryFeature>();
         if (feature is not null)
         {


### PR DESCRIPTION
## Summary
Some DLNA clients (observed with an Orange Livebox decoder, SoftAtHome-based) send stream requests with the query separator percent-encoded as `%3F` instead of a literal `?`, e.g. `/stream.mkv%3FStatic=true&VideoCodec=hevc&...`. ASP.NET Core decodes this into a literal `?` embedded inside `Request.Path`, leaving `QueryString` empty.

This has two knock-on effects:
- Every `[FromQuery]`-bound parameter (`Static`, `DeviceProfileId`, etc.) silently defaults, so a client-requested direct-play (`Static=true`) is silently ignored and the server transcodes instead.
- Route/model binding built from the mangled path ends up concatenating the raw query string into values used downstream (e.g. the transcode output file path), producing paths like `/cache/transcodes/<hash>.mkv?deviceprofileid=...`. FFmpeg then fails with `Unable to choose an output format for '...'`.

This has been reported since 2022 in the old built-in DLNA controller ([jellyfin-plugin-dlna#25](https://github.com/jellyfin/jellyfin-plugin-dlna/issues/25)) and reproduces identically in the now-external DLNA plugin, since the relevant code was carried over unchanged.

## Fix
`QueryStringDecodingMiddleware` already exists specifically to normalize the query string before routing/binding. This extends it to also detect a literal `?` embedded in `Request.Path` (the result of decoding a client's `%3F`) and split it into a proper `Path` + `QueryString` before the rest of the pipeline runs. Well-formed requests are unaffected.

## Testing
Reproduced and confirmed fixed against a real Orange Livebox decoder (SoftAtHome) playing back HEVC/AC3 content requiring transcoding, on Jellyfin 10.11.11.

## Disclosure
This fix was 100% vibecoded — written by an AI coding assistant (Claude) diagnosing the bug from server logs, with me driving and testing on my own hardware. I'm not a Jellyfin contributor and can't personally vouch for its correctness beyond "it fixed my exact repro and didn't break anything else I use." Please review accordingly — happy to test alternate approaches if maintainers prefer a different fix.