### PR TITLE
Let /Audio/{id}/universal reuse a transcode instead of re-encoding per request

### DIFF
--- a/Jellyfin.Api/Controllers/UniversalAudioController.cs
+++ b/Jellyfin.Api/Controllers/UniversalAudioController.cs
@@ -83,6 +83,7 @@ public class UniversalAudioController : BaseJellyfinApiController
     /// <param name="maxAudioSampleRate">Optional. The maximum audio sample rate.</param>
     /// <param name="maxAudioBitDepth">Optional. The maximum audio bit depth.</param>
     /// <param name="enableRemoteMedia">Optional. Whether to enable remote media.</param>
+    /// <param name="playSessionId">Optional. The play session id. Repeating it across requests lets the server reuse the transcode it already produced instead of starting a new one; omitted, a fresh id is generated per request.</param>
     /// <param name="enableAudioVbrEncoding">Optional. Whether to enable Audio Encoding.</param>
     /// <param name="enableRedirection">Whether to enable redirection. Defaults to true.</param>
     /// <response code="200">Audio stream returned.</response>
@@ -113,6 +114,7 @@ public class UniversalAudioController : BaseJellyfinApiController
         [FromQuery] int? maxAudioSampleRate,
         [FromQuery] int? maxAudioBitDepth,
         [FromQuery] bool? enableRemoteMedia,
+        [FromQuery] string? playSessionId = null,
         [FromQuery] bool enableAudioVbrEncoding = true,
         [FromQuery] bool enableRedirection = true)
     {
@@ -136,6 +138,14 @@ public class UniversalAudioController : BaseJellyfinApiController
                 Request,
                 mediaSourceId)
             .ConfigureAwait(false);
+
+        // GetPlaybackInfo mints a fresh play session id on every call, and that id is part of the
+        // transcode's output path. Without honouring a caller-supplied one, two identical requests
+        // land on two different paths and each one re-encodes the whole track from scratch.
+        if (!string.IsNullOrEmpty(playSessionId))
+        {
+            info.PlaySessionId = playSessionId;
+        }
 
         // set device specific data
         foreach (var sourceInfo in info.MediaSources)


### PR DESCRIPTION
**Changes**

`GET /Audio/{itemId}/universal` re-encodes the whole track on every request, even when the request is byte-for-byte identical to the previous one.

The endpoint accepts no `playSessionId`. It uses the one `MediaInfoHelper.GetPlaybackInfo` produces, which is a fresh GUID per call:

```csharp
result.PlaySessionId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
```

and hands it to the `StreamingRequestDto`. Since the transcode's output path is

```csharp
var data = $"{state.MediaPath}-{state.UserAgent}-{deviceId!}-{playSessionId!}";
```

no two requests ever land on the same path, so the completed transcode is never reused. `stream.*` already takes a `playSessionId` and reuses it; `universal` is the odd one out.

Measured on `master`, three identical requests for one track, counting ffmpeg invocations in the server log:

| Request | Before | After |
|---|---|---|
| `/Audio/{id}/universal` ×3, same `playSessionId` | **3 ffmpeg invocations** | **1** |
| `/Audio/{id}/universal` ×3, no `playSessionId` | 3 | 3 (unchanged) |
| `/Audio/{id}/stream.mp3` ×3, same `playSessionId` (control) | 1 | 1 |

The change is additive: the parameter is optional, and when it is absent a fresh id is still generated per request, so no existing caller changes behaviour.

**Side effect worth naming, since it is how this was found.** The Xing/LAME header of an MP3 transcode is written blank on the first pass and backfilled once the encoder knows the frame counts. Because every `universal` request started a new transcode, clients received `frames=0 delay=0 padding=0` on *every* request and had no encoder delay or padding to trim, so tracks played with the priming samples at the head and the padding at the tail. With the transcode reused, the completed header comes back from the second request on:

```
before:  Xing  frames=0     delay=0    padding=0
after:   Info  frames=9881  delay=576  padding=870
```

which is what `stream.mp3` already returns today.

**On tests:** there is no unit test here, and I would rather say so than pad the PR. `UniversalAudioController` takes `MediaInfoHelper`, `AudioHelper` and `DynamicHlsHelper` as concrete classes with non-virtual methods, so it cannot be meaningfully faked, and a test that proved anything about transcode reuse would need the whole transcode stack and real media. The verification is the measurement above: a server built from this branch, one built from `master`, the same library and the same requests, counting ffmpeg invocations in the log. Happy to add a test if a reviewer sees a seam I have missed.

**Code assistance**

Claude Code was used to trace the path from the endpoint to the output-path hash, to run the before/after measurements, and to draft this description. Everything above was verified by executing it — the invocation counts come from server logs on two builds, and the header values from parsing the returned MP3s. Nothing is inferred.

**Issues**

No existing issue found.
