### PR TITLE
Fix TMDb links and season metadata for series ordered by an episode group

### DIFF
--- a/Jellyfin.Api/Controllers/ItemLookupController.cs
+++ b/Jellyfin.Api/Controllers/ItemLookupController.cs
@@ -3,16 +3,14 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
-using Jellyfin.Api.Helpers;
+using Jellyfin.Api.Models.LookupDtos;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Providers;
@@ -20,6 +18,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Providers = MediaBrowser.Controller.Providers;
 
 namespace Jellyfin.Api.Controllers;
 
@@ -30,7 +29,7 @@ namespace Jellyfin.Api.Controllers;
 [Authorize]
 public class ItemLookupController : BaseJellyfinApiController
 {
-    private readonly IProviderManager _providerManager;
+    private readonly Providers.IProviderManager _providerManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILibraryManager _libraryManager;
     private readonly ILogger<ItemLookupController> _logger;
@@ -38,12 +37,12 @@ public class ItemLookupController : BaseJellyfinApiController
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemLookupController"/> class.
     /// </summary>
-    /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+    /// <param name="providerManager">Instance of the <see cref="Providers.IProviderManager"/> interface.</param>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{ItemLookupController}"/> interface.</param>
     public ItemLookupController(
-        IProviderManager providerManager,
+        Providers.IProviderManager providerManager,
         IFileSystem fileSystem,
         ILibraryManager libraryManager,
         ILogger<ItemLookupController> logger)
@@ -88,7 +87,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Movie")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMovieRemoteSearchResults([FromBody, Required] RemoteSearchQuery<MovieInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Movie, MovieInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Movie, Providers.MovieInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -105,7 +104,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Trailer")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetTrailerRemoteSearchResults([FromBody, Required] RemoteSearchQuery<TrailerInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Trailer, TrailerInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Trailer, Providers.TrailerInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -122,7 +121,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicVideo")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicVideoRemoteSearchResults([FromBody, Required] RemoteSearchQuery<MusicVideoInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicVideo, MusicVideoInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicVideo, Providers.MusicVideoInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -139,7 +138,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Series")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetSeriesRemoteSearchResults([FromBody, Required] RemoteSearchQuery<SeriesInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Series, SeriesInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Series, Providers.SeriesInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -156,7 +155,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/BoxSet")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetBoxSetRemoteSearchResults([FromBody, Required] RemoteSearchQuery<BoxSetInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<BoxSet, BoxSetInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<BoxSet, Providers.BoxSetInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -173,7 +172,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicArtist")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicArtistRemoteSearchResults([FromBody, Required] RemoteSearchQuery<ArtistInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicArtist, ArtistInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicArtist, Providers.ArtistInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -190,7 +189,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicAlbum")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicAlbumRemoteSearchResults([FromBody, Required] RemoteSearchQuery<AlbumInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicAlbum, AlbumInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicAlbum, Providers.AlbumInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -208,7 +207,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [Authorize(Policy = Policies.RequiresElevation)]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetPersonRemoteSearchResults([FromBody, Required] RemoteSearchQuery<PersonLookupInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Person, PersonLookupInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Person, Providers.PersonLookupInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -225,7 +224,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Book")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetBookRemoteSearchResults([FromBody, Required] RemoteSearchQuery<BookInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Book, BookInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Book, Providers.BookInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -267,10 +266,10 @@ public class ItemLookupController : BaseJellyfinApiController
         item.SetProviderIds(searchResult.ProviderIds);
         await _providerManager.RefreshFullItem(
             item,
-            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            new Providers.MetadataRefreshOptions(new Providers.DirectoryService(_fileSystem))
             {
-                MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
-                ImageRefreshMode = MetadataRefreshMode.FullRefresh,
+                MetadataRefreshMode = Providers.MetadataRefreshMode.FullRefresh,
+                ImageRefreshMode = Providers.MetadataRefreshMode.FullRefresh,
                 ReplaceAllMetadata = true,
                 ReplaceAllImages = replaceAllImages,
                 SearchResult = searchResult,

--- a/Jellyfin.Api/Controllers/ItemLookupController.cs
+++ b/Jellyfin.Api/Controllers/ItemLookupController.cs
@@ -6,19 +6,20 @@ using System.Threading.Tasks;
 using Jellyfin.Api.Constants;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Api.Helpers;
+using Jellyfin.Api.Models.LookupDtos;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Providers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Providers = MediaBrowser.Controller.Providers;
 
 namespace Jellyfin.Api.Controllers;
 
@@ -29,7 +30,7 @@ namespace Jellyfin.Api.Controllers;
 [Authorize]
 public class ItemLookupController : BaseJellyfinApiController
 {
-    private readonly IProviderManager _providerManager;
+    private readonly Providers.IProviderManager _providerManager;
     private readonly IFileSystem _fileSystem;
     private readonly ILibraryManager _libraryManager;
     private readonly ILogger<ItemLookupController> _logger;
@@ -37,12 +38,12 @@ public class ItemLookupController : BaseJellyfinApiController
     /// <summary>
     /// Initializes a new instance of the <see cref="ItemLookupController"/> class.
     /// </summary>
-    /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface.</param>
+    /// <param name="providerManager">Instance of the <see cref="Providers.IProviderManager"/> interface.</param>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
     /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{ItemLookupController}"/> interface.</param>
     public ItemLookupController(
-        IProviderManager providerManager,
+        Providers.IProviderManager providerManager,
         IFileSystem fileSystem,
         ILibraryManager libraryManager,
         ILogger<ItemLookupController> logger)
@@ -87,7 +88,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Movie")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMovieRemoteSearchResults([FromBody, Required] RemoteSearchQuery<MovieInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Movie, MovieInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Movie, Providers.MovieInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -104,7 +105,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Trailer")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetTrailerRemoteSearchResults([FromBody, Required] RemoteSearchQuery<TrailerInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Trailer, TrailerInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Trailer, Providers.TrailerInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -121,7 +122,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicVideo")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicVideoRemoteSearchResults([FromBody, Required] RemoteSearchQuery<MusicVideoInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicVideo, MusicVideoInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicVideo, Providers.MusicVideoInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -138,7 +139,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Series")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetSeriesRemoteSearchResults([FromBody, Required] RemoteSearchQuery<SeriesInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Series, SeriesInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Series, Providers.SeriesInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -155,7 +156,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/BoxSet")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetBoxSetRemoteSearchResults([FromBody, Required] RemoteSearchQuery<BoxSetInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<BoxSet, BoxSetInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<BoxSet, Providers.BoxSetInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -172,7 +173,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicArtist")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicArtistRemoteSearchResults([FromBody, Required] RemoteSearchQuery<ArtistInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicArtist, ArtistInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicArtist, Providers.ArtistInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -189,7 +190,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/MusicAlbum")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetMusicAlbumRemoteSearchResults([FromBody, Required] RemoteSearchQuery<AlbumInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<MusicAlbum, AlbumInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<MusicAlbum, Providers.AlbumInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -207,7 +208,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [Authorize(Policy = Policies.RequiresElevation)]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetPersonRemoteSearchResults([FromBody, Required] RemoteSearchQuery<PersonLookupInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Person, PersonLookupInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Person, Providers.PersonLookupInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -224,7 +225,7 @@ public class ItemLookupController : BaseJellyfinApiController
     [HttpPost("Items/RemoteSearch/Book")]
     public async Task<ActionResult<IEnumerable<RemoteSearchResult>>> GetBookRemoteSearchResults([FromBody, Required] RemoteSearchQuery<BookInfo> query)
     {
-        var results = await _providerManager.GetRemoteSearchResults<Book, BookInfo>(query, CancellationToken.None)
+        var results = await _providerManager.GetRemoteSearchResults<Book, Providers.BookInfo>(query.ToLookupQuery(searchInfo => searchInfo.ToLookupInfo()), CancellationToken.None)
             .ConfigureAwait(false);
         return Ok(results);
     }
@@ -266,10 +267,10 @@ public class ItemLookupController : BaseJellyfinApiController
         item.ProviderIds = searchResult.ProviderIds;
         await _providerManager.RefreshFullItem(
             item,
-            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+            new Providers.MetadataRefreshOptions(new Providers.DirectoryService(_fileSystem))
             {
-                MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
-                ImageRefreshMode = MetadataRefreshMode.FullRefresh,
+                MetadataRefreshMode = Providers.MetadataRefreshMode.FullRefresh,
+                ImageRefreshMode = Providers.MetadataRefreshMode.FullRefresh,
                 ReplaceAllMetadata = true,
                 ReplaceAllImages = replaceAllImages,
                 SearchResult = searchResult,

--- a/Jellyfin.Api/Models/LookupDtos/AlbumInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/AlbumInfo.cs
@@ -9,8 +9,10 @@ namespace Jellyfin.Api.Models.LookupDtos
     {
         public AlbumInfo()
         {
+#pragma warning disable CS0618 // The deprecated members are still carried until they are removed.
             ArtistProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             SongInfos = new List<SongInfo>();
+#pragma warning restore CS0618
             AlbumArtists = Array.Empty<string>();
         }
 
@@ -21,11 +23,16 @@ namespace Jellyfin.Api.Models.LookupDtos
         public IReadOnlyList<string> AlbumArtists { get; set; }
 
         /// <summary>
-        /// Gets or sets the artist provider ids.
+        /// Gets or sets the artist provider ids. Deprecated, use ProviderIds instead.
         /// </summary>
         /// <value>The artist provider ids.</value>
+        [Obsolete("Server side only. Filled in from the parent artist when the server looks the album up.")]
         public Dictionary<string, string> ArtistProviderIds { get; set; }
 
+        /// <summary>
+        /// Gets or sets the songs of the album. Deprecated, use AlbumArtists instead.
+        /// </summary>
+        [Obsolete("Server side only. Filled in from the album's tracks when the server looks the album up.")]
         public List<SongInfo> SongInfos { get; set; }
     }
 }

--- a/Jellyfin.Api/Models/LookupDtos/AlbumInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/AlbumInfo.cs
@@ -1,0 +1,31 @@
+#pragma warning disable CA1002, CA2227, CS1591
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class AlbumInfo : ItemLookupInfo
+    {
+        public AlbumInfo()
+        {
+            ArtistProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            SongInfos = new List<SongInfo>();
+            AlbumArtists = Array.Empty<string>();
+        }
+
+        /// <summary>
+        /// Gets or sets the album artist.
+        /// </summary>
+        /// <value>The album artist.</value>
+        public IReadOnlyList<string> AlbumArtists { get; set; }
+
+        /// <summary>
+        /// Gets or sets the artist provider ids.
+        /// </summary>
+        /// <value>The artist provider ids.</value>
+        public Dictionary<string, string> ArtistProviderIds { get; set; }
+
+        public List<SongInfo> SongInfos { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/ArtistInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/ArtistInfo.cs
@@ -1,0 +1,16 @@
+#pragma warning disable CA1002, CA2227, CS1591
+
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class ArtistInfo : ItemLookupInfo
+    {
+        public ArtistInfo()
+        {
+            SongInfos = new List<SongInfo>();
+        }
+
+        public List<SongInfo> SongInfos { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/ArtistInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/ArtistInfo.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CA1002, CA2227, CS1591
 
+using System;
 using System.Collections.Generic;
 
 namespace Jellyfin.Api.Models.LookupDtos
@@ -8,9 +9,15 @@ namespace Jellyfin.Api.Models.LookupDtos
     {
         public ArtistInfo()
         {
+#pragma warning disable CS0618 // The deprecated members are still carried until they are removed.
             SongInfos = new List<SongInfo>();
+#pragma warning restore CS0618
         }
 
+        /// <summary>
+        /// Gets or sets the songs of the artist. Deprecated, no search provider reads it.
+        /// </summary>
+        [Obsolete("Server side only. Filled in from the artist's tracks when the server looks the artist up.")]
         public List<SongInfo> SongInfos { get; set; }
     }
 }

--- a/Jellyfin.Api/Models/LookupDtos/BookInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/BookInfo.cs
@@ -1,0 +1,15 @@
+#nullable disable
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for books.
+    /// </summary>
+    public class BookInfo : ItemLookupInfo
+    {
+        /// <summary>
+        /// Gets or sets the name of the series the book belongs to.
+        /// </summary>
+        public string SeriesName { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/BoxSetInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/BoxSetInfo.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for box sets.
+    /// </summary>
+    public class BoxSetInfo : ItemLookupInfo
+    {
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/ItemLookupInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/ItemLookupInfo.cs
@@ -1,0 +1,68 @@
+#nullable disable
+
+#pragma warning disable CA2227, CS1591
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class ItemLookupInfo
+    {
+        public ItemLookupInfo()
+        {
+            IsAutomated = true;
+            ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the original title.
+        /// </summary>
+        /// <value>The original title of the item.</value>
+        public string OriginalTitle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path.
+        /// </summary>
+        /// <value>The path.</value>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata language.
+        /// </summary>
+        /// <value>The metadata language.</value>
+        public string MetadataLanguage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the metadata country code.
+        /// </summary>
+        /// <value>The metadata country code.</value>
+        public string MetadataCountryCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider ids.
+        /// </summary>
+        /// <value>The provider ids.</value>
+        public Dictionary<string, string> ProviderIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the year.
+        /// </summary>
+        /// <value>The year.</value>
+        public int? Year { get; set; }
+
+        public int? IndexNumber { get; set; }
+
+        public int? ParentIndexNumber { get; set; }
+
+        public DateTime? PremiereDate { get; set; }
+
+        public bool IsAutomated { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/ItemLookupInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/ItemLookupInfo.cs
@@ -11,7 +11,9 @@ namespace Jellyfin.Api.Models.LookupDtos
     {
         public ItemLookupInfo()
         {
+#pragma warning disable CS0618 // The deprecated members are still carried until they are removed.
             IsAutomated = true;
+#pragma warning restore CS0618
             ProviderIds = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -28,9 +30,10 @@ namespace Jellyfin.Api.Models.LookupDtos
         public string OriginalTitle { get; set; }
 
         /// <summary>
-        /// Gets or sets the path.
+        /// Gets or sets the path. Deprecated, the server fills this in from the item being identified.
         /// </summary>
         /// <value>The path.</value>
+        [Obsolete("Server side only. The path of the item on the server, no search provider reads it from a request.")]
         public string Path { get; set; }
 
         /// <summary>
@@ -63,6 +66,11 @@ namespace Jellyfin.Api.Models.LookupDtos
 
         public DateTime? PremiereDate { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the lookup was triggered by a scheduled refresh.
+        /// Deprecated, a remote search is user initiated by definition.
+        /// </summary>
+        [Obsolete("Server side only. Set by the refresh pipeline and never read from a request.")]
         public bool IsAutomated { get; set; }
     }
 }

--- a/Jellyfin.Api/Models/LookupDtos/LookupDtoExtensions.cs
+++ b/Jellyfin.Api/Models/LookupDtos/LookupDtoExtensions.cs
@@ -1,3 +1,6 @@
+// The mapper has to keep carrying the deprecated members for as long as they are part of the contract.
+#pragma warning disable CS0618
+
 using System;
 using System.Collections.Generic;
 using Internal = MediaBrowser.Controller.Providers;

--- a/Jellyfin.Api/Models/LookupDtos/LookupDtoExtensions.cs
+++ b/Jellyfin.Api/Models/LookupDtos/LookupDtoExtensions.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using Internal = MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Api.Models.LookupDtos;
+
+/// <summary>
+/// Maps the remote search request bodies onto the lookup info the metadata providers consume.
+/// </summary>
+/// <remarks>
+/// The two are kept apart so the provider types can change without altering the API contract.
+/// The DTOs therefore mirror the serialized shape of the lookup info exactly and must not drift from it.
+/// </remarks>
+public static class LookupDtoExtensions
+{
+    /// <summary>
+    /// Converts a remote search query.
+    /// </summary>
+    /// <param name="query">The query to convert.</param>
+    /// <param name="convert">Converts the contained search info.</param>
+    /// <typeparam name="TDto">The type of the search info to convert.</typeparam>
+    /// <typeparam name="TInfo">The type of the lookup info to convert to.</typeparam>
+    /// <returns>The converted query.</returns>
+    public static Internal.RemoteSearchQuery<TInfo> ToLookupQuery<TDto, TInfo>(this RemoteSearchQuery<TDto> query, Func<TDto, TInfo> convert)
+        where TDto : ItemLookupInfo
+        where TInfo : Internal.ItemLookupInfo
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(convert);
+
+        return new Internal.RemoteSearchQuery<TInfo>
+        {
+            // Left null when the client sends no search info, so the behaviour matches binding it directly.
+            SearchInfo = query.SearchInfo is null ? null! : convert(query.SearchInfo),
+            ItemId = query.ItemId,
+            SearchProviderName = query.SearchProviderName,
+            IncludeDisabledProviders = query.IncludeDisabledProviders
+        };
+    }
+
+    /// <summary>
+    /// Converts movie lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.MovieInfo ToLookupInfo(this MovieInfo dto)
+        => CopyTo(dto, new Internal.MovieInfo());
+
+    /// <summary>
+    /// Converts trailer lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.TrailerInfo ToLookupInfo(this TrailerInfo dto)
+        => CopyTo(dto, new Internal.TrailerInfo());
+
+    /// <summary>
+    /// Converts series lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.SeriesInfo ToLookupInfo(this SeriesInfo dto)
+        => CopyTo(dto, new Internal.SeriesInfo());
+
+    /// <summary>
+    /// Converts box set lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.BoxSetInfo ToLookupInfo(this BoxSetInfo dto)
+        => CopyTo(dto, new Internal.BoxSetInfo());
+
+    /// <summary>
+    /// Converts person lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.PersonLookupInfo ToLookupInfo(this PersonLookupInfo dto)
+        => CopyTo(dto, new Internal.PersonLookupInfo());
+
+    /// <summary>
+    /// Converts book lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.BookInfo ToLookupInfo(this BookInfo dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var info = CopyTo(dto, new Internal.BookInfo());
+        info.SeriesName = dto.SeriesName;
+
+        return info;
+    }
+
+    /// <summary>
+    /// Converts music video lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.MusicVideoInfo ToLookupInfo(this MusicVideoInfo dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var info = CopyTo(dto, new Internal.MusicVideoInfo());
+        info.Artists = dto.Artists;
+
+        return info;
+    }
+
+    /// <summary>
+    /// Converts artist lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.ArtistInfo ToLookupInfo(this ArtistInfo dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var info = CopyTo(dto, new Internal.ArtistInfo());
+        // Null-forgiving because a client can send an explicit null, exactly as it could before the split.
+        info.SongInfos = ToLookupInfos(dto.SongInfos)!;
+
+        return info;
+    }
+
+    /// <summary>
+    /// Converts album lookup info.
+    /// </summary>
+    /// <param name="dto">The lookup info to convert.</param>
+    /// <returns>The converted lookup info.</returns>
+    public static Internal.AlbumInfo ToLookupInfo(this AlbumInfo dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        var info = CopyTo(dto, new Internal.AlbumInfo());
+        info.AlbumArtists = dto.AlbumArtists;
+        info.ArtistProviderIds = dto.ArtistProviderIds;
+        // Null-forgiving because a client can send an explicit null, exactly as it could before the split.
+        info.SongInfos = ToLookupInfos(dto.SongInfos)!;
+
+        return info;
+    }
+
+    private static List<Internal.SongInfo>? ToLookupInfos(List<SongInfo>? songInfos)
+    {
+        if (songInfos is null)
+        {
+            return null;
+        }
+
+        var infos = new List<Internal.SongInfo>(songInfos.Count);
+        foreach (var songInfo in songInfos)
+        {
+            var info = CopyTo(songInfo, new Internal.SongInfo());
+            info.Album = songInfo.Album;
+            info.AlbumArtists = songInfo.AlbumArtists;
+            info.Artists = songInfo.Artists;
+
+            infos.Add(info);
+        }
+
+        return infos;
+    }
+
+    private static TInfo CopyTo<TInfo>(ItemLookupInfo dto, TInfo info)
+        where TInfo : Internal.ItemLookupInfo
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        info.Name = dto.Name;
+        info.OriginalTitle = dto.OriginalTitle;
+        info.Path = dto.Path;
+        info.MetadataLanguage = dto.MetadataLanguage;
+        info.MetadataCountryCode = dto.MetadataCountryCode;
+        info.ProviderIds = dto.ProviderIds;
+        info.Year = dto.Year;
+        info.IndexNumber = dto.IndexNumber;
+        info.ParentIndexNumber = dto.ParentIndexNumber;
+        info.PremiereDate = dto.PremiereDate;
+        info.IsAutomated = dto.IsAutomated;
+
+        return info;
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/MovieInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/MovieInfo.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for movies.
+    /// </summary>
+    public class MovieInfo : ItemLookupInfo
+    {
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/MusicVideoInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/MusicVideoInfo.cs
@@ -1,0 +1,13 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class MusicVideoInfo : ItemLookupInfo
+    {
+        public IReadOnlyList<string> Artists { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/PersonLookupInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/PersonLookupInfo.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for persons.
+    /// </summary>
+    public class PersonLookupInfo : ItemLookupInfo
+    {
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/RemoteSearchQuery.cs
+++ b/Jellyfin.Api/Models/LookupDtos/RemoteSearchQuery.cs
@@ -1,0 +1,27 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+using System;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class RemoteSearchQuery<T>
+        where T : ItemLookupInfo
+    {
+        public T SearchInfo { get; set; }
+
+        public Guid ItemId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the provider name to search within if set.
+        /// </summary>
+        public string SearchProviderName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether disabled providers should be included.
+        /// </summary>
+        /// <value><c>true</c> if disabled providers should be included.</value>
+        public bool IncludeDisabledProviders { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/SeriesInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/SeriesInfo.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for series.
+    /// </summary>
+    public class SeriesInfo : ItemLookupInfo
+    {
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/SongInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/SongInfo.cs
@@ -1,0 +1,24 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    public class SongInfo : ItemLookupInfo
+    {
+        public SongInfo()
+        {
+            Artists = Array.Empty<string>();
+            AlbumArtists = Array.Empty<string>();
+        }
+
+        public IReadOnlyList<string> AlbumArtists { get; set; }
+
+        public string Album { get; set; }
+
+        public IReadOnlyList<string> Artists { get; set; }
+    }
+}

--- a/Jellyfin.Api/Models/LookupDtos/TrailerInfo.cs
+++ b/Jellyfin.Api/Models/LookupDtos/TrailerInfo.cs
@@ -1,0 +1,9 @@
+namespace Jellyfin.Api.Models.LookupDtos
+{
+    /// <summary>
+    /// The lookup info for trailers.
+    /// </summary>
+    public class TrailerInfo : ItemLookupInfo
+    {
+    }
+}

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -524,6 +524,8 @@ namespace MediaBrowser.Controller.Entities.TV
         {
             var info = GetItemLookupInfo<SeriesInfo>();
 
+            info.DisplayOrder = DisplayOrder;
+
             return info;
         }
 

--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -533,6 +533,8 @@ namespace MediaBrowser.Controller.Entities.TV
         {
             var info = GetItemLookupInfo<SeriesInfo>();
 
+            info.DisplayOrder = DisplayOrder;
+
             return info;
         }
 

--- a/MediaBrowser.Controller/Providers/SeriesInfo.cs
+++ b/MediaBrowser.Controller/Providers/SeriesInfo.cs
@@ -5,5 +5,9 @@ namespace MediaBrowser.Controller.Providers
     /// </summary>
     public class SeriesInfo : ItemLookupInfo
     {
+        /// <summary>
+        /// Gets or sets the episode order the series is displayed in.
+        /// </summary>
+        public string? DisplayOrder { get; set; }
     }
 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -124,6 +124,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                     // Forces a deep copy of the first TvEpisode, so we don't modify the original because it's cached
                     episodeResult = new TvEpisode()
                     {
+                        // The id of the first episode, so a multi-episode file still links to a real TMDb episode.
+                        Id = result[0].Id,
                         Name = result[0].Name,
                         Overview = result[0].Overview,
                         AirDate = result[0].AirDate,
@@ -189,6 +191,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             };
 
             var externalIds = episodeResult.ExternalIds;
+            item.TrySetProviderId(MetadataProvider.Tmdb, episodeResult.Id?.ToString(CultureInfo.InvariantCulture));
             item.TrySetProviderId(MetadataProvider.Tvdb, externalIds?.TvdbId);
             item.TrySetProviderId(MetadataProvider.Imdb, externalIds?.ImdbId);
             item.TrySetProviderId(MetadataProvider.TvRage, externalIds?.TvrageId);

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbEpisodeProvider.cs
@@ -125,6 +125,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                     // Forces a deep copy of the first TvEpisode, so we don't modify the original because it's cached
                     episodeResult = new TvEpisode()
                     {
+                        // The id of the first episode, so a multi-episode file still links to a real TMDb episode.
+                        Id = result[0].Id,
                         Name = result[0].Name,
                         Overview = result[0].Overview,
                         AirDate = result[0].AirDate,
@@ -190,6 +192,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             };
 
             var externalIds = episodeResult.ExternalIds;
+            item.TrySetProviderId(MetadataProvider.Tmdb, episodeResult.Id?.ToString(CultureInfo.InvariantCulture));
             item.TrySetProviderId(MetadataProvider.Tvdb, externalIds?.TvdbId);
             item.TrySetProviderId(MetadataProvider.Imdb, externalIds?.ImdbId);
             item.TrySetProviderId(MetadataProvider.TvRage, externalIds?.TvrageId);

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -59,10 +59,21 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             if (season?.IndexNumber is null || series?.TryGetTmdbId(out seriesTmdbId) != true)
             {
-                return Enumerable.Empty<RemoteImageInfo>();
+                return [];
             }
 
             var language = item.GetPreferredMetadataLanguage();
+
+            // The season number counts episode groups when the series is ordered by one, and TMDb has no artwork
+            // for a group, so there is nothing to offer rather than the posters of an unrelated season.
+            var groupCollection = await _tmdbClientManager
+                .GetSeriesGroupAsync(seriesTmdbId, series?.DisplayOrder, null, null, null, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (groupCollection?.Groups?.Exists(g => g.Order == season.IndexNumber.Value) == true)
+            {
+                return [];
+            }
 
             // TODO use image languages if All Languages isn't toggled, but there's currently no way to get that value in here
             var seasonResult = await _tmdbClientManager
@@ -72,7 +83,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             var posters = seasonResult?.Images?.Posters;
             if (posters is null)
             {
-                return Enumerable.Empty<RemoteImageInfo>();
+                return [];
             }
 
             return _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language);

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonImageProvider.cs
@@ -61,10 +61,21 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             if (seriesTmdbId <= 0 || season?.IndexNumber is null)
             {
-                return Enumerable.Empty<RemoteImageInfo>();
+                return [];
             }
 
             var language = item.GetPreferredMetadataLanguage();
+
+            // The season number counts episode groups when the series is ordered by one, and TMDb has no artwork
+            // for a group, so there is nothing to offer rather than the posters of an unrelated season.
+            var groupCollection = await _tmdbClientManager
+                .GetSeriesGroupAsync(seriesTmdbId, series?.DisplayOrder, null, null, null, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (groupCollection?.Groups?.Exists(g => g.Order == season.IndexNumber.Value) == true)
+            {
+                return [];
+            }
 
             // TODO use image languages if All Languages isn't toggled, but there's currently no way to get that value in here
             var seasonResult = await _tmdbClientManager
@@ -74,7 +85,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             var posters = seasonResult?.Images?.Posters;
             if (posters is null)
             {
-                return Enumerable.Empty<RemoteImageInfo>();
+                return [];
             }
 
             return _tmdbClientManager.ConvertPostersToRemoteImageInfo(posters, language);

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using TMDbLib.Objects.TvShows;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 {
@@ -53,6 +54,20 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             if (!seasonNumber.HasValue || !TmdbUtils.TryParseTmdbId(seriesTmdbId, out var seriesId))
             {
                 return result;
+            }
+
+            var seriesId = Convert.ToInt32(seriesTmdbId, CultureInfo.InvariantCulture);
+
+            // When the series is ordered by an episode group, the season number counts groups rather than TMDb
+            // seasons, so the group has to be resolved instead of fetching a season that holds unrelated episodes.
+            var groupCollection = await _tmdbClientManager
+                .GetSeriesGroupAsync(seriesId, info.SeriesDisplayOrder, info.MetadataLanguage, TmdbUtils.GetImageLanguagesParam(info.MetadataLanguage, info.MetadataCountryCode), info.MetadataCountryCode, cancellationToken)
+                .ConfigureAwait(false);
+
+            var group = groupCollection?.Groups?.Find(g => g.Order == seasonNumber.Value);
+            if (group is not null)
+            {
+                return MapGroupToSeason(group, seasonNumber.Value, config.ImportSeasonName);
             }
 
             var seasonResult = await _tmdbClientManager
@@ -155,6 +170,44 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Maps an episode group to a season.
+        /// </summary>
+        /// <remarks>
+        /// A group spans whatever TMDb seasons its episodes come from, so only the group's own name and the air date
+        /// of its first episode describe it. TMDb has neither an overview, artwork nor credits for a group.
+        /// </remarks>
+        /// <param name="group">The episode group the season maps to.</param>
+        /// <param name="seasonNumber">The season number.</param>
+        /// <param name="importSeasonName">Whether the season name should be imported.</param>
+        /// <returns>The season metadata.</returns>
+        internal static MetadataResult<Season> MapGroupToSeason(TvGroup group, int seasonNumber, bool importSeasonName)
+        {
+            var airDate = group.Episodes?
+                .Where(e => e.AirDate.HasValue)
+                .Min(e => e.AirDate);
+
+            var season = new Season
+            {
+                IndexNumber = seasonNumber,
+                PremiereDate = airDate,
+                ProductionYear = airDate?.Year
+            };
+
+            if (importSeasonName)
+            {
+                season.Name = group.Name;
+            }
+
+            season.TrySetProviderId(TmdbUtils.EpisodeGroupProviderKey, group.Id);
+
+            return new MetadataResult<Season>
+            {
+                HasMetadata = true,
+                Item = season
+            };
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeasonProvider.cs
@@ -13,6 +13,7 @@ using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
+using TMDbLib.Objects.TvShows;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 {
@@ -53,8 +54,22 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
                 return result;
             }
 
+            var seriesId = Convert.ToInt32(seriesTmdbId, CultureInfo.InvariantCulture);
+
+            // When the series is ordered by an episode group, the season number counts groups rather than TMDb
+            // seasons, so the group has to be resolved instead of fetching a season that holds unrelated episodes.
+            var groupCollection = await _tmdbClientManager
+                .GetSeriesGroupAsync(seriesId, info.SeriesDisplayOrder, info.MetadataLanguage, TmdbUtils.GetImageLanguagesParam(info.MetadataLanguage, info.MetadataCountryCode), info.MetadataCountryCode, cancellationToken)
+                .ConfigureAwait(false);
+
+            var group = groupCollection?.Groups?.Find(g => g.Order == seasonNumber.Value);
+            if (group is not null)
+            {
+                return MapGroupToSeason(group, seasonNumber.Value, config.ImportSeasonName);
+            }
+
             var seasonResult = await _tmdbClientManager
-                .GetSeasonAsync(Convert.ToInt32(seriesTmdbId, CultureInfo.InvariantCulture), seasonNumber.Value, info.MetadataLanguage, TmdbUtils.GetImageLanguagesParam(info.MetadataLanguage, info.MetadataCountryCode), info.MetadataCountryCode, cancellationToken)
+                .GetSeasonAsync(seriesId, seasonNumber.Value, info.MetadataLanguage, TmdbUtils.GetImageLanguagesParam(info.MetadataLanguage, info.MetadataCountryCode), info.MetadataCountryCode, cancellationToken)
                 .ConfigureAwait(false);
 
             if (seasonResult is null)
@@ -153,6 +168,44 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Maps an episode group to a season.
+        /// </summary>
+        /// <remarks>
+        /// A group spans whatever TMDb seasons its episodes come from, so only the group's own name and the air date
+        /// of its first episode describe it. TMDb has neither an overview, artwork nor credits for a group.
+        /// </remarks>
+        /// <param name="group">The episode group the season maps to.</param>
+        /// <param name="seasonNumber">The season number.</param>
+        /// <param name="importSeasonName">Whether the season name should be imported.</param>
+        /// <returns>The season metadata.</returns>
+        internal static MetadataResult<Season> MapGroupToSeason(TvGroup group, int seasonNumber, bool importSeasonName)
+        {
+            var airDate = group.Episodes?
+                .Where(e => e.AirDate.HasValue)
+                .Min(e => e.AirDate);
+
+            var season = new Season
+            {
+                IndexNumber = seasonNumber,
+                PremiereDate = airDate,
+                ProductionYear = airDate?.Year
+            };
+
+            if (importSeasonName)
+            {
+                season.Name = group.Name;
+            }
+
+            season.TrySetProviderId(TmdbUtils.EpisodeGroupProviderKey, group.Id);
+
+            return new MetadataResult<Season>
+            {
+                HasMetadata = true,
+                Item = season
+            };
         }
 
         /// <inheritdoc />

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -228,7 +228,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             result = new MetadataResult<Series>
             {
-                Item = MapTvShowToSeries(tvShow, info.MetadataCountryCode),
+                Item = MapTvShowToSeries(tvShow, info.MetadataCountryCode, info.DisplayOrder),
                 ResultLanguage = info.MetadataLanguage ?? tvShow.OriginalLanguage
             };
 
@@ -242,7 +242,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             return result;
         }
 
-        private static Series MapTvShowToSeries(TvShow seriesResult, string preferredCountryCode)
+        private static Series MapTvShowToSeries(TvShow seriesResult, string preferredCountryCode, string? displayOrder)
         {
             var series = new Series
             {
@@ -251,6 +251,14 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             };
 
             series.SetProviderId(MetadataProvider.Tmdb, seriesResult.Id.ToString(CultureInfo.InvariantCulture));
+
+            // The seasons of a series ordered by an episode group belong to that group, not to the series itself.
+            var groupType = TmdbUtils.GetEpisodeGroupType(displayOrder);
+            if (groupType is not null)
+            {
+                var episodeGroup = seriesResult.EpisodeGroups?.Results?.Find(g => g.Type == groupType);
+                series.TrySetProviderId(TmdbUtils.EpisodeGroupProviderKey, episodeGroup?.Id);
+            }
 
             series.CommunityRating = Convert.ToSingle(seriesResult.VoteAverage);
 

--- a/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TV/TmdbSeriesProvider.cs
@@ -231,7 +231,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
 
             result = new MetadataResult<Series>
             {
-                Item = MapTvShowToSeries(tvShow, info.MetadataCountryCode),
+                Item = MapTvShowToSeries(tvShow, info.MetadataCountryCode, info.DisplayOrder),
                 ResultLanguage = info.MetadataLanguage ?? tvShow.OriginalLanguage
             };
 
@@ -245,7 +245,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             return result;
         }
 
-        private static Series MapTvShowToSeries(TvShow seriesResult, string preferredCountryCode)
+        private static Series MapTvShowToSeries(TvShow seriesResult, string preferredCountryCode, string? displayOrder)
         {
             var series = new Series
             {
@@ -254,6 +254,14 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.TV
             };
 
             series.SetProviderId(MetadataProvider.Tmdb, seriesResult.Id.ToString(CultureInfo.InvariantCulture));
+
+            // The seasons of a series ordered by an episode group belong to that group, not to the series itself.
+            var groupType = TmdbUtils.GetEpisodeGroupType(displayOrder);
+            if (groupType is not null)
+            {
+                var episodeGroup = seriesResult.EpisodeGroups?.Results?.Find(g => g.Type == groupType);
+                series.TrySetProviderId(TmdbUtils.EpisodeGroupProviderKey, episodeGroup?.Id);
+            }
 
             series.CommunityRating = Convert.ToSingle(seriesResult.VoteAverage);
 

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -170,18 +170,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <param name="imageLanguages">A comma-separated list of image languages.</param>
         /// <param name="countryCode">The country code, ISO 3166-1.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The TMDb tv show episode group information or null if not found.</returns>
-        private async Task<TvGroupCollection?> GetSeriesGroupAsync(int tvShowId, string displayOrder, string? language, string? imageLanguages, string? countryCode, CancellationToken cancellationToken)
+        /// <returns>The TMDb tv show episode group information or null if the display order has no matching group.</returns>
+        public async Task<TvGroupCollection?> GetSeriesGroupAsync(int tvShowId, string? displayOrder, string? language, string? imageLanguages, string? countryCode, CancellationToken cancellationToken)
         {
-            TvGroupType? groupType =
-                string.Equals(displayOrder, "originalAirDate", StringComparison.Ordinal) ? TvGroupType.OriginalAirDate :
-                string.Equals(displayOrder, "absolute", StringComparison.Ordinal) ? TvGroupType.Absolute :
-                string.Equals(displayOrder, "dvd", StringComparison.Ordinal) ? TvGroupType.DVD :
-                string.Equals(displayOrder, "digital", StringComparison.Ordinal) ? TvGroupType.Digital :
-                string.Equals(displayOrder, "storyArc", StringComparison.Ordinal) ? TvGroupType.StoryArc :
-                string.Equals(displayOrder, "production", StringComparison.Ordinal) ? TvGroupType.Production :
-                string.Equals(displayOrder, "tv", StringComparison.Ordinal) ? TvGroupType.TV :
-                null;
+            var groupType = TmdbUtils.GetEpisodeGroupType(displayOrder);
 
             if (groupType is null)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -167,18 +167,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// <param name="imageLanguages">A comma-separated list of image languages.</param>
         /// <param name="countryCode">The country code, ISO 3166-1.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The TMDb tv show episode group information or null if not found.</returns>
-        private async Task<TvGroupCollection?> GetSeriesGroupAsync(int tvShowId, string displayOrder, string? language, string? imageLanguages, string? countryCode, CancellationToken cancellationToken)
+        /// <returns>The TMDb tv show episode group information or null if the display order has no matching group.</returns>
+        public async Task<TvGroupCollection?> GetSeriesGroupAsync(int tvShowId, string? displayOrder, string? language, string? imageLanguages, string? countryCode, CancellationToken cancellationToken)
         {
-            TvGroupType? groupType =
-                string.Equals(displayOrder, "originalAirDate", StringComparison.Ordinal) ? TvGroupType.OriginalAirDate :
-                string.Equals(displayOrder, "absolute", StringComparison.Ordinal) ? TvGroupType.Absolute :
-                string.Equals(displayOrder, "dvd", StringComparison.Ordinal) ? TvGroupType.DVD :
-                string.Equals(displayOrder, "digital", StringComparison.Ordinal) ? TvGroupType.Digital :
-                string.Equals(displayOrder, "storyArc", StringComparison.Ordinal) ? TvGroupType.StoryArc :
-                string.Equals(displayOrder, "production", StringComparison.Ordinal) ? TvGroupType.Production :
-                string.Equals(displayOrder, "tv", StringComparison.Ordinal) ? TvGroupType.TV :
-                null;
+            var groupType = TmdbUtils.GetEpisodeGroupType(displayOrder);
 
             if (groupType is null)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbExternalUrlProvider.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -22,53 +21,63 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
     {
         switch (item)
         {
-            case Series:
-                if (item.TryGetProviderId(MetadataProvider.Tmdb, out var externalId))
+            case Series series:
+                if (series.TryGetProviderId(MetadataProvider.Tmdb, out var externalId))
                 {
                     yield return TmdbUtils.BaseTmdbUrl + $"tv/{externalId}";
+
+                    if (!IsAirDateOrder(series.DisplayOrder)
+                        && series.TryGetProviderId(TmdbUtils.EpisodeGroupProviderKey, out var seriesGroupId))
+                    {
+                        yield return TmdbUtils.BaseTmdbUrl + $"tv/{externalId}/episode_group/{seriesGroupId}";
+                    }
                 }
 
                 break;
             case Season season:
-                if (season.Series?.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId) == true)
+                var seasonSeries = season.Series;
+
+                // The season number counts episode groups rather than TMDb seasons when the series is ordered by one.
+                if (seasonSeries is not null && !IsAirDateOrder(seasonSeries.DisplayOrder))
                 {
-                    var orderString = season.Series.DisplayOrder;
-                    var seasonNumber = season.IndexNumber;
-                    if (string.IsNullOrEmpty(orderString) && seasonNumber is not null)
+                    if (seasonSeries.TryGetProviderId(MetadataProvider.Tmdb, out var groupSeriesId)
+                        && seasonSeries.TryGetProviderId(TmdbUtils.EpisodeGroupProviderKey, out var collectionId)
+                        && season.TryGetProviderId(TmdbUtils.EpisodeGroupProviderKey, out var groupId))
                     {
-                        // Default order is airdate
-                        yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{seasonNumber}";
+                        yield return TmdbUtils.BaseTmdbUrl + $"tv/{groupSeriesId}/episode_group/{collectionId}/group/{groupId}";
                     }
 
-                    if (Enum.TryParse<TvGroupType>(season.Series.DisplayOrder, out var order))
-                    {
-                        if (order.Equals(TvGroupType.OriginalAirDate) && seasonNumber is not null)
-                        {
-                            yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{seasonNumber}";
-                        }
-                    }
+                    break;
+                }
+
+                // The season's own id already points at the right page, so prefer it over the numbering.
+                if (season.TryGetProviderId(MetadataProvider.Tmdb, out var seasonExternalId))
+                {
+                    yield return TmdbUtils.BaseTmdbUrl + $"tv/season/{seasonExternalId}";
+                    break;
+                }
+
+                if (seasonSeries?.TryGetProviderId(MetadataProvider.Tmdb, out var seriesExternalId) == true
+                    && season.IndexNumber is { } seasonNumber)
+                {
+                    yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{seasonNumber}";
                 }
 
                 break;
             case Episode episode:
-                if (episode.Series?.TryGetProviderId(MetadataProvider.Tmdb, out seriesExternalId) == true)
+                if (episode.TryGetProviderId(MetadataProvider.Tmdb, out var episodeExternalId))
                 {
-                    var orderString = episode.Series.DisplayOrder;
-                    var seasonNumber = episode.Season?.IndexNumber;
-                    var episodeNumber = episode.IndexNumber;
-                    if (string.IsNullOrEmpty(orderString) && seasonNumber is not null && episodeNumber is not null)
-                    {
-                        // Default order is airdate
-                        yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{seasonNumber}/episode/{episodeNumber}";
-                    }
+                    yield return TmdbUtils.BaseTmdbUrl + $"tv/episode/{episodeExternalId}";
+                    break;
+                }
 
-                    if (Enum.TryParse<TvGroupType>(orderString, out var order))
-                    {
-                        if (order.Equals(TvGroupType.OriginalAirDate) && seasonNumber is not null && episodeNumber is not null)
-                        {
-                            yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{seasonNumber}/episode/{episodeNumber}";
-                        }
-                    }
+                // Fall back to the numbering for items that were last refreshed before the episode id was stored.
+                if (episode.Series?.TryGetProviderId(MetadataProvider.Tmdb, out seriesExternalId) == true
+                    && episode.Season?.IndexNumber is { } episodeSeasonNumber
+                    && episode.IndexNumber is { } episodeNumber
+                    && IsAirDateOrder(episode.Series.DisplayOrder))
+                {
+                    yield return TmdbUtils.BaseTmdbUrl + $"tv/{seriesExternalId}/season/{episodeSeasonNumber}/episode/{episodeNumber}";
                 }
 
                 break;
@@ -95,4 +104,9 @@ public class TmdbExternalUrlProvider : IExternalUrlProvider
                 break;
         }
     }
+
+    // Only air date ordering keeps the Jellyfin season and episode numbers in sync with the TMDb ones,
+    // every other episode group renumbers them.
+    private static bool IsAirDateOrder(string? displayOrder)
+        => string.IsNullOrEmpty(displayOrder) || TmdbUtils.GetEpisodeGroupType(displayOrder) == TvGroupType.OriginalAirDate;
 }

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Model.Entities;
 using TMDbLib.Objects.General;
+using TMDbLib.Objects.TvShows;
 
 namespace MediaBrowser.Providers.Plugins.Tmdb
 {
@@ -28,6 +29,15 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// API key to use when performing an API call.
         /// </summary>
         public const string ApiKey = "4219e299c89411838049ab0dab19ebd5";
+
+        /// <summary>
+        /// Provider id holding the TMDb episode group a series is ordered by, and the group a season maps to.
+        /// </summary>
+        /// <remarks>
+        /// Derived from the series display order on every refresh, so it is deliberately not exposed as an
+        /// <see cref="Controller.Providers.IExternalId"/> for the user to edit.
+        /// </remarks>
+        public const string EpisodeGroupProviderKey = "TmdbEpisodeGroup";
 
         /// <summary>
         /// The crew types to keep.
@@ -61,6 +71,28 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
 
         [GeneratedRegex(@"[\W_-[·]]+")]
         private static partial Regex NonWordRegex();
+
+        /// <summary>
+        /// Maps a series display order to the matching TMDb episode group type.
+        /// </summary>
+        /// <param name="displayOrder">The series display order.</param>
+        /// <returns>The matching <see cref="TvGroupType"/>, or <c>null</c> if the order has no TMDb counterpart.</returns>
+        public static TvGroupType? GetEpisodeGroupType(string? displayOrder)
+        {
+            // Lowercased because the order can also come from an NFO written by a third party tool.
+            // The Tvdb-only orders (alternate, regional, altdvd) intentionally have no TMDb counterpart.
+            return displayOrder?.ToLowerInvariant() switch
+            {
+                "originalairdate" => TvGroupType.OriginalAirDate,
+                "absolute" => TvGroupType.Absolute,
+                "dvd" => TvGroupType.DVD,
+                "digital" => TvGroupType.Digital,
+                "storyarc" => TvGroupType.StoryArc,
+                "production" => TvGroupType.Production,
+                "tv" => TvGroupType.TV,
+                _ => null
+            };
+        }
 
         /// <summary>
         /// Cleans the name according to TMDb requirements.

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -40,6 +40,15 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         private const int YearAdjacentScore = 1;
 
         /// <summary>
+        /// Provider id holding the TMDb episode group a series is ordered by, and the group a season maps to.
+        /// </summary>
+        /// <remarks>
+        /// Derived from the series display order on every refresh, so it is deliberately not exposed as an
+        /// <see cref="Controller.Providers.IExternalId"/> for the user to edit.
+        /// </remarks>
+        public const string EpisodeGroupProviderKey = "TmdbEpisodeGroup";
+
+        /// <summary>
         /// The crew types to keep.
         /// </summary>
         public static readonly string[] WantedCrewTypes =
@@ -109,6 +118,28 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             // id. Reporting that as "no id" lets the caller fall back to a search and repair the id,
             // instead of throwing on every refresh of the item.
             return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out tmdbId) && tmdbId > 0;
+        }
+
+        /// <summary>
+        /// Maps a series display order to the matching TMDb episode group type.
+        /// </summary>
+        /// <param name="displayOrder">The series display order.</param>
+        /// <returns>The matching <see cref="TvGroupType"/>, or <c>null</c> if the order has no TMDb counterpart.</returns>
+        public static TvGroupType? GetEpisodeGroupType(string? displayOrder)
+        {
+            // Lowercased because the order can also come from an NFO written by a third party tool.
+            // The Tvdb-only orders (alternate, regional, altdvd) intentionally have no TMDb counterpart.
+            return displayOrder?.ToLowerInvariant() switch
+            {
+                "originalairdate" => TvGroupType.OriginalAirDate,
+                "absolute" => TvGroupType.Absolute,
+                "dvd" => TvGroupType.DVD,
+                "digital" => TvGroupType.Digital,
+                "storyarc" => TvGroupType.StoryArc,
+                "production" => TvGroupType.Production,
+                "tv" => TvGroupType.TV,
+                _ => null
+            };
         }
 
         /// <summary>

--- a/tests/Jellyfin.Providers.Tests/ExternalId/TmdbExternalUrlProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/ExternalId/TmdbExternalUrlProviderTests.cs
@@ -127,6 +127,181 @@ namespace Jellyfin.Providers.Tests.ExternalId
             Assert.Empty(urls);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData("originalAirDate")]
+        public void GetExternalUrls_SeasonWithOwnTmdbId_ReturnsIdUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "1399");
+
+            var season = new Season { IndexNumber = 3, SeriesId = series.Id };
+            season.SetProviderId(MetadataProvider.Tmdb, "3627");
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+
+            var urls = _provider.GetExternalUrls(season);
+
+            Assert.Equal([TmdbUtils.BaseTmdbUrl + "tv/season/3627"], urls);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("originalAirDate")]
+        [InlineData("OriginalAirDate")]
+        public void GetExternalUrls_SeasonInAirDateOrderWithoutOwnTmdbId_ReturnsNumberedUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "1399");
+
+            var season = new Season { IndexNumber = 3, SeriesId = series.Id };
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+
+            var urls = _provider.GetExternalUrls(season);
+
+            Assert.Equal([TmdbUtils.BaseTmdbUrl + "tv/1399/season/3"], urls);
+        }
+
+        [Theory]
+        [InlineData("absolute")]
+        [InlineData("dvd")]
+        [InlineData("digital")]
+        [InlineData("storyArc")]
+        [InlineData("production")]
+        [InlineData("tv")]
+        public void GetExternalUrls_SeasonInGroupOrderWithGroupIds_ReturnsGroupUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+            series.SetProviderId(TmdbUtils.EpisodeGroupProviderKey, "5f24dcdc869e75003658360e");
+
+            var season = new Season { IndexNumber = 2, SeriesId = series.Id };
+            season.SetProviderId(TmdbUtils.EpisodeGroupProviderKey, "652da673024ec800aeccf025");
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+
+            var urls = _provider.GetExternalUrls(season);
+
+            Assert.Equal(
+                [TmdbUtils.BaseTmdbUrl + "tv/46260/episode_group/5f24dcdc869e75003658360e/group/652da673024ec800aeccf025"],
+                urls);
+        }
+
+        [Fact]
+        public void GetExternalUrls_SeasonInGroupOrderWithoutGroupIds_ReturnsNoUrl()
+        {
+            // The season number belongs to the episode group, so it cannot be used against the series.
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = "tv" };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+
+            var season = new Season { IndexNumber = 3, SeriesId = series.Id };
+            season.SetProviderId(MetadataProvider.Tmdb, "3627");
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+
+            var urls = _provider.GetExternalUrls(season);
+
+            Assert.Empty(urls);
+        }
+
+        [Fact]
+        public void GetExternalUrls_SeasonWithStaleGroupIdAfterSwitchingToAiredOrder_ReturnsSeasonUrl()
+        {
+            // Provider ids are only ever merged, so a group id from a previous order can outlive it.
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = string.Empty };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+            series.SetProviderId(TmdbUtils.EpisodeGroupProviderKey, "5f24dcdc869e75003658360e");
+
+            var season = new Season { IndexNumber = 2, SeriesId = series.Id };
+            season.SetProviderId(MetadataProvider.Tmdb, "3627");
+            season.SetProviderId(TmdbUtils.EpisodeGroupProviderKey, "652da673024ec800aeccf025");
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+
+            var urls = _provider.GetExternalUrls(season);
+
+            Assert.Equal([TmdbUtils.BaseTmdbUrl + "tv/season/3627"], urls);
+        }
+
+        [Fact]
+        public void GetExternalUrls_SeriesInGroupOrder_ReturnsSeriesAndGroupUrl()
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = "tv" };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+            series.SetProviderId(TmdbUtils.EpisodeGroupProviderKey, "5f24dcdc869e75003658360e");
+
+            var urls = _provider.GetExternalUrls(series);
+
+            Assert.Equal(
+                [
+                    TmdbUtils.BaseTmdbUrl + "tv/46260",
+                    TmdbUtils.BaseTmdbUrl + "tv/46260/episode_group/5f24dcdc869e75003658360e"
+                ],
+                urls);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("originalAirDate")]
+        [InlineData("tv")]
+        [InlineData("digital")]
+        public void GetExternalUrls_EpisodeWithOwnTmdbId_ReturnsIdUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+
+            var season = new Season { Id = Guid.NewGuid(), IndexNumber = 3, SeriesId = series.Id };
+
+            var episode = new Episode { IndexNumber = 1, SeasonId = season.Id, SeriesId = series.Id };
+            episode.SetProviderId(MetadataProvider.Tmdb, "1104330");
+
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+            _libraryManagerMock.Setup(m => m.GetItemById(season.Id)).Returns(season);
+
+            var urls = _provider.GetExternalUrls(episode);
+
+            Assert.Equal([TmdbUtils.BaseTmdbUrl + "tv/episode/1104330"], urls);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("originalAirDate")]
+        [InlineData("OriginalAirDate")]
+        public void GetExternalUrls_EpisodeInAirDateOrderWithoutOwnTmdbId_ReturnsNumberedUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "1399");
+
+            var season = new Season { Id = Guid.NewGuid(), IndexNumber = 2, SeriesId = series.Id };
+            var episode = new Episode { IndexNumber = 5, SeasonId = season.Id, SeriesId = series.Id };
+
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+            _libraryManagerMock.Setup(m => m.GetItemById(season.Id)).Returns(season);
+
+            var urls = _provider.GetExternalUrls(episode);
+
+            Assert.Equal([TmdbUtils.BaseTmdbUrl + "tv/1399/season/2/episode/5"], urls);
+        }
+
+        [Theory]
+        [InlineData("absolute")]
+        [InlineData("dvd")]
+        [InlineData("digital")]
+        [InlineData("storyArc")]
+        [InlineData("production")]
+        [InlineData("tv")]
+        public void GetExternalUrls_EpisodeInGroupOrderWithoutOwnTmdbId_ReturnsNoUrl(string displayOrder)
+        {
+            var series = new Series { Id = Guid.NewGuid(), DisplayOrder = displayOrder };
+            series.SetProviderId(MetadataProvider.Tmdb, "46260");
+
+            var season = new Season { Id = Guid.NewGuid(), IndexNumber = 3, SeriesId = series.Id };
+            var episode = new Episode { IndexNumber = 1, SeasonId = season.Id, SeriesId = series.Id };
+
+            _libraryManagerMock.Setup(m => m.GetItemById(series.Id)).Returns(series);
+            _libraryManagerMock.Setup(m => m.GetItemById(season.Id)).Returns(season);
+
+            var urls = _provider.GetExternalUrls(episode);
+
+            Assert.Empty(urls);
+        }
+
         [Fact]
         public void GetExternalUrls_MovieWithTmdbId_ReturnsCorrectUrl()
         {

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbSeasonProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbSeasonProviderTests.cs
@@ -1,0 +1,74 @@
+using System;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Providers.Plugins.Tmdb;
+using MediaBrowser.Providers.Plugins.Tmdb.TV;
+using TMDbLib.Objects.TvShows;
+using Xunit;
+
+namespace Jellyfin.Providers.Tests.Tmdb;
+
+public static class TmdbSeasonProviderTests
+{
+    // Modelled on the "TVDB Order" group of Naruto, whose third group holds episodes of TMDb season 2.
+    private static TvGroup CreateGroup() => new()
+    {
+        Id = "65356cb791f0ea00c422eb8e",
+        Name = "Season 3",
+        Order = 3,
+        Episodes =
+        [
+            new() { Order = 1, SeasonNumber = 2, EpisodeNumber = 85, AirDate = new DateTime(2004, 11, 3, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Order = 0, SeasonNumber = 2, EpisodeNumber = 84, AirDate = new DateTime(2004, 10, 27, 0, 0, 0, DateTimeKind.Utc) },
+            new() { Order = 2, SeasonNumber = 2, EpisodeNumber = 86, AirDate = null }
+        ]
+    };
+
+    [Fact]
+    public static void MapGroupToSeason_UsesGroupIdAndEarliestAirDate()
+    {
+        var result = TmdbSeasonProvider.MapGroupToSeason(CreateGroup(), 3, false);
+
+        Assert.True(result.HasMetadata);
+        Assert.Equal(3, result.Item.IndexNumber);
+        Assert.Equal(new DateTime(2004, 10, 27, 0, 0, 0, DateTimeKind.Utc), result.Item.PremiereDate);
+        Assert.Equal(2004, result.Item.ProductionYear);
+        Assert.Equal("65356cb791f0ea00c422eb8e", result.Item.GetProviderId(TmdbUtils.EpisodeGroupProviderKey));
+    }
+
+    [Fact]
+    public static void MapGroupToSeason_DoesNotSetSeasonTmdbId()
+    {
+        // A group spans whatever TMDb seasons its episodes come from, so no single season describes it.
+        var result = TmdbSeasonProvider.MapGroupToSeason(CreateGroup(), 3, true);
+
+        Assert.False(result.Item.HasProviderId(MetadataProvider.Tmdb));
+        Assert.Null(result.Item.Overview);
+    }
+
+    [Theory]
+    [InlineData(true, "Season 3")]
+    [InlineData(false, null)]
+    public static void MapGroupToSeason_ImportsNameOnlyWhenConfigured(bool importSeasonName, string? expected)
+    {
+        var result = TmdbSeasonProvider.MapGroupToSeason(CreateGroup(), 3, importSeasonName);
+
+        Assert.Equal(expected, result.Item.Name);
+    }
+
+    [Fact]
+    public static void MapGroupToSeason_WithoutAirDates_LeavesPremiereDateUnset()
+    {
+        var group = new TvGroup
+        {
+            Id = "65356f2bc14fee00ad9e753c",
+            Name = "Specials",
+            Order = 0,
+            Episodes = [new() { Order = 0, AirDate = null }]
+        };
+
+        var result = TmdbSeasonProvider.MapGroupToSeason(group, 0, true);
+
+        Assert.Null(result.Item.PremiereDate);
+        Assert.Null(result.Item.ProductionYear);
+    }
+}

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -1,4 +1,5 @@
 using MediaBrowser.Providers.Plugins.Tmdb;
+using TMDbLib.Objects.TvShows;
 using Xunit;
 
 namespace Jellyfin.Providers.Tests.Tmdb
@@ -33,6 +34,29 @@ namespace Jellyfin.Providers.Tests.Tmdb
         public static void AdjustImageLanguage_Valid_Success(string imageLanguage, string requestLanguage, string? expected)
         {
             Assert.Equal(expected, TmdbUtils.AdjustImageLanguage(imageLanguage, requestLanguage));
+        }
+
+        [Theory]
+        // The values the web client writes.
+        [InlineData("originalAirDate", TvGroupType.OriginalAirDate)]
+        [InlineData("absolute", TvGroupType.Absolute)]
+        [InlineData("dvd", TvGroupType.DVD)]
+        [InlineData("digital", TvGroupType.Digital)]
+        [InlineData("storyArc", TvGroupType.StoryArc)]
+        [InlineData("production", TvGroupType.Production)]
+        [InlineData("tv", TvGroupType.TV)]
+        // An NFO written by a third party tool can use any casing.
+        [InlineData("OriginalAirDate", TvGroupType.OriginalAirDate)]
+        [InlineData("DVD", TvGroupType.DVD)]
+        // Tvdb-only orders and the default have no TMDb episode group.
+        [InlineData("alternate", null)]
+        [InlineData("regional", null)]
+        [InlineData("altdvd", null)]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public static void GetEpisodeGroupType_ReturnsMatchingGroupType(string? displayOrder, TvGroupType? expected)
+        {
+            Assert.Equal(expected, TmdbUtils.GetEpisodeGroupType(displayOrder));
         }
     }
 }

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -4,6 +4,7 @@ using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Providers.Plugins.Tmdb;
 using TMDbLib.Objects.Search;
+using TMDbLib.Objects.TvShows;
 using Xunit;
 
 namespace Jellyfin.Providers.Tests.Tmdb
@@ -238,5 +239,28 @@ namespace Jellyfin.Providers.Tests.Tmdb
                 OriginalName = originalName,
                 FirstAirDate = new DateTime(year, 6, 1, 0, 0, 0, DateTimeKind.Utc)
             };
+
+        [Theory]
+        // The values the web client writes.
+        [InlineData("originalAirDate", TvGroupType.OriginalAirDate)]
+        [InlineData("absolute", TvGroupType.Absolute)]
+        [InlineData("dvd", TvGroupType.DVD)]
+        [InlineData("digital", TvGroupType.Digital)]
+        [InlineData("storyArc", TvGroupType.StoryArc)]
+        [InlineData("production", TvGroupType.Production)]
+        [InlineData("tv", TvGroupType.TV)]
+        // An NFO written by a third party tool can use any casing.
+        [InlineData("OriginalAirDate", TvGroupType.OriginalAirDate)]
+        [InlineData("DVD", TvGroupType.DVD)]
+        // Tvdb-only orders and the default have no TMDb episode group.
+        [InlineData("alternate", null)]
+        [InlineData("regional", null)]
+        [InlineData("altdvd", null)]
+        [InlineData("", null)]
+        [InlineData(null, null)]
+        public static void GetEpisodeGroupType_ReturnsMatchingGroupType(string? displayOrder, TvGroupType? expected)
+        {
+            Assert.Equal(expected, TmdbUtils.GetEpisodeGroupType(displayOrder));
+        }
     }
 }


### PR DESCRIPTION
Seasons and episodes of a series with a non-default episode order had no TMDb link at all, because `TmdbExternalUrlProvider` parsed the order with a case-sensitive `Enum.TryParse` while the order is stored camelCased (`"tv"`, `"digital"`), so no real value ever parsed and only an empty order produced a URL.
Fixing the parse alone is not enough: under an episode group the season and episode numbers count groups rather than TMDb seasons, so the numbered URL points at the wrong page - and `TmdbSeasonProvider` ignored the order entirely, giving TVDB-order "Season 3" the name, overview, air date and artwork of a TMDb season that holds completely different episodes.
Episodes are now linked by their TMDb episode id (which `TmdbEpisodeProvider` never stored, despite `TmdbEpisodeExternalId` advertising it) since that resolves the group remapping and is correct for every order, and seasons are described by and linked to their episode group.
Getting the display order to the series provider needs a new field on `SeriesInfo`, which was also the request body of `POST /Items/RemoteSearch/Series`, so the first commit separates the API contract from the provider lookup info, the DTOs keep the type names. The third commit then flags the fields that only the server ever fills in as deprecated.

**Changes**

- `Decouple the remote search API contract from the provider lookup info` - mirrors `ItemLookupInfo` and friends under `Jellyfin.Api.Models.LookupDtos`, mapped in `ItemLookupController`.
- `Fix TMDb links and season metadata for series ordered by an episode group` - the actual bug fix.
- `Deprecate the server side only fields of the remote search DTOs` - `Path`, `IsAutomated`, `ArtistInfo.SongInfos`, `AlbumInfo.SongInfos`/`ArtistProviderIds`.

**Code assistance**

Used Claude Opus 5 for the decoupling and the tests.

**Issues**

Fixes #17410

**Notes**

Overlaps #16052, which persists the same episode group id as a user-editable external id. That approach also lets users pick between the several groups TMDb often has for one type, which this PR does not, it takes the first match. The two are complementary: #16052 would override the same provider key.