### PR TITLE
Fix EF core designer drifts

### DIFF
--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20210407110544_NullableCustomPrefValue.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20210407110544_NullableCustomPrefValue.Designer.cs
@@ -117,8 +117,6 @@ namespace Jellyfin.Server.Implementations.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("UserId");
-
                     b.HasIndex("UserId", "ItemId", "Client", "Key")
                         .IsUnique();
 
@@ -175,8 +173,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .HasColumnType("TEXT");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("UserId");
 
                     b.HasIndex("UserId", "ItemId", "Client")
                         .IsUnique();
@@ -291,12 +287,17 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .IsConcurrencyToken()
                         .HasColumnType("INTEGER");
 
+                    b.Property<Guid?>("UserId")
+                        .HasColumnType("TEXT");
+
                     b.Property<bool>("Value")
                         .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Permission_Permissions_Guid");
+                    b.HasIndex("UserId", "Kind")
+                        .IsUnique()
+                        .HasFilter("[UserId] IS NOT NULL");
 
                     b.ToTable("Permissions");
                 });
@@ -317,6 +318,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .IsConcurrencyToken()
                         .HasColumnType("INTEGER");
 
+                    b.Property<Guid?>("UserId")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Value")
                         .IsRequired()
                         .HasMaxLength(65535)
@@ -324,7 +328,9 @@ namespace Jellyfin.Server.Implementations.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Preference_Preferences_Guid");
+                    b.HasIndex("UserId", "Kind")
+                        .IsUnique()
+                        .HasFilter("[UserId] IS NOT NULL");
 
                     b.ToTable("Preferences");
                 });
@@ -431,9 +437,13 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT");
+                        .HasColumnType("TEXT")
+                        .UseCollation("NOCASE");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("Username")
+                        .IsUnique();
 
                     b.ToTable("Users");
                 });
@@ -469,7 +479,8 @@ namespace Jellyfin.Server.Implementations.Migrations
                 {
                     b.HasOne("Jellyfin.Data.Entities.User", null)
                         .WithOne("ProfileImage")
-                        .HasForeignKey("Jellyfin.Data.Entities.ImageInfo", "UserId");
+                        .HasForeignKey("Jellyfin.Data.Entities.ImageInfo", "UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 
             modelBuilder.Entity("Jellyfin.Data.Entities.ItemDisplayPreferences", b =>
@@ -485,14 +496,16 @@ namespace Jellyfin.Server.Implementations.Migrations
                 {
                     b.HasOne("Jellyfin.Data.Entities.User", null)
                         .WithMany("Permissions")
-                        .HasForeignKey("Permission_Permissions_Guid");
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 
             modelBuilder.Entity("Jellyfin.Data.Entities.Preference", b =>
                 {
                     b.HasOne("Jellyfin.Data.Entities.User", null)
                         .WithMany("Preferences")
-                        .HasForeignKey("Preference_Preferences_Guid");
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
                 });
 
             modelBuilder.Entity("Jellyfin.Data.Entities.DisplayPreferences", b =>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20230923170422_UserCastReceiver.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20230923170422_UserCastReceiver.Designer.cs
@@ -445,6 +445,37 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.ToTable("DeviceOptions");
                 });
 
+            modelBuilder.Entity("Jellyfin.Data.Entities.TrickplayInfo", b =>
+                {
+                    b.Property<Guid>("ItemId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<int>("Width")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("Bandwidth")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("Height")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("Interval")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("ThumbnailCount")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("TileHeight")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("TileWidth")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("ItemId", "Width");
+
+                    b.ToTable("TrickplayInfos");
+                });
+
             modelBuilder.Entity("Jellyfin.Data.Entities.User", b =>
                 {
                     b.Property<Guid>("Id")

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20240729140605_AddMediaSegments.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20240729140605_AddMediaSegments.Designer.cs
@@ -285,6 +285,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<Guid>("ItemId")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("SegmentProviderId")
+                        .HasColumnType("TEXT");
+
                     b.Property<long>("StartTicks")
                         .HasColumnType("INTEGER");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250204092455_MakeStartEndDateNullable.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250204092455_MakeStartEndDateNullable.Designer.cs
@@ -1247,8 +1247,7 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250214031148_ChannelIdGuid.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250214031148_ChannelIdGuid.Designer.cs
@@ -1247,8 +1247,7 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("TEXT")
-                        .UseCollation("NOCASE");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250327101120_AddKeyframeData.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250327101120_AddKeyframeData.Designer.cs
@@ -229,6 +229,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<int?>("IndexNumber")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int?>("InheritedParentalRatingSubValue")
+                        .HasColumnType("INTEGER");
+
                     b.Property<int?>("InheritedParentalRatingValue")
                         .HasColumnType("INTEGER");
 
@@ -1275,7 +1278,10 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<int>("MaxActiveSessions")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("MaxParentalAgeRating")
+                    b.Property<int?>("MaxParentalRatingScore")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int?>("MaxParentalRatingSubScore")
                         .HasColumnType("INTEGER");
 
                     b.Property<bool>("MustUpdatePassword")

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250327171413_AddHdr10PlusFlag.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250327171413_AddHdr10PlusFlag.Designer.cs
@@ -229,6 +229,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<int?>("IndexNumber")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int?>("InheritedParentalRatingSubValue")
+                        .HasColumnType("INTEGER");
+
                     b.Property<int?>("InheritedParentalRatingValue")
                         .HasColumnType("INTEGER");
 
@@ -748,6 +751,24 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
                 });
 
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.Property<Guid>("ItemId")
+                        .HasColumnType("TEXT");
+
+                    b.PrimitiveCollection<string>("KeyframeTicks")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("TotalDuration")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("ItemId");
+
+                    b.ToTable("KeyframeData");
+
+                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
+                });
+
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaSegment", b =>
                 {
                     b.Property<Guid>("Id")
@@ -1260,7 +1281,10 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<int>("MaxActiveSessions")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("MaxParentalAgeRating")
+                    b.Property<int?>("MaxParentalRatingScore")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int?>("MaxParentalRatingSubScore")
                         .HasColumnType("INTEGER");
 
                     b.Property<bool>("MustUpdatePassword")
@@ -1517,6 +1541,17 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("Item");
 
                     b.Navigation("ItemValue");
+                });
+
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.HasOne("Jellyfin.Database.Implementations.Entities.BaseItemEntity", "Item")
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Item");
                 });
 
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaStreamInfo", b =>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250331182844_FixAttachmentMigration.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250331182844_FixAttachmentMigration.Designer.cs
@@ -750,6 +750,24 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
                 });
 
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.Property<Guid>("ItemId")
+                        .HasColumnType("TEXT");
+
+                    b.PrimitiveCollection<string>("KeyframeTicks")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("TotalDuration")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("ItemId");
+
+                    b.ToTable("KeyframeData");
+
+                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
+                });
+
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaSegment", b =>
                 {
                     b.Property<Guid>("Id")
@@ -845,6 +863,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<int?>("ElPresentFlag")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<bool?>("Hdr10PlusPresentFlag")
                         .HasColumnType("INTEGER");
 
                     b.Property<int?>("Height")
@@ -1519,6 +1540,17 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("Item");
 
                     b.Navigation("ItemValue");
+                });
+
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.HasOne("Jellyfin.Database.Implementations.Entities.BaseItemEntity", "Item")
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Item");
                 });
 
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaStreamInfo", b =>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250401142247_FixAncestors.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250401142247_FixAncestors.Designer.cs
@@ -123,7 +123,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<string>("Codec")
-                        .IsRequired()
                         .HasColumnType("TEXT");
 
                     b.Property<string>("CodecTag")
@@ -751,6 +750,24 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
                 });
 
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.Property<Guid>("ItemId")
+                        .HasColumnType("TEXT");
+
+                    b.PrimitiveCollection<string>("KeyframeTicks")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("TotalDuration")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("ItemId");
+
+                    b.ToTable("KeyframeData");
+
+                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
+                });
+
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaSegment", b =>
                 {
                     b.Property<Guid>("Id")
@@ -846,6 +863,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<int?>("ElPresentFlag")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<bool?>("Hdr10PlusPresentFlag")
                         .HasColumnType("INTEGER");
 
                     b.Property<int?>("Height")
@@ -1520,6 +1540,17 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("Item");
 
                     b.Navigation("ItemValue");
+                });
+
+            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.KeyframeData", b =>
+                {
+                    b.HasOne("Jellyfin.Database.Implementations.Entities.BaseItemEntity", "Item")
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Item");
                 });
 
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.MediaStreamInfo", b =>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250405075612_FixItemValuesIndices.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20250405075612_FixItemValuesIndices.Designer.cs
@@ -183,9 +183,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<DateTime?>("DateCreated")
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTime?>("DateCreatedFilesystem")
-                        .HasColumnType("TEXT");
-
                     b.Property<DateTime?>("DateLastMediaAdded")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260113233000_AddForeignKeyToOwnerId.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260113233000_AddForeignKeyToOwnerId.Designer.cs
@@ -955,6 +955,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260113233500_DropExtraIdsColumn.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260113233500_DropExtraIdsColumn.Designer.cs
@@ -952,6 +952,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260116114245_AddLatestItemsDateCreatedIndexes.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260116114245_AddLatestItemsDateCreatedIndexes.Designer.cs
@@ -952,6 +952,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260118182305_AddIndicesToImageInfo.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260118182305_AddIndicesToImageInfo.Designer.cs
@@ -954,6 +954,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260130232147_AddBaseItemNameIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260130232147_AddBaseItemNameIndex.Designer.cs
@@ -956,6 +956,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260206224832_IndexOptimizations.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260206224832_IndexOptimizations.Designer.cs
@@ -956,6 +956,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260215201634_ChangePrimaryVersionIdToGuid.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260215201634_ChangePrimaryVersionIdToGuid.Designer.cs
@@ -956,6 +956,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260308123920_AddTypeCleanNameIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260308123920_AddTypeCleanNameIndex.Designer.cs
@@ -958,6 +958,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260504075755_AddPartialIndexForItemCounts.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260504075755_AddPartialIndexForItemCounts.Designer.cs
@@ -961,6 +961,9 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260522092303_AddNormalizedUsername.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260522092303_AddNormalizedUsername.Designer.cs
@@ -961,6 +961,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260524120336_AddUniqueNormalizedUsernameIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260524120336_AddUniqueNormalizedUsernameIndex.Designer.cs
@@ -961,6 +961,9 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<bool?>("IsInterlaced")
                         .HasColumnType("INTEGER");
 
+                    b.Property<bool>("IsOriginal")
+                        .HasColumnType("INTEGER");
+
                     b.Property<string>("KeyFrames")
                         .HasColumnType("TEXT");
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260724185102_AddPrimaryVersionIdIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260724185102_AddPrimaryVersionIdIndex.Designer.cs
@@ -818,22 +818,20 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<Guid>("ParentId")
                         .HasColumnType("TEXT");
 
+                    b.Property<int>("SortOrder")
+                        .HasColumnType("INTEGER");
+
                     b.Property<Guid>("ChildId")
                         .HasColumnType("TEXT");
 
                     b.Property<int>("ChildType")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("SortOrder")
-                        .HasColumnType("INTEGER");
-
-                    b.HasKey("ParentId", "ChildId");
+                    b.HasKey("ParentId", "SortOrder");
 
                     b.HasIndex("ChildId", "ChildType");
 
                     b.HasIndex("ParentId", "ChildType");
-
-                    b.HasIndex("ParentId", "SortOrder");
 
                     b.ToTable("LinkedChildren", (string)null);
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260728170000_AddPeopleNameLowerIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260728170000_AddPeopleNameLowerIndex.Designer.cs
@@ -818,22 +818,20 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Property<Guid>("ParentId")
                         .HasColumnType("TEXT");
 
+                    b.Property<int>("SortOrder")
+                        .HasColumnType("INTEGER");
+
                     b.Property<Guid>("ChildId")
                         .HasColumnType("TEXT");
 
                     b.Property<int>("ChildType")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("SortOrder")
-                        .HasColumnType("INTEGER");
-
-                    b.HasKey("ParentId", "ChildId");
+                    b.HasKey("ParentId", "SortOrder");
 
                     b.HasIndex("ChildId", "ChildType");
 
                     b.HasIndex("ParentId", "ChildType");
-
-                    b.HasIndex("ParentId", "SortOrder");
 
                     b.ToTable("LinkedChildren", (string)null);
 
@@ -1103,58 +1101,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .HasFilter("[UserId] IS NOT NULL");
 
                     b.ToTable("Permissions");
-
-                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.PlaybackItem", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
-
-                    b.Property<DateTime>("DateCreated")
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid?>("ItemId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("MediaType")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("Title")
-                        .HasColumnType("TEXT");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ItemId");
-
-                    b.ToTable("PlaybackItems");
-
-                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.PlaybackItemKey", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("Key")
-                        .IsRequired()
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid>("PlaybackItemId")
-                        .HasColumnType("TEXT");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Key")
-                        .IsUnique();
-
-                    b.HasIndex("PlaybackItemId");
-
-                    b.ToTable("PlaybackItemKeys");
 
                     b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
                 });
@@ -1526,131 +1472,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
                 });
 
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.UserPlaybackHistory", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
-
-                    b.Property<long?>("ActualBytesTransferred")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<int?>("Bitrate")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("ClientName")
-                        .HasColumnType("TEXT");
-
-                    b.Property<DateTime>("DateStarted")
-                        .HasColumnType("TEXT");
-
-                    b.Property<DateTime>("DateStopped")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("DeviceId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("DeviceName")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("MediaSourceId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<string>("PlaySessionId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<Guid>("PlaybackItemId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<long>("PlayedDurationTicks")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("PlayedToCompletion")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long?>("RunTimeTicks")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long>("StartPositionTicks")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<long>("StopPositionTicks")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool>("Transcoded")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("TEXT");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("PlaybackItemId", "PlayedToCompletion");
-
-                    b.HasIndex("UserId", "DateStopped");
-
-                    b.HasIndex("UserId", "PlaybackItemId", "DateStopped");
-
-                    b.ToTable("UserPlaybackHistory");
-
-                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.UserPlaybackHistoryStream", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("TEXT");
-
-                    b.Property<int?>("Bitrate")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<int?>("Channels")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("Codec")
-                        .HasColumnType("TEXT");
-
-                    b.Property<int?>("Height")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<Guid>("HistoryId")
-                        .HasColumnType("TEXT");
-
-                    b.Property<bool?>("IsForced")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool?>("IsHearingImpaired")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("Language")
-                        .HasColumnType("TEXT");
-
-                    b.Property<int>("Origin")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<int>("StreamType")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<string>("VideoRange")
-                        .HasColumnType("TEXT");
-
-                    b.Property<int?>("Width")
-                        .HasColumnType("INTEGER");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("HistoryId");
-
-                    b.HasIndex("StreamType", "Origin", "Language");
-
-                    b.HasIndex("StreamType", "Origin", "VideoRange");
-
-                    b.ToTable("UserPlaybackHistoryStreams");
-
-                    b.HasAnnotation("Sqlite:UseSqlReturningClause", false);
-                });
-
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.AccessSchedule", b =>
                 {
                     b.HasOne("Jellyfin.Database.Implementations.Entities.User", null)
@@ -1884,17 +1705,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
                 });
 
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.PlaybackItemKey", b =>
-                {
-                    b.HasOne("Jellyfin.Database.Implementations.Entities.PlaybackItem", "PlaybackItem")
-                        .WithMany("Keys")
-                        .HasForeignKey("PlaybackItemId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("PlaybackItem");
-                });
-
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.Preference", b =>
                 {
                     b.HasOne("Jellyfin.Database.Implementations.Entities.User", null)
@@ -1931,28 +1741,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("Item");
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.UserPlaybackHistory", b =>
-                {
-                    b.HasOne("Jellyfin.Database.Implementations.Entities.PlaybackItem", "PlaybackItem")
-                        .WithMany("History")
-                        .HasForeignKey("PlaybackItemId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("PlaybackItem");
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.UserPlaybackHistoryStream", b =>
-                {
-                    b.HasOne("Jellyfin.Database.Implementations.Entities.UserPlaybackHistory", "History")
-                        .WithMany("Streams")
-                        .HasForeignKey("HistoryId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("History");
                 });
 
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.BaseItemEntity", b =>
@@ -2003,13 +1791,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("BaseItems");
                 });
 
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.PlaybackItem", b =>
-                {
-                    b.Navigation("History");
-
-                    b.Navigation("Keys");
-                });
-
             modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.User", b =>
                 {
                     b.Navigation("AccessSchedules");
@@ -2023,11 +1804,6 @@ namespace Jellyfin.Server.Implementations.Migrations
                     b.Navigation("Preferences");
 
                     b.Navigation("ProfileImage");
-                });
-
-            modelBuilder.Entity("Jellyfin.Database.Implementations.Entities.UserPlaybackHistory", b =>
-                {
-                    b.Navigation("Streams");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260728182152_AddPeopleItemMapCoveringIndex.Designer.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Migrations/20260728182152_AddPeopleItemMapCoveringIndex.Designer.cs
@@ -818,22 +818,20 @@ namespace Jellyfin.Database.Providers.Sqlite.Migrations
                     b.Property<Guid>("ParentId")
                         .HasColumnType("TEXT");
 
+                    b.Property<int>("SortOrder")
+                        .HasColumnType("INTEGER");
+
                     b.Property<Guid>("ChildId")
                         .HasColumnType("TEXT");
 
                     b.Property<int>("ChildType")
                         .HasColumnType("INTEGER");
 
-                    b.Property<int?>("SortOrder")
-                        .HasColumnType("INTEGER");
-
-                    b.HasKey("ParentId", "ChildId");
+                    b.HasKey("ParentId", "SortOrder");
 
                     b.HasIndex("ChildId", "ChildType");
 
                     b.HasIndex("ParentId", "ChildType");
-
-                    b.HasIndex("ParentId", "SortOrder");
 
                     b.ToTable("LinkedChildren", (string)null);
 


### PR DESCRIPTION
Because PRs and their EF core migrations are often created independently, designer changes from one PR merge cleanly with the ones from another one, but we actually lose information.

**Changes**
Fix all designer definitions to include the changes from all previous migrations.

**Code assistance**
Opus 5 was used to find, validate and fix the dirfts

**Issues**

