### PR TITLE
Fix auto-created collections losing custom name on rescan

### DIFF
--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -84,7 +84,9 @@ public class CollectionPostScanTask : ILibraryPostScanTask
 
                     var tmdbCollectionId = movie.TryGetProviderId(MetadataProvider.TmdbCollection, out var id) ? id : null;
 
-                    var key = string.IsNullOrEmpty(tmdbCollectionId) ? movie.CollectionName : tmdbCollectionId;
+                    var key = string.IsNullOrEmpty(tmdbCollectionId)
+                        ? "name=" + movie.CollectionName
+                        : "id=" + tmdbCollectionId;
 
                     if (!collectionGroups.TryGetValue(key, out var group))
                     {

--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 
 namespace Emby.Server.Implementations.Library.Validators;
@@ -46,7 +47,7 @@ public class CollectionPostScanTask : ILibraryPostScanTask
     /// <returns>Task.</returns>
     public async Task Run(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var collectionNameMoviesMap = new Dictionary<string, HashSet<Guid>>();
+        var collectionGroups = new Dictionary<string, CollectionGroup>();
 
         foreach (var library in _libraryManager.RootFolder.Children)
         {
@@ -74,17 +75,24 @@ public class CollectionPostScanTask : ILibraryPostScanTask
 
                 foreach (var m in movies)
                 {
-                    if (m is Movie movie && !string.IsNullOrEmpty(movie.CollectionName) && !movie.PrimaryVersionId.HasValue)
+                    if (m is not Movie movie
+                        || string.IsNullOrEmpty(movie.CollectionName)
+                        || movie.PrimaryVersionId.HasValue)
                     {
-                        if (collectionNameMoviesMap.TryGetValue(movie.CollectionName, out var movieList))
-                        {
-                            movieList.Add(movie.Id);
-                        }
-                        else
-                        {
-                            collectionNameMoviesMap[movie.CollectionName] = new HashSet<Guid> { movie.Id };
-                        }
+                        continue;
                     }
+
+                    var tmdbCollectionId = movie.TryGetProviderId(MetadataProvider.TmdbCollection, out var id) ? id : null;
+
+                    var key = string.IsNullOrEmpty(tmdbCollectionId) ? movie.CollectionName : tmdbCollectionId;
+
+                    if (!collectionGroups.TryGetValue(key, out var group))
+                    {
+                        group = new CollectionGroup(movie.CollectionName, tmdbCollectionId);
+                        collectionGroups[key] = group;
+                    }
+
+                    group.MovieIds.Add(movie.Id);
                 }
 
                 if (movies.Count < pagesize)
@@ -97,7 +105,7 @@ public class CollectionPostScanTask : ILibraryPostScanTask
         }
 
         var numComplete = 0;
-        var count = collectionNameMoviesMap.Count;
+        var count = collectionGroups.Count;
 
         if (count == 0)
         {
@@ -112,27 +120,51 @@ public class CollectionPostScanTask : ILibraryPostScanTask
             Recursive = true
         });
 
-        foreach (var (collectionName, movieIds) in collectionNameMoviesMap)
+        foreach (var group in collectionGroups.Values)
         {
             try
             {
-                var boxSet = boxSets.FirstOrDefault(b => b?.Name == collectionName) as BoxSet;
+                BoxSet? boxSet = null;
+
+                // Prefer the stable TMDB collection id. The box set stores it under the Tmdb
+                // provider key, while movies store it under TmdbCollection
+                if (!string.IsNullOrEmpty(group.TmdbCollectionId))
+                {
+                    boxSet = boxSets
+                        .OfType<BoxSet>()
+                        .FirstOrDefault(b =>
+                            b.TryGetProviderId(MetadataProvider.Tmdb, out var id)
+                            && string.Equals(id, group.TmdbCollectionId, StringComparison.Ordinal));
+                }
+
+                // Fall back to name for legacy box sets that don't have an id yet.
+                boxSet ??= boxSets.FirstOrDefault(b => b?.Name == group.Name) as BoxSet;
+
                 if (boxSet is null)
                 {
                     // won't automatically create collection if only one movie in it
-                    if (movieIds.Count >= 2)
+                    if (group.MovieIds.Count >= 2)
                     {
-                        boxSet = await _collectionManager.CreateCollectionAsync(new CollectionCreationOptions
+                        var options = new CollectionCreationOptions
                         {
-                            Name = collectionName,
-                        }).ConfigureAwait(false);
+                            Name = group.Name,
+                        };
 
-                        await _collectionManager.AddToCollectionAsync(boxSet.Id, movieIds).ConfigureAwait(false);
+                        // Stamp the stable collection id so future scans can match this box set by id
+                        // even after the user renames it
+                        if (!string.IsNullOrEmpty(group.TmdbCollectionId))
+                        {
+                            options.SetProviderId(MetadataProvider.Tmdb, group.TmdbCollectionId);
+                        }
+
+                        boxSet = await _collectionManager.CreateCollectionAsync(options).ConfigureAwait(false);
+
+                        await _collectionManager.AddToCollectionAsync(boxSet.Id, group.MovieIds).ConfigureAwait(false);
                     }
                 }
                 else
                 {
-                    await _collectionManager.AddToCollectionAsync(boxSet.Id, movieIds).ConfigureAwait(false);
+                    await _collectionManager.AddToCollectionAsync(boxSet.Id, group.MovieIds).ConfigureAwait(false);
                 }
 
                 numComplete++;
@@ -144,10 +176,25 @@ public class CollectionPostScanTask : ILibraryPostScanTask
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error refreshing {CollectionName} with {@MovieIds}", collectionName, movieIds);
+                _logger.LogError(ex, "Error refreshing {CollectionName} with {@MovieIds}", group.Name, group.MovieIds);
             }
         }
 
         progress.Report(100);
+    }
+
+    private sealed class CollectionGroup
+    {
+        public CollectionGroup(string name, string? tmdbCollectionId)
+        {
+            Name = name;
+            TmdbCollectionId = tmdbCollectionId;
+        }
+
+        public string Name { get; }
+
+        public string? TmdbCollectionId { get; }
+
+        public HashSet<Guid> MovieIds { get; } = new();
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/CollectionPostScanTaskTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/CollectionPostScanTaskTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Library.Validators;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Collections;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class CollectionPostScanTaskTests
+{
+    private readonly Mock<ILibraryManager> _libraryManager = new(MockBehavior.Loose);
+    private readonly Mock<ICollectionManager> _collectionManager = new(MockBehavior.Loose);
+    private readonly CollectionPostScanTask _task;
+
+    public CollectionPostScanTaskTests()
+    {
+        _task = new CollectionPostScanTask(
+            _libraryManager.Object,
+            _collectionManager.Object,
+            NullLogger<CollectionPostScanTask>.Instance);
+    }
+
+    [Fact]
+    public async Task Run_RenamedLockedCollection_DoesNotRecreateUnderDefaultName()
+    {
+        const string DefaultName = "The Original Collection";
+        const string RenamedName = "My Renamed Collection";
+        const string CollectionId = "10";
+
+        var movie1 = CreateMovie("Film A", DefaultName, CollectionId);
+        var movie2 = CreateMovie("Film B", DefaultName, CollectionId);
+
+        var existingBoxSet = new BoxSet { Name = RenamedName, IsLocked = true };
+        existingBoxSet.SetProviderId(MetadataProvider.Tmdb, CollectionId);
+
+        var library = new Folder { Name = "Movies" };
+        var rootFolder = new AggregateFolder { Children = new List<BaseItem> { library } };
+
+        _libraryManager.Setup(l => l.RootFolder).Returns(rootFolder);
+        _libraryManager.Setup(l => l.GetLibraryOptions(It.IsAny<BaseItem>()))
+            .Returns(new LibraryOptions { AutomaticallyAddToCollection = true });
+
+        _libraryManager
+            .Setup(l => l.GetItemList(It.Is<InternalItemsQuery>(q => q.IncludeItemTypes.Contains(BaseItemKind.Movie))))
+            .Returns(new List<BaseItem> { movie1, movie2 });
+        _libraryManager
+            .Setup(l => l.GetItemList(It.Is<InternalItemsQuery>(q => q.IncludeItemTypes.Contains(BaseItemKind.BoxSet))))
+            .Returns(new List<BaseItem> { existingBoxSet });
+
+        _collectionManager
+            .Setup(c => c.CreateCollectionAsync(It.IsAny<CollectionCreationOptions>()))
+            .ReturnsAsync(new BoxSet { Name = DefaultName });
+        _collectionManager
+            .Setup(c => c.AddToCollectionAsync(It.IsAny<Guid>(), It.IsAny<IEnumerable<Guid>>()))
+            .Returns(Task.CompletedTask);
+
+        await _task.Run(new Progress<double>(), CancellationToken.None);
+
+        _collectionManager.Verify(
+            c => c.CreateCollectionAsync(It.IsAny<CollectionCreationOptions>()),
+            Times.Never,
+            "renamed+locked collection must be matched by stable id, not recreated under its old name");
+
+        // Members are re-added to the existing box set.
+        _collectionManager.Verify(
+            c => c.AddToCollectionAsync(existingBoxSet.Id, It.IsAny<IEnumerable<Guid>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_NewCollection_StampsTmdbCollectionIdOnCreate()
+    {
+        const string CollectionName = "Brand New Collection";
+        const string CollectionId = "42";
+
+        var movie1 = CreateMovie("Film A", CollectionName, CollectionId);
+        var movie2 = CreateMovie("Film B", CollectionName, CollectionId);
+
+        var library = new Folder { Name = "Movies" };
+        var rootFolder = new AggregateFolder { Children = new List<BaseItem> { library } };
+
+        _libraryManager.Setup(l => l.RootFolder).Returns(rootFolder);
+        _libraryManager.Setup(l => l.GetLibraryOptions(It.IsAny<BaseItem>()))
+            .Returns(new LibraryOptions { AutomaticallyAddToCollection = true });
+
+        _libraryManager
+            .Setup(l => l.GetItemList(It.Is<InternalItemsQuery>(q => q.IncludeItemTypes.Contains(BaseItemKind.Movie))))
+            .Returns(new List<BaseItem> { movie1, movie2 });
+
+        // No existing box sets, so the create path runs.
+        _libraryManager
+            .Setup(l => l.GetItemList(It.Is<InternalItemsQuery>(q => q.IncludeItemTypes.Contains(BaseItemKind.BoxSet))))
+            .Returns(new List<BaseItem>());
+
+        // Capture the options the task hands to CreateCollectionAsync so we can inspect them.
+        CollectionCreationOptions? captured = null;
+        _collectionManager
+            .Setup(c => c.CreateCollectionAsync(It.IsAny<CollectionCreationOptions>()))
+            .Callback<CollectionCreationOptions>(o => captured = o)
+            .ReturnsAsync(new BoxSet { Name = CollectionName });
+        _collectionManager
+            .Setup(c => c.AddToCollectionAsync(It.IsAny<Guid>(), It.IsAny<IEnumerable<Guid>>()))
+            .Returns(Task.CompletedTask);
+
+        await _task.Run(new Progress<double>(), CancellationToken.None);
+
+        _collectionManager.Verify(
+            c => c.CreateCollectionAsync(It.IsAny<CollectionCreationOptions>()),
+            Times.Once);
+
+        Assert.NotNull(captured);
+        Assert.Equal(CollectionName, captured!.Name);
+        Assert.Equal(CollectionId, captured.GetProviderId(MetadataProvider.Tmdb));
+    }
+
+    private static Movie CreateMovie(string name, string collectionName, string tmdbCollectionId)
+    {
+        var movie = new Movie { Name = name, Id = Guid.NewGuid(), CollectionName = collectionName };
+        movie.SetProviderId(MetadataProvider.TmdbCollection, tmdbCollectionId);
+        return movie;
+    }
+}


### PR DESCRIPTION
**Changes**

Auto-created collections lost their custom name after a library rescan when
"Automatically add to collection" was enabled. `CollectionPostScanTask`
identified existing collections by their mutable `Name`, so when a user
renamed an auto-created collection the lookup missed (the movies still carried
their original `CollectionName`) and the task recreated the collection under
its default name, discarding the rename regardless of whether metadata was
locked. This changes the task to match existing box sets by the stable TMDB
collection id (falling back to the name for legacy box sets without an id), and
stamps newly created box sets with the id so future scans can match them after
a rename. Adds unit tests covering both the renamed-collection and
new-collection paths.

Note: collections whose movies have no TMDB collection id still fall back to
name matching, so a rename of those isn't preserved yet. A membership-based
identity would be the fuller fix and is left as a potential follow-up.

**Code assistance**

Claude Code Opus 4.8 was used to navigate and explain the codebase. It was
also used to draft the unit tests.

**Issues**

Fixes #15693
