### PR TITLE
add setting to disable obsolete endpoints

### DIFF
--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ using Jellyfin.Server.Configuration;
 using Jellyfin.Server.Filters;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Net;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Entities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -107,8 +108,9 @@ namespace Jellyfin.Server.Extensions
         /// <param name="serviceCollection">The service collection.</param>
         /// <param name="pluginAssemblies">An IEnumerable containing all plugin assemblies with API controllers.</param>
         /// <param name="config">The <see cref="NetworkConfiguration"/>.</param>
+        /// <param name="serverConfiguration">The <see cref="ServerConfiguration"/>.</param>
         /// <returns>The MVC builder.</returns>
-        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, IEnumerable<Assembly> pluginAssemblies, NetworkConfiguration config)
+        public static IMvcBuilder AddJellyfinApi(this IServiceCollection serviceCollection, IEnumerable<Assembly> pluginAssemblies, NetworkConfiguration config, ServerConfiguration serverConfiguration)
         {
             IMvcBuilder mvcBuilder = serviceCollection
                 .AddCors()
@@ -129,6 +131,11 @@ namespace Jellyfin.Server.Extensions
                     opts.OutputFormatters.Add(new XmlOutputFormatter());
 
                     opts.ModelBinderProviders.Insert(0, new NullableEnumModelBinderProvider());
+
+                    if (!serverConfiguration.EnableObsoleteEndpoints)
+                    {
+                        opts.Conventions.Add(new ObsoleteEndpointConvention());
+                    }
                 })
 
                 // Clear app parts to avoid other assemblies being picked up

--- a/Jellyfin.Server/Filters/ObsoleteEndpointConvention.cs
+++ b/Jellyfin.Server/Filters/ObsoleteEndpointConvention.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Jellyfin.Server.Filters
+{
+    /// <summary>
+    /// Searches for actions and controllers marked with <see cref="ObsoleteAttribute"/> and applies a custom filter.
+    /// </summary>
+    public class ObsoleteEndpointConvention : IApplicationModelConvention
+    {
+        /// <inheritdoc />
+        public void Apply(ApplicationModel application)
+        {
+            foreach (var controller in application.Controllers)
+            {
+                var isControllerObsolete = controller.Attributes.OfType<ObsoleteAttribute>().Any();
+
+                foreach (var action in controller.Actions)
+                {
+                    if (isControllerObsolete || action.Attributes.OfType<ObsoleteAttribute>().Any())
+                    {
+                        action.Filters.Add(new ObsoleteEndpointFilter());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Jellyfin.Server/Filters/ObsoleteEndpointFilter.cs
+++ b/Jellyfin.Server/Filters/ObsoleteEndpointFilter.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Jellyfin.Server.Filters;
+
+/// <summary>
+/// Short circuits an obsolete endpoint to return an error code.
+/// </summary>
+public class ObsoleteEndpointFilter : IAsyncActionFilter
+{
+    /// <inheritdoc/>
+    public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var obsoleteResponse = new
+        {
+            error = "Endpoint Obsolete",
+            message = "This endpoint has been manually disabled. You can revert this with the EnableObsoleteEndpoints setting."
+        };
+
+        context.Result = new ObjectResult(obsoleteResponse) { StatusCode = StatusCodes.Status410Gone };
+
+        return Task.CompletedTask;
+    }
+}

--- a/Jellyfin.Server/Startup.cs
+++ b/Jellyfin.Server/Startup.cs
@@ -69,7 +69,7 @@ namespace Jellyfin.Server
                 options.HttpsPort = _serverApplicationHost.HttpsPort;
             });
 
-            services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration());
+            services.AddJellyfinApi(_serverApplicationHost.GetApiPluginAssemblies(), _serverConfigurationManager.GetNetworkConfiguration(), _serverConfigurationManager.Configuration);
             services.AddJellyfinDbContext(_serverApplicationHost.ConfigurationManager, _configuration);
             services.AddJellyfinApiSwagger();
 

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -288,4 +288,9 @@ public class ServerConfiguration : BaseApplicationConfiguration
     /// Gets or sets a value indicating whether old authorization methods are allowed.
     /// </summary>
     public bool EnableLegacyAuthorization { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether obsolete endpoints are allowed.
+    /// </summary>
+    public bool EnableObsoleteEndpoints { get; set; } = true;
 }


### PR DESCRIPTION
**Changes**

This is a smaller implementation than #16664 to hopefully garner more support. This setting is not a new framework for experimental or beta features. It is simply an internal flag (available through manual XML configuration) so developers can validate API deprecations without a custom server, exactly the same as the legacy authorization setting.

There is zero performance penalty since IApplicationModelConventions are only run when the server starts.

**Code Assistance**

None

**Issues**

None