### PR TITLE
Bugfix: #17547 | Batching MediaSourceCount into one call

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -253,6 +253,18 @@ namespace Emby.Server.Implementations.Dto
                 }
             }
 
+            // Batch-detect which videos own alternate versions to avoid the per-item alternate-version
+            // queries in MediaSourceCount. Videos absent from this set have a single media source.
+            IReadOnlySet<Guid>? alternateVersionItemIds = null;
+            if (options.ContainsField(ItemFields.MediaSourceCount))
+            {
+                var versionItemIds = accessibleItems.OfType<Video>().Select(i => i.Id).ToList();
+                if (versionItemIds.Count > 0)
+                {
+                    alternateVersionItemIds = _libraryManager.GetItemsWithAlternateVersions(versionItemIds);
+                }
+            }
+
             for (int index = 0; index < accessibleItems.Count; index++)
             {
                 var item = accessibleItems[index];
@@ -267,7 +279,8 @@ namespace Emby.Server.Implementations.Dto
                     playedCountBatch,
                     artistsBatch,
                     resumeDataBatch?.GetValueOrDefault(item.Id),
-                    peopleBatch);
+                    peopleBatch,
+                    alternateVersionItemIds);
 
                 if (item is LiveTvChannel tvChannel)
                 {
@@ -330,7 +343,8 @@ namespace Emby.Server.Implementations.Dto
             Dictionary<Guid, (int Played, int Total)>? playedCountBatch = null,
             IReadOnlyDictionary<string, MusicArtist[]>? artistsBatch = null,
             VersionResumeData? resumeData = null,
-            IReadOnlyDictionary<Guid, IReadOnlyList<PersonInfo>>? peopleBatch = null)
+            IReadOnlyDictionary<Guid, IReadOnlyList<PersonInfo>>? peopleBatch = null,
+            IReadOnlySet<Guid>? alternateVersionItemIds = null)
         {
             var dto = new BaseItemDto
             {
@@ -399,7 +413,7 @@ namespace Emby.Server.Implementations.Dto
                 AttachStudios(dto, item);
             }
 
-            AttachBasicFields(dto, item, owner, options, artistsBatch, user);
+            AttachBasicFields(dto, item, owner, options, artistsBatch, user, alternateVersionItemIds);
 
             if (options.ContainsField(ItemFields.CanDelete))
             {
@@ -984,7 +998,8 @@ namespace Emby.Server.Implementations.Dto
         /// <param name="options">The options.</param>
         /// <param name="artistsBatch">Optional pre-fetched artist lookup shared across a batch of items.</param>
         /// <param name="user">The user, for per-user values such as the accessible media source count.</param>
-        private void AttachBasicFields(BaseItemDto dto, BaseItem item, BaseItem? owner, DtoOptions options, IReadOnlyDictionary<string, MusicArtist[]>? artistsBatch = null, User? user = null)
+        /// <param name="alternateVersionItemIds">Optional pre-fetched set of item IDs that own alternate versions, shared across a batch of items.</param>
+        private void AttachBasicFields(BaseItemDto dto, BaseItem item, BaseItem? owner, DtoOptions options, IReadOnlyDictionary<string, MusicArtist[]>? artistsBatch = null, User? user = null, IReadOnlySet<Guid>? alternateVersionItemIds = null)
         {
             if (options.ContainsField(ItemFields.DateCreated))
             {
@@ -1298,15 +1313,25 @@ namespace Emby.Server.Implementations.Dto
 
                 if (options.ContainsField(ItemFields.MediaSourceCount))
                 {
-                    // Match the per-user filtering of the media sources: versions the user cannot
-                    // access are not selectable, so they must not count towards the badge either.
-                    var mediaSourceCount = user is null
-                        || (!video.PrimaryVersionId.HasValue && video.LinkedAlternateVersions.Length == 0 && !video.HasLocalAlternateVersions)
-                            ? video.MediaSourceCount
-                            : video.GetAllVersions().Count(v => v.Id.Equals(video.Id) || v.IsVisibleStandalone(user));
-                    if (mediaSourceCount != 1)
+                    // A video with no primary version and no alternate versions always has a single
+                    // media source. When the batch has already determined this item owns no alternate
+                    // versions, skip the per-item alternate-version queries entirely (the common case).
+                    var hasNoAlternateVersions = alternateVersionItemIds is not null
+                        && !video.PrimaryVersionId.HasValue
+                        && !alternateVersionItemIds.Contains(video.Id);
+
+                    if (!hasNoAlternateVersions)
                     {
-                        dto.MediaSourceCount = mediaSourceCount;
+                        // Match the per-user filtering of the media sources: versions the user cannot
+                        // access are not selectable, so they must not count towards the badge either.
+                        var mediaSourceCount = user is null
+                            || (!video.PrimaryVersionId.HasValue && video.LinkedAlternateVersions.Length == 0 && !video.HasLocalAlternateVersions)
+                                ? video.MediaSourceCount
+                                : video.GetAllVersions().Count(v => v.Id.Equals(video.Id) || v.IsVisibleStandalone(user));
+                        if (mediaSourceCount != 1)
+                        {
+                            dto.MediaSourceCount = mediaSourceCount;
+                        }
                     }
                 }
 

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -261,7 +261,7 @@ namespace Emby.Server.Implementations.Dto
                 var versionItemIds = accessibleItems.OfType<Video>().Select(i => i.Id).ToList();
                 if (versionItemIds.Count > 0)
                 {
-                    alternateVersionItemIds = _libraryManager.GetItemsWithAlternateVersions(versionItemIds);
+                    alternateVersionItemIds = _libraryManager.GetItemIdsWithAlternateVersions(versionItemIds);
                 }
             }
 
@@ -1314,13 +1314,15 @@ namespace Emby.Server.Implementations.Dto
                 if (options.ContainsField(ItemFields.MediaSourceCount))
                 {
                     // A video with no primary version and no alternate versions always has a single
-                    // media source. When the batch has already determined this item owns no alternate
-                    // versions, skip the per-item alternate-version queries entirely (the common case).
-                    var hasNoAlternateVersions = alternateVersionItemIds is not null
-                        && !video.PrimaryVersionId.HasValue
-                        && !alternateVersionItemIds.Contains(video.Id);
+                    // media source. Only compute the count for videos that might have more: a primary
+                    // version, or membership in the batch's set of items that own alternate versions.
+                    // Without the batch we can't rule it out, so fall back to computing (the single-item
+                    // path). Everything else is the common case and keeps the default count of one.
+                    var mayHaveAlternateVersions = alternateVersionItemIds is null
+                        || video.PrimaryVersionId.HasValue
+                        || alternateVersionItemIds.Contains(video.Id);
 
-                    if (!hasNoAlternateVersions)
+                    if (mayHaveAlternateVersions)
                     {
                         // Match the per-user filtering of the media sources: versions the user cannot
                         // access are not selectable, so they must not count towards the badge either.

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2235,9 +2235,9 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <inheritdoc />
-        public IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
+        public IReadOnlySet<Guid> GetItemIdsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
         {
-            return _linkedChildrenService.GetItemsWithAlternateVersions(itemIds);
+            return _linkedChildrenService.GetItemIdsWithAlternateVersions(itemIds);
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -2235,6 +2235,12 @@ namespace Emby.Server.Implementations.Library
         }
 
         /// <inheritdoc />
+        public IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
+        {
+            return _linkedChildrenService.GetItemsWithAlternateVersions(itemIds);
+        }
+
+        /// <inheritdoc />
         public void UpsertLinkedChild(Guid parentId, Guid childId, MediaBrowser.Controller.Entities.LinkedChildType childType)
         {
             _linkedChildrenService.UpsertLinkedChild(parentId, childId, childType);

--- a/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
+++ b/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
@@ -70,9 +70,9 @@ public class LinkedChildrenService : ILinkedChildrenService
         using var dbContext = _dbProvider.CreateDbContext();
 
         return dbContext.LinkedChildren
-            .Where(lc => (lc.ChildType == DbLinkedChildType.LocalAlternateVersion
-                    || lc.ChildType == DbLinkedChildType.LinkedAlternateVersion)
-                && itemIds.Contains(lc.ParentId))
+            .Where(lc => lc.ChildType == DbLinkedChildType.LocalAlternateVersion
+                || lc.ChildType == DbLinkedChildType.LinkedAlternateVersion)
+            .WhereOneOrMany(itemIds as IList<Guid> ?? itemIds.ToList(), lc => lc.ParentId)
             .Select(lc => lc.ParentId)
             .Distinct()
             .ToHashSet();

--- a/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
+++ b/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
@@ -60,6 +60,27 @@ public class LinkedChildrenService : ILinkedChildrenService
     }
 
     /// <inheritdoc/>
+    public IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
+    {
+        if (itemIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        using var dbContext = _dbProvider.CreateDbContext();
+
+        var parentIds = dbContext.LinkedChildren
+            .Where(lc => (lc.ChildType == DbLinkedChildType.LocalAlternateVersion
+                    || lc.ChildType == DbLinkedChildType.LinkedAlternateVersion)
+                && itemIds.Contains(lc.ParentId))
+            .Select(lc => lc.ParentId)
+            .Distinct()
+            .ToArray();
+
+        return parentIds.ToHashSet();
+    }
+
+    /// <inheritdoc/>
     public IReadOnlyDictionary<string, MusicArtist[]> FindArtists(IReadOnlyList<string> artistNames)
     {
         using var dbContext = _dbProvider.CreateDbContext();

--- a/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
+++ b/Jellyfin.Server.Implementations/Item/LinkedChildrenService.cs
@@ -60,7 +60,7 @@ public class LinkedChildrenService : ILinkedChildrenService
     }
 
     /// <inheritdoc/>
-    public IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
+    public IReadOnlySet<Guid> GetItemIdsWithAlternateVersions(IReadOnlyList<Guid> itemIds)
     {
         if (itemIds.Count == 0)
         {
@@ -69,15 +69,13 @@ public class LinkedChildrenService : ILinkedChildrenService
 
         using var dbContext = _dbProvider.CreateDbContext();
 
-        var parentIds = dbContext.LinkedChildren
+        return dbContext.LinkedChildren
             .Where(lc => (lc.ChildType == DbLinkedChildType.LocalAlternateVersion
                     || lc.ChildType == DbLinkedChildType.LinkedAlternateVersion)
                 && itemIds.Contains(lc.ParentId))
             .Select(lc => lc.ParentId)
             .Distinct()
-            .ToArray();
-
-        return parentIds.ToHashSet();
+            .ToHashSet();
     }
 
     /// <inheritdoc/>

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -261,7 +261,7 @@ namespace MediaBrowser.Controller.Library
         /// </summary>
         /// <param name="itemIds">The item IDs to check.</param>
         /// <returns>The set of item IDs that have alternate versions.</returns>
-        IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
+        IReadOnlySet<Guid> GetItemIdsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
 
         /// <summary>
         /// Creates or updates a LinkedChild entry linking a parent to a child item.

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -256,6 +256,14 @@ namespace MediaBrowser.Controller.Library
         IEnumerable<Video> GetLinkedAlternateVersions(Video video);
 
         /// <summary>
+        /// Gets, in a single query, the subset of the supplied items that own at least one alternate
+        /// version (local or linked). Items absent from the result have no alternate versions.
+        /// </summary>
+        /// <param name="itemIds">The item IDs to check.</param>
+        /// <returns>The set of item IDs that have alternate versions.</returns>
+        IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
+
+        /// <summary>
         /// Creates or updates a LinkedChild entry linking a parent to a child item.
         /// </summary>
         /// <param name="parentId">The parent item ID.</param>

--- a/MediaBrowser.Controller/Persistence/ILinkedChildrenService.cs
+++ b/MediaBrowser.Controller/Persistence/ILinkedChildrenService.cs
@@ -26,7 +26,7 @@ public interface ILinkedChildrenService
     /// </summary>
     /// <param name="itemIds">The item IDs to check.</param>
     /// <returns>The set of item IDs that have alternate versions.</returns>
-    IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
+    IReadOnlySet<Guid> GetItemIdsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
 
     /// <summary>
     /// Gets all artist matches from the database.

--- a/MediaBrowser.Controller/Persistence/ILinkedChildrenService.cs
+++ b/MediaBrowser.Controller/Persistence/ILinkedChildrenService.cs
@@ -20,6 +20,15 @@ public interface ILinkedChildrenService
     IReadOnlyList<Guid> GetLinkedChildrenIds(Guid parentId, int? childType = null);
 
     /// <summary>
+    /// Gets, in a single query, the subset of the supplied items that own at least one alternate
+    /// version (local or linked). Items absent from the result have no alternate versions, so their
+    /// media source count is one.
+    /// </summary>
+    /// <param name="itemIds">The item IDs to check.</param>
+    /// <returns>The set of item IDs that have alternate versions.</returns>
+    IReadOnlySet<Guid> GetItemsWithAlternateVersions(IReadOnlyList<Guid> itemIds);
+
+    /// <summary>
     /// Gets all artist matches from the database.
     /// </summary>
     /// <param name="artistNames">The names of the artists.</param>

--- a/tests/Jellyfin.Server.Implementations.Tests/Dto/DtoServiceImageInheritanceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Dto/DtoServiceImageInheritanceTests.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Controller.Drawing;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.Providers;
@@ -205,6 +206,43 @@ public class DtoServiceImageInheritanceTests
         libraryManager.Verify(x => x.GetPeople(It.IsAny<BaseItem>()), Times.Never);
     }
 
+    [Fact]
+    public void GetBaseItemDtos_Videos_ResolveMediaSourceCountFromBatch_WithoutPerItemLookup()
+    {
+        static Movie MakeMovie() => new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Movie",
+            ImageInfos = []
+        };
+
+        var movieOne = MakeMovie();
+        var movieTwo = MakeMovie();
+
+        var libraryManager = new Mock<ILibraryManager>();
+
+        // DtoService detects which videos own alternate versions in ONE batch
+        // (GetItemsWithAlternateVersions) before the per-item loop. Videos absent from that set have a
+        // single media source, so the per-item GetLinkedAlternateVersions/GetLocalAlternateVersionIds
+        // queries (the N+1) must be skipped entirely. Here neither movie has alternate versions.
+        libraryManager
+            .Setup(x => x.GetItemsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()))
+            .Returns(new HashSet<Guid>());
+
+        var dtoService = BuildDtoService(libraryManager);
+
+        var options = new DtoOptions(false) { Fields = [ItemFields.MediaSourceCount] };
+        var dtos = dtoService.GetBaseItemDtos([movieOne, movieTwo], options);
+
+        Assert.Equal(2, dtos.Count);
+
+        // The alternate-version check is batched once for the whole set, and the per-item lookups are
+        // never reached because the batch already ruled out alternate versions.
+        libraryManager.Verify(x => x.GetItemsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()), Times.Once);
+        libraryManager.Verify(x => x.GetLinkedAlternateVersions(It.IsAny<Video>()), Times.Never);
+        libraryManager.Verify(x => x.GetLocalAlternateVersionIds(It.IsAny<Video>()), Times.Never);
+    }
+
     private static DtoService BuildDtoService(BaseItem displayParent)
     {
         var libraryManager = new Mock<ILibraryManager>();
@@ -230,6 +268,10 @@ public class DtoServiceImageInheritanceTests
         imageProcessor
             .Setup(x => x.GetImageCacheTag(It.IsAny<BaseItem>(), It.IsAny<ItemImageInfo>()))
             .Returns<BaseItem, ItemImageInfo>((_, image) => image.Path);
+
+        // Video.IsActiveRecording() dereferences this static during DTO building.
+        Video.RecordingsManager = recordingsManager.Object;
+        BaseItem.LibraryManager = libraryManager.Object;
 
         return new DtoService(
             logger.Object,

--- a/tests/Jellyfin.Server.Implementations.Tests/Dto/DtoServiceImageInheritanceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Dto/DtoServiceImageInheritanceTests.cs
@@ -222,11 +222,11 @@ public class DtoServiceImageInheritanceTests
         var libraryManager = new Mock<ILibraryManager>();
 
         // DtoService detects which videos own alternate versions in ONE batch
-        // (GetItemsWithAlternateVersions) before the per-item loop. Videos absent from that set have a
+        // (GetItemIdsWithAlternateVersions) before the per-item loop. Videos absent from that set have a
         // single media source, so the per-item GetLinkedAlternateVersions/GetLocalAlternateVersionIds
         // queries (the N+1) must be skipped entirely. Here neither movie has alternate versions.
         libraryManager
-            .Setup(x => x.GetItemsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()))
+            .Setup(x => x.GetItemIdsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()))
             .Returns(new HashSet<Guid>());
 
         var dtoService = BuildDtoService(libraryManager);
@@ -236,11 +236,52 @@ public class DtoServiceImageInheritanceTests
 
         Assert.Equal(2, dtos.Count);
 
+        // A single media source is the default, so the count is left unset (the client treats null as one).
+        foreach (var dto in dtos)
+        {
+            Assert.Null(dto.MediaSourceCount);
+        }
+
         // The alternate-version check is batched once for the whole set, and the per-item lookups are
         // never reached because the batch already ruled out alternate versions.
-        libraryManager.Verify(x => x.GetItemsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()), Times.Once);
+        libraryManager.Verify(x => x.GetItemIdsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()), Times.Once);
         libraryManager.Verify(x => x.GetLinkedAlternateVersions(It.IsAny<Video>()), Times.Never);
         libraryManager.Verify(x => x.GetLocalAlternateVersionIds(It.IsAny<Video>()), Times.Never);
+    }
+
+    [Fact]
+    public void GetBaseItemDtos_VideoInAlternateVersionBatch_ResolvesRealCount()
+    {
+        var movie = new Movie
+        {
+            Id = Guid.NewGuid(),
+            Name = "Movie",
+            ImageInfos = []
+        };
+
+        var libraryManager = new Mock<ILibraryManager>();
+
+        // This movie IS in the batch set, so the fast path must not short-circuit it: the per-item
+        // lookups still run and the count is computed exactly as it was before batching. Two linked
+        // alternate versions plus the movie itself is a count of three.
+        libraryManager
+            .Setup(x => x.GetItemIdsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()))
+            .Returns(new HashSet<Guid> { movie.Id });
+        libraryManager
+            .Setup(x => x.GetLinkedAlternateVersions(It.IsAny<Video>()))
+            .Returns([new Movie { Id = Guid.NewGuid() }, new Movie { Id = Guid.NewGuid() }]);
+        libraryManager
+            .Setup(x => x.GetLocalAlternateVersionIds(It.IsAny<Video>()))
+            .Returns([]);
+
+        var dtoService = BuildDtoService(libraryManager);
+
+        var options = new DtoOptions(false) { Fields = [ItemFields.MediaSourceCount] };
+        var dtos = dtoService.GetBaseItemDtos([movie], options);
+
+        Assert.Single(dtos);
+        Assert.Equal(3, dtos[0].MediaSourceCount);
+        libraryManager.Verify(x => x.GetItemIdsWithAlternateVersions(It.IsAny<IReadOnlyList<Guid>>()), Times.Once);
     }
 
     private static DtoService BuildDtoService(BaseItem displayParent)


### PR DESCRIPTION
 **Changes**

Browsing a page of videos with the MediaSourceCount field ran one alternate version query per item, each opening a fresh DbContext. On a large library that turned a single page into hundreds of sequential round trips and made the Items endpoint take tens of seconds while holding a request thread the whole time.

Detect which videos own alternate versions once per page with a single query, mirroring the existing people batch. 

The new query is `GetItemsWithAlternateVersions` on `ILinkedChildrenService` (implemented in `LinkedChildrenService`) and exposed through `ILibraryManager.GetItemsWithAlternateVersions`. `DtoService.GetBaseItemDtos` calls it once for the whole page and threads the result into `AttachBasicFields`, where the MediaSourceCount block now skips the per item `GetLinkedAlternateVersions` and `GetLocalAlternateVersionIds` calls for any video that the batch already ruled out. Videos that own no alternate versions are the common case and take that fast path, and videos that do have alternates still take the original path so their count is unchanged. 

Adds a regression test asserting the count resolves from the batch and the per item lookups are never called.

 I verified the output is identical before and after on a real library of 4772 episodes and 196 movies. The MediaSourceCount value for every item matched byte for byte, including the ten episodes that actually have alternate versions (counts of 2, 3 and 7). On that same box the full library page dropped from about 3.45s to about 0.63s with the field requested, which is essentially the cost of the page without the field at all. So for folks with larger libraries this should result in better processing time.

 **Code assistance**
  
  Used an LLM to help build the benchmarking once again before/after verification harness. Context too big for further. I think I got the full path here.

  **Issues**

  Fixes #17547

