### PR TITLE
fix: ignore invalid TMDb person identifiers

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonImageProvider.cs
@@ -54,14 +54,15 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
         {
             var person = (Person)item;
 
-            if (!person.TryGetProviderId(MetadataProvider.Tmdb, out var personTmdbId))
+            if (!person.TryGetProviderId(MetadataProvider.Tmdb, out var personTmdbId)
+                || !TmdbUtils.TryParseTmdbId(personTmdbId, out var parsedPersonTmdbId))
             {
                 return Enumerable.Empty<RemoteImageInfo>();
             }
 
             var language = item.GetPreferredMetadataLanguage();
             var countryCode = item.GetPreferredMetadataCountryCode();
-            var personResult = await _tmdbClientManager.GetPersonAsync(int.Parse(personTmdbId, CultureInfo.InvariantCulture), language, countryCode, cancellationToken).ConfigureAwait(false);
+            var personResult = await _tmdbClientManager.GetPersonAsync(parsedPersonTmdbId, language, countryCode, cancellationToken).ConfigureAwait(false);
             if (personResult?.Images?.Profiles is null)
             {
                 return Enumerable.Empty<RemoteImageInfo>();

--- a/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonProvider.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/People/TmdbPersonProvider.cs
@@ -37,9 +37,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
         /// <inheritdoc />
         public async Task<IEnumerable<RemoteSearchResult>> GetSearchResults(PersonLookupInfo searchInfo, CancellationToken cancellationToken)
         {
-            if (searchInfo.TryGetProviderId(MetadataProvider.Tmdb, out var personTmdbId))
+            if (searchInfo.TryGetProviderId(MetadataProvider.Tmdb, out var personTmdbId)
+                && TmdbUtils.TryParseTmdbId(personTmdbId, out var parsedPersonTmdbId))
             {
-                var personResult = await _tmdbClientManager.GetPersonAsync(int.Parse(personTmdbId, CultureInfo.InvariantCulture), searchInfo.MetadataLanguage, searchInfo.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
+                var personResult = await _tmdbClientManager.GetPersonAsync(parsedPersonTmdbId, searchInfo.MetadataLanguage, searchInfo.MetadataCountryCode, cancellationToken).ConfigureAwait(false);
 
                 if (personResult is not null)
                 {
@@ -89,7 +90,10 @@ namespace MediaBrowser.Providers.Plugins.Tmdb.People
         /// <inheritdoc />
         public async Task<MetadataResult<Person>> GetMetadata(PersonLookupInfo info, CancellationToken cancellationToken)
         {
-            var personTmdbId = Convert.ToInt32(info.GetProviderId(MetadataProvider.Tmdb), CultureInfo.InvariantCulture);
+            var personTmdbId = TmdbUtils.TryParseTmdbId(
+                info.GetProviderId(MetadataProvider.Tmdb), out var parsedPersonTmdbId)
+                ? parsedPersonTmdbId
+                : 0;
 
             // We don't already have an Id, need to fetch it
             if (personTmdbId <= 0)

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -63,6 +63,18 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         private static partial Regex NonWordRegex();
 
         /// <summary>
+        /// Tries to parse a TMDb provider identifier.
+        /// </summary>
+        /// <param name="providerId">The provider identifier.</param>
+        /// <param name="tmdbId">The parsed TMDb identifier.</param>
+        /// <returns><see langword="true"/> when the identifier is a positive integer.</returns>
+        public static bool TryParseTmdbId(string? providerId, out int tmdbId)
+        {
+            return int.TryParse(providerId, NumberStyles.None, CultureInfo.InvariantCulture, out tmdbId)
+                && tmdbId > 0;
+        }
+
+        /// <summary>
         /// Cleans the name according to TMDb requirements.
         /// </summary>
         /// <param name="name">The name of the entity.</param>

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -6,6 +6,27 @@ namespace Jellyfin.Providers.Tests.Tmdb
     public static class TmdbUtilsTests
     {
         [Theory]
+        [InlineData("123", 123)]
+        [InlineData("2147483647", 2147483647)]
+        public static void TryParseTmdbId_Valid_Success(string input, int expected)
+        {
+            Assert.True(TmdbUtils.TryParseTmdbId(input, out var actual));
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("nm123")]
+        [InlineData("0")]
+        [InlineData("-1")]
+        [InlineData("2147483648")]
+        public static void TryParseTmdbId_Invalid_ReturnsFalse(string? input)
+        {
+            Assert.False(TmdbUtils.TryParseTmdbId(input, out _));
+        }
+
+        [Theory]
         [InlineData("de", "de")]
         [InlineData("En", "En")]
         [InlineData("de-de", "de-DE")]


### PR DESCRIPTION
## What changed

Ignore malformed or non-positive TMDb person identifiers instead of throwing during metadata and image updates. Metadata falls back to the existing name search path, while the image provider skips invalid IDs.

Added focused coverage for valid and invalid TMDb identifiers.

## Testing

- `git diff --check`
- `dotnet test tests/Jellyfin.Providers.Tests/Jellyfin.Providers.Tests.csproj --no-restore --filter FullyQualifiedName~TmdbUtilsTests` (not run: this environment has no .NET SDK installed)

Fixes #17581