### PR TITLE
Fix captured (and discarded) Execute exceptions

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/Locking/OptimisticLockBehavior.cs
@@ -88,13 +88,13 @@ public class OptimisticLockBehavior : IEntityFrameworkCoreLockingBehavior
     /// <inheritdoc/>
     public void OnSaveChanges(JellyfinDbContext context, Action saveChanges)
     {
-        _writePolicy.ExecuteAndCapture(saveChanges);
+        _writePolicy.Execute(saveChanges);
     }
 
     /// <inheritdoc/>
     public async Task OnSaveChangesAsync(JellyfinDbContext context, Func<Task> saveChanges)
     {
-        await _writeAsyncPolicy.ExecuteAndCaptureAsync(saveChanges).ConfigureAwait(false);
+        await _writeAsyncPolicy.ExecuteAsync(saveChanges).ConfigureAwait(false);
     }
 
     private sealed class TransactionLockingInterceptor : DbTransactionInterceptor


### PR DESCRIPTION
Using ExecuteAndCapture (and the async version) requires something to manage the captured exception, which we don't do. Errors would be silently dropped and the writes/deletes treated as if they succeeded.

**Changes**

Switch ExecuteAndCapture to Execute (so the exception isn't eaten)
Switch ExecuteAndCaptureAsync to ExecuteAsync (same reason)

**Code assistance**

None 

**Issues**

Silent database write losses.
