### PR TITLE
Improve season folder resolution: series-prefixed names and empty
  folder handling

### DIFF
--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -193,10 +193,11 @@ namespace Emby.Naming.TV
                 if (suffix >= 1900 && suffix <= 2099)
                 {
                     var prefix = seasonNumber / 10000;
-                    // Only strip if the remaining prefix is a reasonable season number (1-99)
-                    if (prefix > 0 && prefix < 100)
+                    // Only strip if the remaining prefix is a reasonable season number (1-99).
+                    // prefix is always >= 1 here since seasonNumber >= 10000.
+                    if (prefix < 100)
                     {
-                        return (int)prefix;
+                        return prefix;
                     }
                 }
             }

--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Emby.Naming.TV
@@ -129,12 +130,13 @@ namespace Emby.Naming.TV
             // Find each season keyword occurrence and try parsing from that position.
             // Iterate all keyword matches to handle cases like "The Series Finale - Season 1"
             // where the series name itself contains a season keyword (e.g. "Series").
-            var keywordMatches = SeasonKeyword().Matches(filename);
-            foreach (Match kwMatch in keywordMatches)
+            // Iterate each season keyword position in the folder name.
+            // Only the Index is needed — the Match object is not used beyond that.
+            foreach (var idx in SeasonKeyword().Matches(filename).Select(m => m.Index))
             {
                 // Skip keyword matches that have a digit immediately before them —
                 // this indicates an episode pattern like "Episode 1 Season 2"
-                if (kwMatch.Index > 0 && char.IsDigit(filename[kwMatch.Index - 1]))
+                if (idx > 0 && char.IsDigit(filename[idx - 1]))
                 {
                     continue;
                 }
@@ -144,7 +146,7 @@ namespace Emby.Naming.TV
                     return (null, false);
                 }
 
-                var fromKeyword = filename[kwMatch.Index..];
+                var fromKeyword = filename[idx..];
 
                 preMatch = ProcessPre().Match(fromKeyword);
                 if (preMatch.Success)

--- a/Emby.Naming/TV/SeasonPathParser.cs
+++ b/Emby.Naming/TV/SeasonPathParser.cs
@@ -110,16 +110,56 @@ namespace Emby.Naming.TV
 
                 return CheckMatch(preMatch);
             }
-            else
+
+            var postMatch = ProcessPost().Match(filename);
+            if (postMatch.Success)
             {
-                var postMatch = ProcessPost().Match(filename);
-                if (postMatch.Success && isMixedLibrary && !SeasonKeyword().IsMatch(fileName))
+                if (isMixedLibrary && !SeasonKeyword().IsMatch(fileName))
                 {
                     return (null, false);
                 }
 
                 return CheckMatch(postMatch);
             }
+
+            // Fallback: handle series-prefixed season folders like
+            // "Solar Opposites - Season 1" or "Show (2020) - Season 3".
+            // The anchored ProcessPre/ProcessPost regexes require the season keyword
+            // at the start of the string, which fails when the series name precedes it.
+            // Find each season keyword occurrence and try parsing from that position.
+            // Iterate all keyword matches to handle cases like "The Series Finale - Season 1"
+            // where the series name itself contains a season keyword (e.g. "Series").
+            var keywordMatches = SeasonKeyword().Matches(filename);
+            foreach (Match kwMatch in keywordMatches)
+            {
+                // Skip keyword matches that have a digit immediately before them —
+                // this indicates an episode pattern like "Episode 1 Season 2"
+                if (kwMatch.Index > 0 && char.IsDigit(filename[kwMatch.Index - 1]))
+                {
+                    continue;
+                }
+
+                if (isMixedLibrary && !SeasonKeyword().IsMatch(fileName))
+                {
+                    return (null, false);
+                }
+
+                var fromKeyword = filename[kwMatch.Index..];
+
+                preMatch = ProcessPre().Match(fromKeyword);
+                if (preMatch.Success)
+                {
+                    return CheckMatch(preMatch);
+                }
+
+                postMatch = ProcessPost().Match(fromKeyword);
+                if (postMatch.Success)
+                {
+                    return CheckMatch(postMatch);
+                }
+            }
+
+            return (null, false);
         }
 
         private static (int? SeasonNumber, bool IsSeasonFolder) CheckMatch(Match match)
@@ -129,11 +169,39 @@ namespace Emby.Naming.TV
             {
                 if (int.TryParse(numberString.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seasonNumber))
                 {
-                    return (seasonNumber, true);
+                    return (SanitizeSeasonNumber(seasonNumber), true);
                 }
             }
 
             return (null, false);
+        }
+
+        /// <summary>
+        /// Sanitizes a season number that may have absorbed an adjacent year value
+        /// due to CleanNameRegex removing delimiters (e.g. "Season 7 (2023)" becomes
+        /// "Season72023" after cleaning, which would parse as 72023).
+        /// If the number ends with a plausible 4-digit year (1900-2099), strip it.
+        /// </summary>
+        private static int? SanitizeSeasonNumber(int seasonNumber)
+        {
+            // No TV show has 10,000+ seasons — if we got a number this large,
+            // it likely absorbed an adjacent year like "Season 7 2023" → 72023.
+            if (seasonNumber >= 10000)
+            {
+                var suffix = seasonNumber % 10000;
+                // Check if the last 4 digits look like a plausible year
+                if (suffix >= 1900 && suffix <= 2099)
+                {
+                    var prefix = seasonNumber / 10000;
+                    // Only strip if the remaining prefix is a reasonable season number (1-99)
+                    if (prefix > 0 && prefix < 100)
+                    {
+                        return (int)prefix;
+                    }
+                }
+            }
+
+            return seasonNumber;
         }
 
         /// <summary>

--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
@@ -53,6 +53,41 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
 
                 var path = args.Path;
 
+                // Reject empty folders — a season folder must contain at least one video file.
+                // This check runs regardless of naming, so folders like "Season 1" that are
+                // empty don't create phantom seasons that compete with real ones.
+                // Guard with Directory.Exists so tests using fake paths are unaffected.
+                if (Directory.Exists(path))
+                {
+                    var exts = _namingOptions.VideoFileExtensions;
+
+                    // 1) Check top-level files — most season folders have episodes directly here.
+                    var hasAnyVideo = Directory.EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly)
+                        .Any(file => exts.Contains(Path.GetExtension(file)));
+
+                    // 2) Check one level of subdirectories — covers episode-in-subfolder layouts
+                    //    without recursing into .trickplay/, .actors/ or other metadata folders
+                    //    that don't contain video files.
+                    if (!hasAnyVideo)
+                    {
+                        hasAnyVideo = Directory.EnumerateDirectories(path)
+                            .Any(subdir => Directory.EnumerateFiles(subdir, "*", SearchOption.TopDirectoryOnly)
+                                .Any(file => exts.Contains(Path.GetExtension(file))));
+                    }
+
+                    // 3) Rare deep-nesting fallback — e.g. BDMV/STREAM/*.m2ts in a TV folder.
+                    if (!hasAnyVideo)
+                    {
+                        hasAnyVideo = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
+                            .Any(file => exts.Contains(Path.GetExtension(file)));
+                    }
+
+                    if (!hasAnyVideo)
+                    {
+                        return null;
+                    }
+                }
+
                 var seasonParserResult = SeasonPathParser.Parse(path, series.ContainingFolderPath, true, true);
 
                 var season = new Season
@@ -83,13 +118,10 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
                         return null;
                     }
 
-                    var hasAnyVideo = Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
-                        .Any(file => _namingOptions.VideoFileExtensions.Contains(Path.GetExtension(file)));
-
-                    if (!hasAnyVideo)
-                    {
-                        return null;
-                    }
+                    // hasAnyVideo already checked above — the folder has video.
+                    // We couldn't determine the season number from the name, but
+                    // create the season anyway with whatever we have; metadata
+                    // refresh can fill in the missing IndexNumber later.
                 }
 
                 if (season.IndexNumber.HasValue && string.IsNullOrEmpty(season.Name))

--- a/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
+++ b/tests/Jellyfin.Naming.Tests/TV/SeasonPathParserTests.cs
@@ -47,7 +47,7 @@ public class SeasonPathParserTests
     [InlineData("/Drive/Season 02", "/Drive", 2, true)]
     [InlineData("/Drive/Seinfeld/S02", "/Seinfeld", 2, true)]
     [InlineData("/Drive/Seinfeld/2", "/Seinfeld", 2, true)]
-    [InlineData("/Drive/Seinfeld Season 2", "/Drive", null, false)]
+    [InlineData("/Drive/Seinfeld Season 2", "/Drive", 2, true)]
     [InlineData("/Drive/Season 2009", "/Drive", 2009, true)]
     [InlineData("/Drive/Season1", "/Drive", 1, true)]
     [InlineData("The Wonder Years/The.Wonder.Years.S04.PDTV.x264-JCH", "/The Wonder Years", 4, true)]
@@ -76,6 +76,41 @@ public class SeasonPathParserTests
     [InlineData("The Wonder Years/The Wonder Years Season 01 1080p", "/The Wonder Years", 1, true)]
 
     public void GetSeasonNumberFromPathTest(string path, string? parentPath, int? seasonNumber, bool isSeasonDirectory)
+    {
+        var result = SeasonPathParser.Parse(path, parentPath, true, true);
+
+        Assert.Equal(result.SeasonNumber is not null, result.Success);
+        Assert.Equal(seasonNumber, result.SeasonNumber);
+        Assert.Equal(isSeasonDirectory, result.IsSeasonFolder);
+    }
+
+    [Theory]
+    // Series-prefixed season folders: "{SeriesName} - Season {N}" (Sonarr default naming)
+    [InlineData("/Drive/Series/Solar Opposites/Solar Opposites - Season 1", "/Drive/Series", 1, true)]
+    [InlineData("/Drive/Series/The Office/The Office Season 2", "/Drive/Series", 2, true)]
+    [InlineData("/Drive/Series/Friends/Friends - Staffel 5", "/Drive/Series", 5, true)]
+    [InlineData("/Drive/Series/Friends/Friends - Säsong 3", "/Drive/Series", 3, true)]
+    [InlineData("/Drive/Series/The Boys/The Boys - Temporada 4", "/Drive/Series", 4, true)]
+    // Series-prefixed with year: "{SeriesName} (2020) - Season {N}"
+    [InlineData("/Drive/Series/Solar Opposites (2020)/Solar Opposites (2020) - Season 1", "/Drive/Series", 1, true)]
+    [InlineData("/Drive/Series/Star Trek Discovery (2017)/Star Trek Discovery (2017) - Season 3", "/Drive/Series", 3, true)]
+    // Series name containing a season keyword (e.g. "The Series Finale - Season 1")
+    // Should still find the actual season number
+    [InlineData("/Drive/TV/The Series Finale/The Series Finale - Season 1", "/Drive/TV", 1, true)]
+    // Season with year suffix: "Season 7 (2023)" — should parse as 7, not 72023
+    [InlineData("/Drive/Series/Rick and Morty/Rick and Morty - Season 7 (2023)", "/Drive/Series", 7, true)]
+    [InlineData("/Drive/Series/Show/Show - Season 4 (2024)", "/Drive/Series", 4, true)]
+    // Standard naming still works exactly as before
+    [InlineData("/Drive/Series/Season 1", "/Drive/Series", 1, true)]
+    [InlineData("/Drive/Series/S01", "/Drive/Series", 1, true)]
+    [InlineData("/Drive/Series/Staffel 1", "/Drive/Series", 1, true)]
+    // Defensive: ensure non-season-keyword-containing words don't false-match
+    [InlineData("/Drive/Series/Reasoning/Reasoning - S01", "/Drive/Series", 1, true)]
+    [InlineData("/Drive/Series/The Reason/The Reason S02", "/Drive/Series", 2, true)]
+    // Year edge cases: should NOT sanitize when the "year" part isn't actually a year
+    [InlineData("/Drive/Series/Season 2009", "/Drive", 2009, true)]
+    [InlineData("/Drive/Series/Season 100", "/Drive", 100, true)]
+    public void GetSeasonNumberFromPathSeriesPrefixTest(string path, string? parentPath, int? seasonNumber, bool isSeasonDirectory)
     {
         var result = SeasonPathParser.Parse(path, parentPath, true, true);
 


### PR DESCRIPTION
## What I found

My season folders are named like "Solar Opposites - Season 1" (Sonarr default). After digging into the code, I noticed SeasonPathParser cant parse these because the season keyword isnt at the start of the cleaned folder name.

This seems to cause some problems:
- Physical seasons end up with IndexNumber = null
- Metadata providers then create virtual seasons that compete with them  
- Episodes get linked to the wrong season
- On scans, things get removed and recreated, triggering webhooks

I also noticed empty folders like an unused "Season 1" sitting next to a real "Invasion - Season 1" folder will create phantom seasons, because the empty-folder check only ran when name parsing failed.

## What I changed

Two small changes:

In SeasonPathParser.cs: after the anchored regex checks, look for season keywords anywhere in the name and try parsing from there. It skips matches with a digit right before them (to avoid episode patterns like "Episode 1 Season 2"), and itll try to strip trailing years so "Season 7 (2023)" comes out as 7 not 72023.

In SeasonResolver.cs: moved the empty-folder check earlier so it runs for all folders, not just ones that failed parsing. Uses a quick top-level check first, then one level of subdirectories (to skip .trickplay/ image folders), and only does full recursive as a last resort.

## Testing

On my server (12.0-rc4, ~250 eps):
- Ran 5+ full scans across rc3 and rc4, saw no more remove/recreate cycles
- Solar Opposites went from 4 real + 4 duplicate virtual seasons to just 4 real ones
- Invasion phantom seasons cleaned up
- Legitimate virtuals for undownloaded content stayed intact
- Scan times unchanged (~8s)

Unit tests: added 14 new cases covering prefixed names, years, international keywords, etc. Full naming suite (701) and SeasonResolver tests (10) all pass, no regressions.

Patch applies cleanly to rc1 through rc4 — the affected files didnt change between them.

I also tested on rc4 which has a LinkedChildrenLoaded guard on Folder (#17455) — seems to work fine alongside these changes, though I havent dug into whether there is any actual interaction.

## Caveats

This is my first contribution here. I tested as thoroughly as I could on my own server but would appreciate a closer look, specially around the year sanitization approach and the directory scanning.

Note: I used Claude Code to help dig through the codebase and iterate on the fix, but the testing was done on my own server and these words are mine. Per the LLM policy, happy to adjust anything that needs changing.

This problem alone was fundamentally breaking my 12.0RC3 install. Every day more episodes would simply disappear,  it  quickly became unusable. So far, this fix seems to be working. I've tested it to the best of my ability with my limited skills and library, on multiple server builds and 12.0 versions.  So far, it seems to be solving the problem. 

Of course I welcome feedback, criticism and suggestions. My goal in doing this is not only to fix it for myself, but to fix it for the community. I urge the community to test on sacrificial servers, and please report back any bugs / fixes.