### PR TITLE
use NamingOptions for books and improve InternalComicInfoProvider

### DIFF
--- a/Emby.Naming/Common/NamingOptions.cs
+++ b/Emby.Naming/Common/NamingOptions.cs
@@ -12,7 +12,7 @@ using MediaBrowser.Model.Entities;
 namespace Emby.Naming.Common
 {
     /// <summary>
-    /// Big ugly class containing lot of different naming options that should be split and injected instead of passes everywhere.
+    /// Big ugly class containing a lot of different naming options that should be split and injected instead of passes everywhere.
     /// </summary>
     public class NamingOptions
     {
@@ -292,6 +292,37 @@ namespace Emby.Naming.Common
                 ".xm",
                 ".xsp",
                 ".ymf"
+            ];
+
+            ComicFileExtensions =
+            [
+                ".cb7",
+                ".cbr",
+                ".cbt",
+                ".cbz"
+            ];
+
+            ArchiveHtmlFileExtensions =
+            [
+                ".epub",
+                ".ibooks",
+                ".kepub"
+            ];
+
+            BinaryHtmlFileExtensions =
+            [
+                ".azw",
+                ".azw3",
+                ".mobi",
+                ".kfx"
+            ];
+
+            BookFileExtensions =
+            [
+                ".pdf",
+                .. ComicFileExtensions,
+                .. ArchiveHtmlFileExtensions,
+                .. BinaryHtmlFileExtensions
             ];
 
             MediaFlagDelimiters =
@@ -791,6 +822,26 @@ namespace Emby.Naming.Common
         /// Gets or sets list of audio file extensions.
         /// </summary>
         public string[] AudioFileExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of extensions used by comics for images stored directly in an archive file.
+        /// </summary>
+        public string[] ComicFileExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of book file extensions that use HTML and are internally equivalent to EPUB files.
+        /// </summary>
+        public string[] ArchiveHtmlFileExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of book file extensions that package HTML in bespoke containers and formats.
+        /// </summary>
+        public string[] BinaryHtmlFileExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets list of all supported book and comic file extensions. This does not include audiobooks.
+        /// </summary>
+        public string[] BookFileExtensions { get; set; }
 
         /// <summary>
         /// Gets or sets list of external media flag delimiters.

--- a/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Books/BookResolver.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Emby.Naming.Book;
+using Emby.Naming.Common;
 using Jellyfin.Data.Enums;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
@@ -14,7 +15,12 @@ namespace Emby.Server.Implementations.Library.Resolvers.Books
 {
     public class BookResolver : ItemResolver<Book>
     {
-        private readonly string[] _validExtensions = { ".azw", ".azw3", ".cb7", ".cbr", ".cbt", ".cbz", ".epub", ".mobi", ".pdf" };
+        private readonly NamingOptions _namingOptions;
+
+        public BookResolver(NamingOptions namingOptions)
+        {
+            _namingOptions = namingOptions;
+        }
 
         protected override Book? Resolve(ItemResolveArgs args)
         {
@@ -33,7 +39,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Books
 
             var extension = Path.GetExtension(args.Path.AsSpan());
 
-            if (!_validExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
+            if (!_namingOptions.BookFileExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
@@ -58,7 +64,7 @@ namespace Emby.Server.Implementations.Library.Resolvers.Books
             {
                 var fileExtension = Path.GetExtension(f.FullName.AsSpan());
 
-                return _validExtensions.Contains(
+                return _namingOptions.BookFileExtensions.Contains(
                     fileExtension,
                     StringComparison.OrdinalIgnoreCase);
             }).ToList();

--- a/MediaBrowser.Providers/Books/ComicImageProvider.cs
+++ b/MediaBrowser.Providers/Books/ComicImageProvider.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Emby.Naming.Common;
 using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
@@ -16,22 +17,23 @@ using SharpCompress.Archives;
 namespace MediaBrowser.Providers.Books;
 
 /// <summary>
-/// The ComicImageProvider tries to find either an image named "cover" or, in case that
-/// fails, just takes the first image inside the archive, hoping that it is the cover.
+/// This image provider looks for a primary image named cover in a comic archive file. When an image
+/// with that name is missing it will simply use the first image it finds. SharpCompress is required
+/// to support non-ZIP archives.
 /// </summary>
 public class ComicImageProvider : IDynamicImageProvider
 {
-    private readonly string[] _comicBookExtensions = [".cb7", ".cbr", ".cbt", ".cbz"];
-    private readonly string[] _coverExtensions = [".png", ".jpeg", ".jpg", ".webp", ".bmp", ".gif"];
-
+    private readonly NamingOptions _namingOptions;
     private readonly ILogger<ComicImageProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ComicImageProvider"/> class.
     /// </summary>
+    /// <param name="namingOptions">Instance of the <see cref="NamingOptions"/>.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{ComicImageProvider}"/> interface.</param>
-    public ComicImageProvider(ILogger<ComicImageProvider> logger)
+    public ComicImageProvider(NamingOptions namingOptions, ILogger<ComicImageProvider> logger)
     {
+        _namingOptions = namingOptions;
         _logger = logger;
     }
 
@@ -43,7 +45,7 @@ public class ComicImageProvider : IDynamicImageProvider
     {
         var extension = Path.GetExtension(item.Path);
 
-        if (_comicBookExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+        if (_namingOptions.ComicFileExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
         {
             return await LoadCoverAsync(item, cancellationToken).ConfigureAwait(false);
         }
@@ -118,7 +120,7 @@ public class ComicImageProvider : IDynamicImageProvider
 
         // only some comics will explicitly name their cover file
         // in many cases the cover will simply be the first image in the archive
-        foreach (var extension in _coverExtensions)
+        foreach (var extension in BaseItem.SupportedImageExtensions)
         {
             cover = await archive.EntriesAsync.FirstOrDefaultAsync(e => e.Key == "cover" + extension).ConfigureAwait(false);
 
@@ -131,7 +133,7 @@ public class ComicImageProvider : IDynamicImageProvider
         }
 
         cover = await archive.EntriesAsync.OrderBy(x => x.Key)
-            .FirstOrDefaultAsync(x => _coverExtensions.Contains(Path.GetExtension(x.Key), StringComparison.OrdinalIgnoreCase))
+            .FirstOrDefaultAsync(x => BaseItem.SupportedImageExtensions.Contains(Path.GetExtension(x.Key), StringComparison.OrdinalIgnoreCase))
             .ConfigureAwait(false);
 
         if (cover is not null)
@@ -148,9 +150,9 @@ public class ComicImageProvider : IDynamicImageProvider
     {
         ".jpg" => ImageFormat.Jpg,
         ".jpeg" => ImageFormat.Jpg,
+        ".tbn" => ImageFormat.Jpg,
         ".png" => ImageFormat.Png,
         ".webp" => ImageFormat.Webp,
-        ".bmp" => ImageFormat.Bmp,
         ".gif" => ImageFormat.Gif,
         ".svg" => ImageFormat.Svg,
         _ => throw new ArgumentException($"unsupported extension: {extension}"),

--- a/MediaBrowser.Providers/Books/ComicInfo/InternalComicInfoProvider.cs
+++ b/MediaBrowser.Providers/Books/ComicInfo/InternalComicInfoProvider.cs
@@ -1,12 +1,15 @@
 using System;
-using System.IO.Compression;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Emby.Naming.Common;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.IO;
 using Microsoft.Extensions.Logging;
+using SharpCompress.Archives;
 
 namespace MediaBrowser.Providers.Books.ComicInfo;
 
@@ -16,17 +19,20 @@ namespace MediaBrowser.Providers.Books.ComicInfo;
 public class InternalComicInfoProvider : IComicProvider
 {
     private readonly IFileSystem _fileSystem;
+    private readonly NamingOptions _namingOptions;
     private readonly ILogger<InternalComicInfoProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InternalComicInfoProvider"/> class.
     /// </summary>
     /// <param name="fileSystem">Instance of the <see cref="IFileSystem"/> interface.</param>
+    /// <param name="namingOptions">Instance of the <see cref="NamingOptions"/>.</param>
     /// <param name="logger">Instance of the <see cref="ILogger{InternalComicInfoProvider}"/> interface.</param>
-    public InternalComicInfoProvider(IFileSystem fileSystem, ILogger<InternalComicInfoProvider> logger)
+    public InternalComicInfoProvider(IFileSystem fileSystem, NamingOptions namingOptions, ILogger<InternalComicInfoProvider> logger)
     {
         _logger = logger;
         _fileSystem = fileSystem;
+        _namingOptions = namingOptions;
     }
 
     /// <inheritdoc />
@@ -80,18 +86,23 @@ public class InternalComicInfoProvider : IComicProvider
         try
         {
             // open the comic archive and try to get the ComicInfo.xml entry
-            using var comicBookFile = await ZipFile.OpenReadAsync(path, cancellationToken).ConfigureAwait(false);
-            var container = comicBookFile.GetEntry(ComicInfoReader.ComicRackMetaFile);
+            using var stream = AsyncFile.OpenRead(path);
+            var archive = await ArchiveFactory.OpenAsyncArchive(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            var container = await archive.EntriesAsync
+                .FirstOrDefaultAsync(e => string.Equals(e.Key, ComicInfoReader.ComicRackMetaFile, StringComparison.OrdinalIgnoreCase), cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
             if (container is null)
             {
                 return null;
             }
 
-            using var containerStream = await container.OpenAsync(cancellationToken).ConfigureAwait(false);
-            var comicInfoXml = XDocument.LoadAsync(containerStream, LoadOptions.None, cancellationToken);
-
-            return await comicInfoXml.ConfigureAwait(false);
+            var containerStream = await container.OpenEntryStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using (containerStream.ConfigureAwait(false))
+            {
+                return await XDocument.LoadAsync(containerStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (Exception e)
         {
@@ -110,7 +121,8 @@ public class InternalComicInfoProvider : IComicProvider
         }
 
         // only parse files that are known to have internal metadata
-        if (!string.Equals(fileInfo.Extension, ".cbz", StringComparison.OrdinalIgnoreCase))
+        // SharpCompress is required to support non-ZIP archives
+        if (!_namingOptions.ComicFileExtensions.Contains(fileInfo.Extension, StringComparison.OrdinalIgnoreCase))
         {
             return null;
         }

--- a/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
+++ b/MediaBrowser.Providers/MediaInfo/ProbeProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Emby.Naming.Common;
+using Jellyfin.Extensions;
 using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
@@ -46,6 +47,7 @@ namespace MediaBrowser.Providers.MediaInfo
         IHasItemChangeMonitor
     {
         private readonly ILogger<ProbeProvider> _logger;
+        private readonly NamingOptions _namingOptions;
         private readonly AudioResolver _audioResolver;
         private readonly SubtitleResolver _subtitleResolver;
         private readonly LyricResolver _lyricResolver;
@@ -87,6 +89,7 @@ namespace MediaBrowser.Providers.MediaInfo
             IMediaStreamRepository mediaStreamRepository)
         {
             _logger = loggerFactory.CreateLogger<ProbeProvider>();
+            _namingOptions = namingOptions;
             _audioResolver = new AudioResolver(loggerFactory.CreateLogger<AudioResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _subtitleResolver = new SubtitleResolver(loggerFactory.CreateLogger<SubtitleResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
             _lyricResolver = new LyricResolver(loggerFactory.CreateLogger<LyricResolver>(), localization, mediaEncoder, fileSystem, namingOptions);
@@ -226,39 +229,32 @@ namespace MediaBrowser.Providers.MediaInfo
             }
 
             long pageCount;
-            switch (Path.GetExtension(item.Path).ToLowerInvariant())
+            var extension = Path.GetExtension(item.Path)?.ToLowerInvariant();
+
+            if (_namingOptions.ComicFileExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
             {
-                case ".cb7":
-                case ".cbr":
-                case ".cbt":
-                case ".cbz":
-                    using (var stream = File.OpenRead(item.Path))
-                    using (var archive = ArchiveFactory.OpenArchive(stream))
-                    {
-                        pageCount = archive.Entries.Count(e => !e.IsDirectory);
-                    }
-
-                    break;
-
+                // SharpCompress is required to support non-ZIP archives
+                using var stream = File.OpenRead(item.Path);
+                using var archive = ArchiveFactory.OpenArchive(stream);
+                pageCount = archive.Entries.Count(e => !e.IsDirectory);
+            }
+            else if (string.Equals(extension, ".pdf", StringComparison.OrdinalIgnoreCase))
+            {
 #pragma warning disable CA1416
-                case ".pdf":
-                    using (var stream = File.OpenRead(item.Path))
-                    {
-                        pageCount = Conversion.GetPageCount(stream);
-                    }
-
-                    break;
+                using var stream = File.OpenRead(item.Path);
+                pageCount = Conversion.GetPageCount(stream);
 #pragma warning restore CA1416
-
-                case ".epub":
-                    // TODO process CFI and store as a string when multiple progress types are supported
-                    // current progress value is percentage stored as a proportion of one second worth of ticks
-                    item.RunTimeTicks = TimeSpan.TicksPerSecond;
-
-                    return Task.FromResult(ItemUpdateType.MetadataImport);
-
-                default:
-                    return _cachedTask;
+            }
+            else if (_namingOptions.ArchiveHtmlFileExtensions.Contains(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                // TODO process CFI and store as a string when multiple progress types are supported
+                // current progress value is percentage stored as a proportion of one second worth of ticks
+                item.RunTimeTicks = TimeSpan.TicksPerSecond;
+                return Task.FromResult(ItemUpdateType.MetadataImport);
+            }
+            else
+            {
+                return _cachedTask;
             }
 
             // TODO use page count without modification when multiple progress types are supported


### PR DESCRIPTION
**Changes**

Moves the book file extensions to a global location to match other media types. PDF is the odd one out since it doesn't have any sibling formats. Also supports ComicInfo XML from *any* supported archive rather than just ZIP archives.

**Code Assistance**

None

**Issues**

None