### PR TITLE
Fix by-name endpoints reporting TotalRecordCount=0 next to a populated Items array

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -144,11 +144,6 @@ public sealed partial class BaseItemRepository
     {
         ArgumentNullException.ThrowIfNull(filter);
 
-        if (!filter.Limit.HasValue)
-        {
-            filter.EnableTotalRecordCount = false;
-        }
-
         using var context = _dbProvider.CreateDbContext();
 
         var innerQueryFilter = TranslateQuery(context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId)), context, new InternalItemsQuery(filter.User)

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryByNameTotalCountTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryByNameTotalCountTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Configuration;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+/// <summary>
+/// The by-name endpoints (artists, album artists, genres, studios) all funnel through
+/// <c>GetItemValues</c>. A query without a <c>Limit</c> used to have its total record count
+/// silently disabled, so callers got a populated <c>Items</c> array next to a zero total.
+/// </summary>
+public sealed class BaseItemRepositoryByNameTotalCountTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly BaseItemRepository _repository;
+    private readonly ItemTypeLookup _itemTypeLookup;
+
+    public BaseItemRepositoryByNameTotalCountTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using (var ctx = CreateDbContext())
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+        _itemTypeLookup = new ItemTypeLookup();
+
+        var serverConfigurationManager = new Mock<IServerConfigurationManager>();
+        serverConfigurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+
+        _repository = new BaseItemRepository(
+            factory.Object,
+            new Mock<IServerApplicationHost>().Object,
+            _itemTypeLookup,
+            serverConfigurationManager.Object,
+            NullLogger<BaseItemRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public void GetArtists_WithoutLimit_ReportsTotalRecordCount()
+    {
+        SeedArtists(3);
+
+        var result = _repository.GetArtists(CreateQuery(limit: null));
+
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(3, result.TotalRecordCount);
+    }
+
+    [Fact]
+    public void GetArtists_WithLimit_ReportsTotalBeyondThePage()
+    {
+        SeedArtists(3);
+
+        var result = _repository.GetArtists(CreateQuery(limit: 2));
+
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal(3, result.TotalRecordCount);
+    }
+
+    [Fact]
+    public void GetArtists_TotalRecordCountDisabled_StaysZero()
+    {
+        SeedArtists(3);
+
+        var query = CreateQuery(limit: null);
+        query.EnableTotalRecordCount = false;
+
+        var result = _repository.GetArtists(query);
+
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(0, result.TotalRecordCount);
+    }
+
+    [Fact]
+    public void GetArtists_WithoutLimit_DoesNotMutateCallerQuery()
+    {
+        SeedArtists(1);
+
+        var query = CreateQuery(limit: null);
+        Assert.True(query.EnableTotalRecordCount);
+
+        _repository.GetArtists(query);
+
+        // The repository used to flip this flag on the caller's own query object, so a
+        // reused query silently lost its total on every subsequent call.
+        Assert.True(query.EnableTotalRecordCount);
+    }
+
+    private static InternalItemsQuery CreateQuery(int? limit)
+    {
+        return new InternalItemsQuery(new User("test", "auth", "reset"))
+        {
+            Limit = limit
+        };
+    }
+
+    /// <summary>
+    /// Creates <paramref name="count"/> artists, each credited on one song, which is what
+    /// makes them visible to the item-value join behind the by-name endpoints.
+    /// </summary>
+    private void SeedArtists(int count)
+    {
+        using var ctx = CreateDbContext();
+
+        for (var i = 0; i < count; i++)
+        {
+            var name = $"Artist {i}";
+            var cleanName = name.ToLowerInvariant();
+
+            var artistId = Guid.Parse($"aaaaaaaa-0000-0000-0000-{i:D12}");
+            var songId = Guid.Parse($"55555555-0000-0000-0000-{i:D12}");
+            var valueId = Guid.Parse($"cccccccc-0000-0000-0000-{i:D12}");
+
+            var artist = new BaseItemEntity
+            {
+                Id = artistId,
+                Type = _itemTypeLookup.BaseItemKindNames[BaseItemKind.MusicArtist],
+                Name = name,
+                CleanName = cleanName,
+                PresentationUniqueKey = artistId.ToString("N"),
+                IsFolder = true,
+                IsVirtualItem = false
+            };
+
+            var song = new BaseItemEntity
+            {
+                Id = songId,
+                Type = _itemTypeLookup.BaseItemKindNames[BaseItemKind.Audio],
+                Name = $"Song {i}",
+                CleanName = $"song {i}",
+                PresentationUniqueKey = songId.ToString("N"),
+                MediaType = "Audio",
+                IsFolder = false,
+                IsVirtualItem = false
+            };
+
+            var itemValue = new ItemValue
+            {
+                ItemValueId = valueId,
+                Type = ItemValueType.Artist,
+                Value = name,
+                CleanValue = cleanName
+            };
+
+            ctx.BaseItems.Add(artist);
+            ctx.BaseItems.Add(song);
+            ctx.ItemValues.Add(itemValue);
+            ctx.ItemValuesMap.Add(new ItemValueMap
+            {
+                ItemId = songId,
+                ItemValueId = valueId,
+                Item = song,
+                ItemValue = itemValue
+            });
+        }
+
+        ctx.SaveChanges();
+    }
+
+    private JellyfinDbContext CreateDbContext()
+    {
+        return new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+    }
+}


### PR DESCRIPTION
**Changes**

The by-name endpoints report `TotalRecordCount = 0` while returning a populated `Items` array, whenever the request carries no explicit `limit`.

`GetItemValues` in `BaseItemRepository.ByName.cs` is the shared path behind `/Artists`, `/Artists/AlbumArtists`, `/Genres`, `/MusicGenres` and `/Studios`. Its first act is to turn the count off:

```csharp
if (!filter.Limit.HasValue)
{
    filter.EnableTotalRecordCount = false;
}
```

so the count never reaches the result a hundred lines below:

```csharp
if (filter.EnableTotalRecordCount)
{
    result.TotalRecordCount = representativeIds.Count;
}
```

A client that pages on the reported total — the contract every other list endpoint honours — reads a populated response as an empty library. `/Items` and `/Persons` do not go through `GetItemValues` and report the count correctly, which is what makes the inconsistency observable without reading any source.

Measured against `master` (12.0.0) with a 62-track music library:

| Request | Before | After |
|---|---|---|
| `GET /Artists?UserId=…` | `TotalRecordCount=0`, `Items=7` | `TotalRecordCount=7`, `Items=7` |
| `GET /MusicGenres?UserId=…` | `TotalRecordCount=0`, `Items=38` | `TotalRecordCount=38`, `Items=38` |
| `GET /Studios?UserId=…` | `TotalRecordCount=0`, `Items=6` | `TotalRecordCount=6`, `Items=6` |
| `GET /Artists/AlbumArtists?UserId=…` | `TotalRecordCount=0`, `Items=5` | `TotalRecordCount=5`, `Items=5` |
| `GET /Artists?UserId=…&limit=100` | `TotalRecordCount=7` | unchanged |
| `GET /Items?…` (control, different path) | correct | unchanged |

The `limit` column is the tell: the same query reports the total correctly as soon as a limit is present, which is exactly what the removed block keyed on.

**Removing the block costs nothing.** `representativeIds` is materialised into a `List<Guid>` regardless a few lines further down, so the count was already computed and in hand — no extra query, no extra pass. Callers that genuinely want to skip counting still can: `EnableTotalRecordCount = false` is honoured as before, and that is covered by a test.

The block additionally mutated the *caller's* query object rather than a local copy, so an `InternalItemsQuery` instance reused across calls silently lost its total after the first limitless one. Also covered by a test.

Four unit tests are added in `BaseItemRepositoryByNameTotalCountTests`, against an in-memory SQLite context seeded with artists credited on songs (the item-value join the by-name endpoints rely on). Two of them fail on `master` — the limitless count and the query mutation — and the other two pass both before and after, guarding the paging case and the opt-out.

**Code assistance**

Claude Code was used to locate the failing path, reproduce it against a server built from `master`, write the fix and the tests, and draft this description. Everything stated above was verified by running it: the before/after numbers come from HTTP responses against two servers built from this branch with and without the change, and the "fails on master" claim comes from running the new tests against the unmodified file. Nothing here is inferred.

**Issues**

No existing issue found; the failing requests are listed above.
