### PR TITLE
Add busy_timeout pragma support

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/PragmaConnectionInterceptor.cs
@@ -20,6 +20,7 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private readonly int? _journalSizeLimit;
     private readonly int _tempStoreMode;
     private readonly int _syncMode;
+    private readonly int _busyTimeout;
     private readonly IDictionary<string, string> _customPragma;
 
     /// <summary>
@@ -31,8 +32,9 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     /// <param name="journalSizeLimit">Journal Size.</param>
     /// <param name="tempStoreMode">The https://sqlite.org/pragma.html#pragma_temp_store pragma.</param>
     /// <param name="syncMode">The https://sqlite.org/pragma.html#pragma_synchronous pragma.</param>
+    /// <param name="busyTimeout">The https://sqlite.org/pragma.html#pragma_busy_timeout pragma, in milliseconds.</param>
     /// <param name="customPragma">A list of custom provided Pragma in the list of CustomOptions starting with "#PRAGMA:".</param>
-    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, IDictionary<string, string> customPragma)
+    public PragmaConnectionInterceptor(ILogger logger, int? cacheSize, string lockingMode, int? journalSizeLimit, int tempStoreMode, int syncMode, int busyTimeout, IDictionary<string, string> customPragma)
     {
         _logger = logger;
         _cacheSize = cacheSize;
@@ -40,6 +42,7 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
         _journalSizeLimit = journalSizeLimit;
         _tempStoreMode = tempStoreMode;
         _syncMode = syncMode;
+        _busyTimeout = busyTimeout;
         _customPragma = customPragma;
 
         InitialCommand = BuildCommandText();
@@ -80,6 +83,15 @@ public class PragmaConnectionInterceptor : DbConnectionInterceptor
     private string BuildCommandText()
     {
         var sb = new StringBuilder();
+
+        // Do this first, so the remaining pragmas are covered by it. SQLite defaults to 0, which
+        // makes any lock conflict fall through to Microsoft.Data.Sqlite's 150ms poll
+        // until CommandTimeout.
+        if (_busyTimeout > 0)
+        {
+            sb.AppendLine(CultureInfo.InvariantCulture, $"PRAGMA busy_timeout={_busyTimeout};");
+        }
+
         if (_cacheSize.HasValue)
         {
             sb.AppendLine(CultureInfo.InvariantCulture, $"PRAGMA cache_size={_cacheSize.Value};");

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -22,6 +22,18 @@ namespace Jellyfin.Database.Providers.Sqlite;
 public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 {
     private const string BackupFolderName = "SQLiteBackups";
+
+    /// <summary>
+    /// Time SQLite waits on a locked database before returning SQLITE_BUSY, in milliseconds.
+    /// </summary>
+    private const int DefaultBusyTimeoutMs = 5_000;
+
+    /// <summary>
+    /// Outer bound on the driver's lock-wait fallback, in seconds. Kept above
+    /// <see cref="DefaultBusyTimeoutMs"/> so SQLite's busy handler does the waiting.
+    /// </summary>
+    private const int DefaultCommandTimeoutSeconds = 60;
+
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;
 
@@ -60,6 +72,8 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         var customOptions = databaseConfiguration.CustomProviderOptions?.Options;
 
+        var busyTimeout = GetOption(customOptions, "busytimeout", int.Parse, () => DefaultBusyTimeoutMs);
+
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
             DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
@@ -69,7 +83,9 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             // so busy_timeout is skipped and the command fails at CommandTimeout instead.
             Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Private),
             Pooling = GetOption(customOptions, "pooling", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => true),
-            DefaultTimeout = GetOption(customOptions, "command-timeout", int.Parse, () => 60)
+
+            // Bounds only the driver's lock-wait poll, not the runtime of an executing query.
+            DefaultTimeout = GetOption(customOptions, "command-timeout", int.Parse, () => DefaultCommandTimeoutSeconds)
         };
 
         var connectionString = sqliteConnectionBuilder.ToString();
@@ -92,6 +108,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                 GetOption(customOptions, "journalsizelimit", int.Parse, () => 134_217_728),
                 GetOption(customOptions, "tempstoremode", int.Parse, () => 2),
                 GetOption(customOptions, "syncmode", int.Parse, () => 1),
+                busyTimeout,
                 customOptions?.Where(e => e.Key.StartsWith("#PRAGMA:", StringComparison.OrdinalIgnoreCase)).ToDictionary(e => e.Key["#PRAGMA:".Length..], e => e.Value) ?? []));
 
         var enableSensitiveDataLogging = GetOption(customOptions, "EnableSensitiveDataLogging", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => false);

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -26,7 +26,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     /// <summary>
     /// Time SQLite waits on a locked database before returning SQLITE_BUSY, in milliseconds.
     /// </summary>
-    private const int DefaultBusyTimeoutMs = 5_000;
+    private const int DefaultBusyTimeoutMs = 100;
 
     /// <summary>
     /// Outer bound on the driver's lock-wait fallback, in seconds. Kept above


### PR DESCRIPTION
Add support for the `busy_timeout` PRAGMA for SQLite and pass it through the database options. By setting this to 5s (by default), the SQLite library can spin internally and not block the thread-pool. If the command timeout expires then the normal .Net SQLite Provider will kick in, but at that point we've already given the database/connection time to decongest.

**Changes**

- Add busy timeout support to the PragmaConnectionInterceptor and emit the
PRAGMA if it is set to non-zero.
- Add busy timeout loading from the database.xml configuration. Defaults to 5 seconds if not set
- Add default command-timeout constant (same 60s)


<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
