### PR TITLE
Switch SQLite connection Cache to Private

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -63,7 +63,11 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
             DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
-            Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Default),
+            // Private, not Default: sqlite3_enable_shared_cache is process-global, so a plugin
+            // enabling it makes these connections share a cache too. Contention then surfaces as
+            // SQLITE_LOCKED ("database table is locked"), which the busy handler does not cover,
+            // so busy_timeout is skipped and the command fails at CommandTimeout instead.
+            Cache = GetOption(customOptions, "cache", Enum.Parse<SqliteCacheMode>, () => SqliteCacheMode.Private),
             Pooling = GetOption(customOptions, "pooling", e => e.Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase), () => true),
             DefaultTimeout = GetOption(customOptions, "command-timeout", int.Parse, () => 60)
         };


### PR DESCRIPTION
When SQLite's cache mode is set to Default, any settings that another consumer sets will pollute the process-global settings. This allows plugins to change the behavior of the Jellyfin core cache.

**Changes**

Change the SqliteCacheMode to Private from Default

**Code assistance**

None

**Issues**

Lock and cache corruptions when plugins like Playback Reports set their own options