### PR TITLE
Stop image endpoints from upscaling beyond the source resolution

### DIFF
--- a/MediaBrowser.Controller/Drawing/ImageHelper.cs
+++ b/MediaBrowser.Controller/Drawing/ImageHelper.cs
@@ -12,9 +12,7 @@ namespace MediaBrowser.Controller.Drawing
             var newSize = DrawingUtils.Resize(originalImageSize, options.Width ?? 0, options.Height ?? 0, options.MaxWidth ?? 0, options.MaxHeight ?? 0);
             newSize = DrawingUtils.ResizeFill(newSize, options.FillWidth, options.FillHeight);
 
-            // Never encode larger than the source. Upscaling adds no detail, and the requested
-            // width/height are caller-controlled, so without this an unauthenticated request can
-            // pin a CPU and allocate several GB encoding a single image.
+            // Never encode larger than the source.
             return DrawingUtils.ScaleDownToFit(newSize, originalImageSize);
         }
     }

--- a/MediaBrowser.Controller/Drawing/ImageHelper.cs
+++ b/MediaBrowser.Controller/Drawing/ImageHelper.cs
@@ -11,7 +11,11 @@ namespace MediaBrowser.Controller.Drawing
             // Determine the output size based on incoming parameters
             var newSize = DrawingUtils.Resize(originalImageSize, options.Width ?? 0, options.Height ?? 0, options.MaxWidth ?? 0, options.MaxHeight ?? 0);
             newSize = DrawingUtils.ResizeFill(newSize, options.FillWidth, options.FillHeight);
-            return newSize;
+
+            // Never encode larger than the source. Upscaling adds no detail, and the requested
+            // width/height are caller-controlled, so without this an unauthenticated request can
+            // pin a CPU and allocate several GB encoding a single image.
+            return DrawingUtils.ScaleDownToFit(newSize, originalImageSize);
         }
     }
 }

--- a/MediaBrowser.Model/Drawing/DrawingUtils.cs
+++ b/MediaBrowser.Model/Drawing/DrawingUtils.cs
@@ -104,6 +104,35 @@ namespace MediaBrowser.Model.Drawing
         }
 
         /// <summary>
+        /// Scales a size down uniformly until it fits inside a bounding box.
+        /// Returns the original size if it already fits, so this never upscales.
+        /// </summary>
+        /// <param name="size">The size object.</param>
+        /// <param name="boundingBox">The box the result has to fit inside.</param>
+        /// <returns>A new size object, or <paramref name="size"/> if it already fits.</returns>
+        public static ImageDimensions ScaleDownToFit(ImageDimensions size, ImageDimensions boundingBox)
+        {
+            if (size.Width <= 0 || size.Height <= 0 || boundingBox.Width <= 0 || boundingBox.Height <= 0)
+            {
+                return size;
+            }
+
+            double widthRatio = size.Width / (double)boundingBox.Width;
+            double heightRatio = size.Height / (double)boundingBox.Height;
+            double scaleRatio = Math.Max(widthRatio, heightRatio);
+
+            if (scaleRatio <= 1)
+            {
+                return size;
+            }
+
+            var newWidth = Math.Clamp(Convert.ToInt32(Math.Round(size.Width / scaleRatio)), 1, boundingBox.Width);
+            var newHeight = Math.Clamp(Convert.ToInt32(Math.Round(size.Height / scaleRatio)), 1, boundingBox.Height);
+
+            return new ImageDimensions(newWidth, newHeight);
+        }
+
+        /// <summary>
         /// Gets the new width.
         /// </summary>
         /// <param name="currentHeight">Height of the current.</param>

--- a/tests/Jellyfin.Controller.Tests/Drawing/ImageHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Drawing/ImageHelperTests.cs
@@ -1,0 +1,64 @@
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Model.Drawing;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.Drawing;
+
+public static class ImageHelperTests
+{
+    [Fact]
+    public static void GetNewImageSize_ExplicitSizeLargerThanSource_ClampsToSource()
+    {
+        // Regression test for https://github.com/jellyfin/jellyfin/issues/17056: the caller-supplied
+        // width/height were used verbatim, so a single request could ask for a 23100x23100 encode.
+        var options = new ImageProcessingOptions { Width = 23100, Height = 23100 };
+
+        var newSize = ImageHelper.GetNewImageSize(options, new ImageDimensions(600, 336));
+
+        Assert.Equal(336, newSize.Width);
+        Assert.Equal(336, newSize.Height);
+    }
+
+    [Fact]
+    public static void GetNewImageSize_WidthLargerThanSource_ClampsToSource()
+    {
+        var options = new ImageProcessingOptions { Width = 10000 };
+
+        var newSize = ImageHelper.GetNewImageSize(options, new ImageDimensions(600, 336));
+
+        Assert.Equal(600, newSize.Width);
+        Assert.Equal(336, newSize.Height);
+    }
+
+    [Fact]
+    public static void GetNewImageSize_FillLargerThanSource_ClampsToSource()
+    {
+        // ResizeFill already refused to upscale; this pins that behaviour.
+        var options = new ImageProcessingOptions { FillWidth = 23100, FillHeight = 23100 };
+
+        var newSize = ImageHelper.GetNewImageSize(options, new ImageDimensions(600, 336));
+
+        Assert.Equal(600, newSize.Width);
+        Assert.Equal(336, newSize.Height);
+    }
+
+    [Fact]
+    public static void GetNewImageSize_SmallerThanSource_StillDownscales()
+    {
+        var options = new ImageProcessingOptions { MaxWidth = 300 };
+
+        var newSize = ImageHelper.GetNewImageSize(options, new ImageDimensions(600, 336));
+
+        Assert.Equal(300, newSize.Width);
+        Assert.Equal(168, newSize.Height);
+    }
+
+    [Fact]
+    public static void GetNewImageSize_NoSizeRequested_ReturnsSource()
+    {
+        var newSize = ImageHelper.GetNewImageSize(new ImageProcessingOptions(), new ImageDimensions(600, 336));
+
+        Assert.Equal(600, newSize.Width);
+        Assert.Equal(336, newSize.Height);
+    }
+}

--- a/tests/Jellyfin.Model.Tests/Drawing/DrawingUtilsTests.cs
+++ b/tests/Jellyfin.Model.Tests/Drawing/DrawingUtilsTests.cs
@@ -1,0 +1,28 @@
+using MediaBrowser.Model.Drawing;
+using Xunit;
+
+namespace Jellyfin.Model.Drawing;
+
+public static class DrawingUtilsTests
+{
+    [Theory]
+    // Already inside the box, returned untouched.
+    [InlineData(600, 336, 1920, 1080, 600, 336)]
+    [InlineData(1920, 1080, 1920, 1080, 1920, 1080)]
+    // Scaled down uniformly, requested aspect ratio preserved.
+    [InlineData(23100, 23100, 1920, 1080, 1080, 1080)]
+    [InlineData(3840, 2160, 1920, 1080, 1920, 1080)]
+    [InlineData(1200, 400, 600, 336, 600, 200)]
+    // Extreme ratios still produce at least one pixel per axis.
+    [InlineData(10000, 1, 100, 100, 100, 1)]
+    // Degenerate inputs are passed through rather than dividing by zero.
+    [InlineData(600, 336, 0, 0, 600, 336)]
+    [InlineData(0, 0, 1920, 1080, 0, 0)]
+    public static void ScaleDownToFit_Bounds_WithoutUpscaling(int width, int height, int boxWidth, int boxHeight, int expectedWidth, int expectedHeight)
+    {
+        var scaled = DrawingUtils.ScaleDownToFit(new ImageDimensions(width, height), new ImageDimensions(boxWidth, boxHeight));
+
+        Assert.Equal(expectedWidth, scaled.Width);
+        Assert.Equal(expectedHeight, scaled.Height);
+    }
+}


### PR DESCRIPTION
<!--
Please follow the template. Not doing so may result in your PR being closed.
-->

## Changes

`ImageHelper.GetNewImageSize` passed the caller-supplied `width`/`height` straight through to `SkiaEncoder.EncodeImage`, which builds an `SKImageInfo` of exactly that size. Nothing bounded those values against the source image, so `GET /Items/<id>/Images/Primary?width=23100&height=23100&quality=100` makes the server allocate and resample a 23100×23100 surface from a poster that may be 600×336. The reporter of #17056 measured 100% of a core for 10–15 minutes and 6–12 GB resident per request. The item image endpoints are unauthenticated, and changing the requested size by one pixel misses the resize cache, so this is repeatable at will by anyone who knows an item id.

- `MediaBrowser.Model/Drawing/DrawingUtils.cs`: new `ScaleDownToFit(ImageDimensions size, ImageDimensions boundingBox)`. It scales `size` down uniformly until both axes fit inside `boundingBox` and returns `size` unchanged when it already fits, so it can only ever shrink.
- `MediaBrowser.Controller/Drawing/ImageHelper.cs`: `GetNewImageSize` now applies `ScaleDownToFit` against `originalImageSize` as its last step.

Effect: a request for more pixels than the source has now returns the source resolution, scaled to the aspect ratio that was asked for. Downscaling is unchanged. `ResizeFill` already refused to upscale (`// Clamp to current size.`), so this makes `width`/`height` behave the same way `fillWidth`/`fillHeight` already did.

`DrawingUtils.Resize` itself is deliberately not changed: `EncodingJobInfo.OutputWidth`/`OutputHeight` and `StreamInfo` use it to size video transcodes, where scaling up is a legitimate request.

Tests: `tests/Jellyfin.Model.Tests/Drawing/DrawingUtilsTests.cs` covers `ScaleDownToFit` including degenerate zero-sized inputs, and `tests/Jellyfin.Controller.Tests/Drawing/ImageHelperTests.cs` covers `GetNewImageSize` with the 23100×23100 case from the issue. The two `ImageHelperTests` upscale cases fail on `master` and pass with this change.

Out of scope, and still open after this PR:

- The resize cache key is still built from the *requested* dimensions, so distinct URLs that now resolve to the same output still produce distinct cache files. Each file is bounded by the source resolution now, but the file count is not.
- The permission check and the "don't reveal the item name when the requested image type doesn't exist" points from the issue are separate concerns and are untouched here.

## Code assistance

This PR was written with the assistance of an LLM (Claude). The root cause analysis, the choice to bound the output at the source resolution rather than at a fixed configured maximum, and the decision to leave `DrawingUtils.Resize` alone for the transcoding callers are mine; the LLM was used to navigate the drawing pipeline, draft the helper and the tests, and check that the existing callers were unaffected. Everything was built and tested locally before submitting.

## Issues

Fixes #17056.
