### PR TITLE
Add SerializedWrites locking behavior.

### DIFF
--- a/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
+++ b/Jellyfin.Server.Implementations/Extensions/ServiceCollectionExtensions.cs
@@ -134,6 +134,9 @@ public static class ServiceCollectionExtensions
             case DatabaseLockingBehaviorTypes.Optimistic:
                 serviceCollection.AddSingleton<IEntityFrameworkCoreLockingBehavior, OptimisticLockBehavior>();
                 break;
+            case DatabaseLockingBehaviorTypes.SerializedWrites:
+                serviceCollection.AddSingleton<IEntityFrameworkCoreLockingBehavior, SerializedWriteLockBehavior>();
+                break;
         }
 
         serviceCollection.AddPooledDbContextFactory<JellyfinDbContext>((serviceProvider, opt) =>

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseConfigurationOptions.cs
@@ -18,7 +18,7 @@ public class DatabaseConfigurationOptions
     public CustomDatabaseOptions? CustomProviderOptions { get; set; }
 
     /// <summary>
-    /// Gets or Sets the kind of locking behavior jellyfin should perform. Possible options are "NoLock", "Pessimistic", "Optimistic".
+    /// Gets or Sets the kind of locking behavior jellyfin should perform. Possible options are "NoLock", "Pessimistic", "Optimistic", "SerializedWrites".
     /// Defaults to "NoLock".
     /// </summary>
     public DatabaseLockingBehaviorTypes LockingBehavior { get; set; }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseLockingBehaviorTypes.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/DbConfiguration/DatabaseLockingBehaviorTypes.cs
@@ -18,5 +18,11 @@ public enum DatabaseLockingBehaviorTypes
     /// <summary>
     /// Defines that all writes should be attempted and when fail should be retried.
     /// </summary>
-    Optimistic = 2
+    Optimistic = 2,
+
+    /// <summary>
+    /// Defines a behavior that queues writers so only one runs at a time, while leaving reads
+    /// unsynchronized.
+    /// </summary>
+    SerializedWrites = 3
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/SerializedWriteLockBehavior.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Database.Implementations.Locking;
+
+/// <summary>
+/// A locking behavior that serializes writers in-process while leaving readers unsynchronized.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQLite permits one writer at a time; queueing them in-process lets each take the database lock
+/// uncontended instead of racing for it and generating SQLITE_BUSY retries.
+/// </para>
+/// <para>
+/// Reads are unsynchronized: in WAL mode they neither block nor are blocked by writers.
+/// </para>
+/// <para>
+/// Held via <see cref="SemaphoreSlim"/> so it survives an <see langword="await"/>.
+/// </para>
+/// <para>
+/// The permit spans an explicit transaction's whole lifetime, matching SQLite: Microsoft.Data.Sqlite
+/// issues BEGIN IMMEDIATE for every isolation level except ReadUncommitted, so the database write
+/// lock is held from BEGIN to commit.
+/// </para>
+/// </remarks>
+public sealed class SerializedWriteLockBehavior : IEntityFrameworkCoreLockingBehavior, IDisposable
+{
+    /// <summary>
+    /// How long to queue for the permit before proceeding without it and leaving busy_timeout to
+    /// arbitrate. Reached whenever the holder is slow, not just on nested writes: a write that
+    /// stalls for its full CommandTimeout holds the permit for that whole time, so every queued
+    /// writer times out and then hits the database unsynchronized.
+    /// </summary>
+    private static readonly TimeSpan _acquireTimeout = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Set while this instance owns the permit. Propagates into the guarded call's EF internals so
+    /// the nested interceptors skip re-acquiring.
+    /// </summary>
+    private readonly AsyncLocal<bool> _holdsWriteLock = new();
+
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    /// <summary>
+    /// Explicit transactions owning the permit, mapped to their connection. Keyed by transaction
+    /// because its lifetime spans async flows; removal doubles as the release guard against the
+    /// several end-of-transaction callbacks EF raises. Holds at most one entry.
+    /// </summary>
+    private readonly ConcurrentDictionary<DbTransaction, DbConnection> _lockedTransactions = new();
+
+    private readonly ILogger<SerializedWriteLockBehavior> _logger;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializedWriteLockBehavior"/> class.
+    /// </summary>
+    /// <param name="logger">The application logger.</param>
+    public SerializedWriteLockBehavior(ILogger<SerializedWriteLockBehavior> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public void Initialise(DbContextOptionsBuilder optionsBuilder)
+    {
+        _logger.LogInformation("The database locking mode has been set to: SerializedWrites.");
+        optionsBuilder.AddInterceptors(new WriteSerializingCommandInterceptor(this));
+        optionsBuilder.AddInterceptors(new WriteSerializingTransactionInterceptor(this));
+        optionsBuilder.AddInterceptors(new WriteLockReleasingConnectionInterceptor(this));
+    }
+
+    /// <inheritdoc/>
+    public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
+    {
+        if (AlreadyHoldsLock(context))
+        {
+            saveChanges();
+            return;
+        }
+
+        var acquired = Acquire();
+        try
+        {
+            saveChanges();
+        }
+        finally
+        {
+            Release(acquired);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task OnSaveChangesAsync(JellyfinDbContext context, Func<Task> saveChanges)
+    {
+        if (AlreadyHoldsLock(context))
+        {
+            await saveChanges().ConfigureAwait(false);
+            return;
+        }
+
+        var acquired = await AcquireAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            await saveChanges().ConfigureAwait(false);
+        }
+        finally
+        {
+            Release(acquired);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _writeLock.Dispose();
+    }
+
+    internal bool HoldsWriteLock() => _holdsWriteLock.Value;
+
+    /// <summary>
+    /// Whether an enclosing operation or an explicit transaction on this context holds the lock.
+    /// </summary>
+    private bool AlreadyHoldsLock(JellyfinDbContext context)
+    {
+        if (HoldsWriteLock())
+        {
+            return true;
+        }
+
+        var current = context.Database.CurrentTransaction?.GetDbTransaction();
+        return current is not null && _lockedTransactions.ContainsKey(current);
+    }
+
+    private bool Acquire()
+    {
+        var acquired = _writeLock.Wait(_acquireTimeout);
+        if (acquired)
+        {
+            _holdsWriteLock.Value = true;
+            return true;
+        }
+
+        LogAcquireTimeout();
+        return false;
+    }
+
+    private async ValueTask<bool> AcquireAsync(CancellationToken cancellationToken)
+    {
+        var acquired = await _writeLock.WaitAsync(_acquireTimeout, cancellationToken).ConfigureAwait(false);
+        if (acquired)
+        {
+            _holdsWriteLock.Value = true;
+            return true;
+        }
+
+        LogAcquireTimeout();
+        return false;
+    }
+
+    private void LogAcquireTimeout()
+    {
+        _logger.LogWarning(
+            "Timed out after {Timeout}s waiting for the in-process database write lock; proceeding without it. This means some write is holding the lock far too long, or that writes are nested across separate connections.",
+            _acquireTimeout.TotalSeconds);
+    }
+
+    private void Release(bool acquired)
+    {
+        if (acquired)
+        {
+            _holdsWriteLock.Value = false;
+            _writeLock.Release();
+        }
+    }
+
+    private void TrackTransaction(DbTransaction transaction, DbConnection connection)
+    {
+        _lockedTransactions[transaction] = connection;
+    }
+
+    private void ReleaseTransaction(DbTransaction transaction)
+    {
+        if (_lockedTransactions.TryRemove(transaction, out _))
+        {
+            _writeLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Releases a permit still held by a transaction on a closing connection. EF disposes the
+    /// underlying transaction without a commit, rollback or failure callback, leaving this the only
+    /// release point for a transaction abandoned by an exception.
+    /// </summary>
+    private void ReleaseTransactionsOn(DbConnection connection)
+    {
+        foreach (var (transaction, owner) in _lockedTransactions)
+        {
+            if (ReferenceEquals(owner, connection))
+            {
+                ReleaseTransaction(transaction);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Serializes writes issued outside <c>SaveChanges</c> and outside an explicit transaction:
+    /// ExecuteDelete, ExecuteUpdate, raw SQL and migrations, all of which execute as non-queries.
+    /// Reads pass through.
+    /// </summary>
+    private sealed class WriteSerializingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteSerializingCommandInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            if (!NeedsLock(command, eventData))
+            {
+                return base.NonQueryExecuting(command, eventData, result);
+            }
+
+            var acquired = _owner.Acquire();
+            try
+            {
+                return InterceptionResult<int>.SuppressWithResult(command.ExecuteNonQuery());
+            }
+            finally
+            {
+                _owner.Release(acquired);
+            }
+        }
+
+        public override async ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(DbCommand command, CommandEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+        {
+            if (!NeedsLock(command, eventData))
+            {
+                return await base.NonQueryExecutingAsync(command, eventData, result, cancellationToken).ConfigureAwait(false);
+            }
+
+            var acquired = await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return InterceptionResult<int>.SuppressWithResult(await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false));
+            }
+            finally
+            {
+                _owner.Release(acquired);
+            }
+        }
+
+        private bool NeedsLock(DbCommand command, CommandEventData eventData)
+        {
+            if (!IsWrite(eventData.CommandSource))
+            {
+                return false;
+            }
+
+            // The semaphore is not reentrant; taking it again under an owning operation deadlocks.
+            if (_owner.HoldsWriteLock())
+            {
+                return false;
+            }
+
+            return command.Transaction is null || !_owner._lockedTransactions.ContainsKey(command.Transaction);
+        }
+
+        private static bool IsWrite(CommandSource source) => source switch
+        {
+            CommandSource.SaveChanges => true,
+            CommandSource.Migrations => true,
+            CommandSource.ExecuteSqlRaw => true,
+            CommandSource.ExecuteUpdate => true,
+            CommandSource.ExecuteDelete => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Holds the permit for an explicit transaction's lifetime. Acquires on
+    /// <c>TransactionStarted</c>, where the transaction object exists to key
+    /// the release on.
+    /// </summary>
+    private sealed class WriteSerializingTransactionInterceptor : DbTransactionInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteSerializingTransactionInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override DbTransaction TransactionStarted(DbConnection connection, TransactionEndEventData eventData, DbTransaction result)
+        {
+            if (!_owner.HoldsWriteLock() && _owner.Acquire())
+            {
+                _owner.TrackTransaction(result, connection);
+            }
+
+            return base.TransactionStarted(connection, eventData, result);
+        }
+
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(DbConnection connection, TransactionEndEventData eventData, DbTransaction result, CancellationToken cancellationToken = default)
+        {
+            if (!_owner.HoldsWriteLock() && await _owner.AcquireAsync(cancellationToken).ConfigureAwait(false))
+            {
+                _owner.TrackTransaction(result, connection);
+            }
+
+            return await base.TransactionStartedAsync(connection, eventData, result, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override void TransactionCommitted(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionCommitted(transaction, eventData);
+        }
+
+        public override Task TransactionCommittedAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionCommittedAsync(transaction, eventData, cancellationToken);
+        }
+
+        public override void TransactionRolledBack(DbTransaction transaction, TransactionEndEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionRolledBack(transaction, eventData);
+        }
+
+        public override Task TransactionRolledBackAsync(DbTransaction transaction, TransactionEndEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionRolledBackAsync(transaction, eventData, cancellationToken);
+        }
+
+        public override void TransactionFailed(DbTransaction transaction, TransactionErrorEventData eventData)
+        {
+            _owner.ReleaseTransaction(transaction);
+            base.TransactionFailed(transaction, eventData);
+        }
+
+        public override Task TransactionFailedAsync(DbTransaction transaction, TransactionErrorEventData eventData, CancellationToken cancellationToken = default)
+        {
+            _owner.ReleaseTransaction(transaction);
+            return base.TransactionFailedAsync(transaction, eventData, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Backstop release for transactions abandoned without a commit or rollback callback.
+    /// </summary>
+    private sealed class WriteLockReleasingConnectionInterceptor : DbConnectionInterceptor
+    {
+        private readonly SerializedWriteLockBehavior _owner;
+
+        public WriteLockReleasingConnectionInterceptor(SerializedWriteLockBehavior owner)
+        {
+            _owner = owner;
+        }
+
+        public override void ConnectionClosed(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            _owner.ReleaseTransactionsOn(connection);
+            base.ConnectionClosed(connection, eventData);
+        }
+
+        public override Task ConnectionClosedAsync(DbConnection connection, ConnectionEndEventData eventData)
+        {
+            _owner.ReleaseTransactionsOn(connection);
+            return base.ConnectionClosedAsync(connection, eventData);
+        }
+    }
+}


### PR DESCRIPTION
The OptimisticLockBehavior and PessimisticLockBehavior have issues because they do not mirror the actual SQLite model in WAL mode. Need a LockBehavior that matches the actual SQLite serialized write model.

**Changes**

- Add SerializedWriteLockBehavior to block multiple writers, while allowing multiple readers (outside the write's transaction)
- Add SerializedWrites to the DatabaseLockingBehaviorTypes
- Add handling of SerializedWrites to the ServiceCollectionExtensions registration

<!-- Describe your changes here in 1-5 sentences. -->

**Code assistance**

Claude Code used to diagnose where blocks were occurring and the lock cascade

**Issues**

Helps database locked issues by reducing the wait-chain once something takes too long.
