### PR TITLE
Use DataSource for sqlite db path

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -146,7 +146,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     public Task<string> MigrationBackupFast(CancellationToken cancellationToken)
     {
         var key = DateTime.UtcNow.ToString("yyyyMMddhhmmss", CultureInfo.InvariantCulture);
-        var path = Path.Combine(_applicationPaths.DataPath, "jellyfin.db");
+        var path = GetDatabasePath();
         var backupFile = Path.Combine(_applicationPaths.DataPath, BackupFolderName);
         Directory.CreateDirectory(backupFile);
 
@@ -160,7 +160,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     {
         // ensure there are absolutely no dangling Sqlite connections.
         SqliteConnection.ClearAllPools();
-        var path = Path.Combine(_applicationPaths.DataPath, "jellyfin.db");
+        var path = GetDatabasePath();
         var backupFile = Path.Combine(_applicationPaths.DataPath, BackupFolderName, $"{key}_jellyfin.db");
 
         if (!File.Exists(backupFile))
@@ -186,6 +186,17 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         File.Delete(backupFile);
         return Task.CompletedTask;
+    }
+
+    private string GetDatabasePath()
+    {
+        if (DbContextFactory is null)
+        {
+            throw new InvalidOperationException("The database provider has not been initialized.");
+        }
+
+        using var dbContext = DbContextFactory.CreateDbContext();
+        return dbContext.Database.GetDbConnection().DataSource;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
#15354 added support to move where the db is stored, but there are some hard coded things in the file still for the original path. Tried it out on  my local deployment and hit some issues with migrations. This change will access the DbContext.DataSource to find the actual path instead of hard coding it