### PR TITLE
Stop stale item instances from wiping user data on save

### DIFF
--- a/Emby.Server.Implementations/Library/UserDataManager.cs
+++ b/Emby.Server.Implementations/Library/UserDataManager.cs
@@ -79,6 +79,10 @@ namespace Emby.Server.Implementations.Library
 
             var userId = user.InternalId;
             var cacheKey = GetCacheKey(userId, item.Id);
+
+            // the loop above leaves the last key on the object, but reads resolve to the first
+            // key that has a row, and the save just created one for every key
+            userData.Key = keys[0];
             _cache.AddOrUpdate(cacheKey, userData);
             item.UserData = dbContext.UserData.Where(e => e.ItemId == item.Id).AsNoTracking().ToArray(); // rehydrate the cached userdata
 
@@ -186,24 +190,14 @@ namespace Emby.Server.Implementations.Library
             foreach (var item in items)
             {
                 var cacheKey = GetCacheKey(user.InternalId, item.Id);
-                if (_cache.TryGet(cacheKey, out var cachedData))
+                var userData = ResolveCachedUserData(user, item, cacheKey);
+                if (userData is not null)
                 {
-                    result[item.Id] = cachedData;
+                    result[item.Id] = userData;
                 }
                 else
                 {
-                    var userDataRow = ResolveUserDataRow(item, item.UserData?.Where(e => e.UserId.Equals(user.Id)));
-                    var userData = userDataRow is not null ? Map(userDataRow) : null;
-                    if (userData is not null)
-                    {
-                        result[item.Id] = userData;
-                        _cache.AddOrUpdate(cacheKey, userData);
-                    }
-                    else
-                    {
-                        var keys = item.GetUserDataKeys();
-                        itemsNeedingQuery.Add((item, keys));
-                    }
+                    itemsNeedingQuery.Add((item, item.GetUserDataKeys()));
                 }
             }
 
@@ -353,11 +347,71 @@ namespace Emby.Server.Implementations.Library
         public UserItemData? GetUserData(User user, BaseItem item)
         {
             ArgumentNullException.ThrowIfNull(user);
-            var row = ResolveUserDataRow(item, item.UserData?.Where(e => e.UserId.Equals(user.Id)));
-            return row is not null ? Map(row) : new UserItemData()
+            ArgumentNullException.ThrowIfNull(item);
+
+            var cacheKey = GetCacheKey(user.InternalId, item.Id);
+            var userData = ResolveCachedUserData(user, item, cacheKey);
+            if (userData is not null)
             {
-                Key = item.GetUserDataKeys()[0],
-            };
+                return userData;
+            }
+
+            // A null collection means the item was materialized without its user data, not that
+            // there are no rows. Returning defaults there makes the next save, which writes every
+            // column, wipe whatever is actually stored. An empty collection is a real "no rows".
+            if (item.UserData is null)
+            {
+                using var dbContext = _repository.CreateDbContext();
+                var rows = dbContext.UserData
+                    .AsNoTracking()
+                    .Where(e => e.UserId.Equals(user.Id) && e.ItemId.Equals(item.Id))
+                    .ToArray();
+
+                var row = ResolveUserDataRow(item, rows);
+                if (row is not null)
+                {
+                    userData = Map(row);
+                }
+            }
+
+            if (userData is null)
+            {
+                var keys = item.GetUserDataKeys();
+                userData = new UserItemData
+                {
+                    Key = keys.Count > 0 ? keys[0] : string.Empty
+                };
+            }
+
+            _cache.AddOrUpdate(cacheKey, userData);
+            return userData;
+        }
+
+        /// <summary>
+        /// Resolves user data from the cache, falling back to the rows already attached to the item.
+        /// Both public reads share this so a save through one <see cref="BaseItem"/> instance is
+        /// visible to reads through any other instance of the same item.
+        /// </summary>
+        /// <param name="user">The user the data belongs to.</param>
+        /// <param name="item">The item to resolve data for.</param>
+        /// <param name="cacheKey">The cache key for <paramref name="user"/> and <paramref name="item"/>.</param>
+        /// <returns>The resolved data, or <c>null</c> when neither source can answer.</returns>
+        private UserItemData? ResolveCachedUserData(User user, BaseItem item, string cacheKey)
+        {
+            if (_cache.TryGet(cacheKey, out var cachedData))
+            {
+                return cachedData;
+            }
+
+            var row = ResolveUserDataRow(item, item.UserData?.Where(e => e.UserId.Equals(user.Id)));
+            if (row is null)
+            {
+                return null;
+            }
+
+            var userData = Map(row);
+            _cache.AddOrUpdate(cacheKey, userData);
+            return userData;
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Library/IUserDataManager.cs
+++ b/MediaBrowser.Controller/Library/IUserDataManager.cs
@@ -41,6 +41,11 @@ namespace MediaBrowser.Controller.Library
         /// <summary>
         /// Gets the user data.
         /// </summary>
+        /// <remarks>
+        /// The result is cached and may be shared with other callers holding a different
+        /// <see cref="BaseItem"/> instance for the same item, so it must not be mutated without
+        /// being saved through <see cref="SaveUserData(User, BaseItem, UserItemData, UserDataSaveReason, CancellationToken)"/>.
+        /// </remarks>
         /// <param name="user">User to use.</param>
         /// <param name="item">Item to use.</param>
         /// <returns>User data.</returns>

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/UserDataManagerTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using Emby.Server.Implementations.Library;
 using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
@@ -8,6 +10,8 @@ using Jellyfin.Database.Providers.Sqlite;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -65,12 +69,17 @@ public sealed class UserDataManagerTests : IDisposable
             new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
     }
 
-    private AudioBook CreateAudioBook()
+    /// <summary>
+    /// Creates an audio book. Passing an existing <paramref name="id"/> produces a second
+    /// <see cref="BaseItem"/> instance for the same library item, which is what the playback
+    /// session and the rest of the server routinely hold at the same time.
+    /// </summary>
+    private AudioBook CreateAudioBook(Guid? id = null)
     {
         // GetUserDataKeys(): ["Author-Series-0001Book Title", "<item id N>"]
         return new AudioBook
         {
-            Id = Guid.NewGuid(),
+            Id = id ?? Guid.NewGuid(),
             Name = "Book Title",
             Album = "Series",
             AlbumArtists = new[] { "Author" },
@@ -78,7 +87,7 @@ public sealed class UserDataManagerTests : IDisposable
         };
     }
 
-    private UserData CreateUserDataRow(AudioBook item, string key, long positionTicks)
+    private UserData CreateUserDataRow(AudioBook item, string key, long positionTicks, bool isFavorite = false)
     {
         return new UserData
         {
@@ -87,8 +96,35 @@ public sealed class UserDataManagerTests : IDisposable
             UserId = _user.Id,
             User = null,
             CustomDataKey = key,
-            PlaybackPositionTicks = positionTicks
+            PlaybackPositionTicks = positionTicks,
+            IsFavorite = isFavorite
         };
+    }
+
+    /// <summary>
+    /// Inserts the foreign key rows <see cref="UserDataManager.SaveUserData(User, BaseItem, UserItemData, UserDataSaveReason, CancellationToken)"/>
+    /// depends on, plus any user data rows the test wants present without going through the manager.
+    /// </summary>
+    private void SeedDatabase(AudioBook item, params UserData[] rows)
+    {
+        using var ctx = CreateDbContext();
+        ctx.Users.Add(_user);
+
+        // rows belonging to another user need that user to exist for the foreign key to hold
+        foreach (var userId in rows.Select(e => e.UserId).Distinct().Where(id => !id.Equals(_user.Id)))
+        {
+            ctx.Users.Add(new User("user-" + userId.ToString("N"), "auth-provider", "reset-provider") { Id = userId });
+        }
+
+        ctx.BaseItems.Add(new BaseItemEntity { Id = item.Id, Type = typeof(AudioBook).FullName! });
+        ctx.UserData.AddRange(rows);
+        ctx.SaveChanges();
+    }
+
+    private UserData ReadRow(AudioBook item, string key)
+    {
+        using var ctx = CreateDbContext();
+        return ctx.UserData.AsNoTracking().Single(e => e.ItemId.Equals(item.Id) && e.CustomDataKey == key);
     }
 
     [Fact]
@@ -212,5 +248,170 @@ public sealed class UserDataManagerTests : IDisposable
     {
         var item = CreateAudioBook();
         Assert.Throws<ArgumentNullException>(() => _userDataManager.GetUserData(null!, item));
+    }
+
+    [Fact]
+    public void SaveUserData_StaleInstanceProgressSave_DoesNotClobberFavorite()
+    {
+        var favoriteView = CreateAudioBook();
+        SeedDatabase(favoriteView);
+
+        // the instance the favorite request loaded
+        var favoriteData = _userDataManager.GetUserData(_user, favoriteView);
+        Assert.NotNull(favoriteData);
+        favoriteData.IsFavorite = true;
+        _userDataManager.SaveUserData(_user, favoriteView, favoriteData, UserDataSaveReason.UpdateUserRating, CancellationToken.None);
+
+        // the instance the playback session pinned before the favorite was set, so its rows
+        // still say the item is not a favorite
+        var sessionView = CreateAudioBook(favoriteView.Id);
+        Assert.Empty(sessionView.UserData);
+
+        var progressData = _userDataManager.GetUserData(_user, sessionView);
+        Assert.NotNull(progressData);
+        progressData.PlaybackPositionTicks = 123;
+        _userDataManager.SaveUserData(_user, sessionView, progressData, UserDataSaveReason.PlaybackProgress, CancellationToken.None);
+
+        var row = ReadRow(favoriteView, favoriteView.GetUserDataKeys()[0]);
+        Assert.True(row.IsFavorite);
+        Assert.Equal(123, row.PlaybackPositionTicks);
+    }
+
+    [Fact]
+    public void GetUserData_NullNavigationRows_FallsBackToDatabase()
+    {
+        var item = CreateAudioBook();
+        SeedDatabase(item, CreateUserDataRow(item, item.GetUserDataKeys()[0], 0, isFavorite: true));
+
+        // an item materialized by a query that did not include its user data
+        var detached = CreateAudioBook(item.Id);
+        detached.UserData = null!;
+
+        var userData = _userDataManager.GetUserData(_user, detached);
+
+        Assert.NotNull(userData);
+        Assert.True(userData.IsFavorite);
+    }
+
+    [Fact]
+    public void SaveUserData_DtoWithOnlyPosition_PreservesFavoriteOnNullNavigationRows()
+    {
+        var item = CreateAudioBook();
+        SeedDatabase(item, CreateUserDataRow(item, item.GetUserDataKeys()[0], 0, isFavorite: true));
+
+        // seeded directly rather than through the manager so this exercises the database
+        // fallback instead of the cache
+        var detached = CreateAudioBook(item.Id);
+        detached.UserData = null!;
+
+        _userDataManager.SaveUserData(
+            _user,
+            detached,
+            new UpdateUserItemDataDto { PlaybackPositionTicks = 999 },
+            UserDataSaveReason.UpdateUserData);
+
+        var row = ReadRow(item, item.GetUserDataKeys()[0]);
+        Assert.True(row.IsFavorite);
+        Assert.Equal(999, row.PlaybackPositionTicks);
+    }
+
+    [Fact]
+    public void GetUserData_NullItem_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _userDataManager.GetUserData(_user, null!));
+    }
+
+    [Fact]
+    public void GetUserData_NullNavigationRows_PrefersCurrentKeyRow()
+    {
+        var item = CreateAudioBook();
+
+        // the id-key row is inserted first so selection by row order would return it
+        SeedDatabase(
+            item,
+            CreateUserDataRow(item, item.GetUserDataKeys()[1], 111),
+            CreateUserDataRow(item, item.GetUserDataKeys()[0], 222));
+
+        var detached = CreateAudioBook(item.Id);
+        detached.UserData = null!;
+
+        var userData = _userDataManager.GetUserData(_user, detached);
+
+        Assert.NotNull(userData);
+        Assert.Equal(222, userData.PlaybackPositionTicks);
+    }
+
+    [Fact]
+    public void GetUserData_NullNavigationRows_IgnoresOtherUsersRows()
+    {
+        var item = CreateAudioBook();
+        var otherUserRow = CreateUserDataRow(item, item.GetUserDataKeys()[0], 999, isFavorite: true);
+        otherUserRow.UserId = Guid.NewGuid();
+
+        SeedDatabase(item, otherUserRow);
+
+        var detached = CreateAudioBook(item.Id);
+        detached.UserData = null!;
+
+        var userData = _userDataManager.GetUserData(_user, detached);
+
+        Assert.NotNull(userData);
+        Assert.False(userData.IsFavorite);
+        Assert.Equal(0, userData.PlaybackPositionTicks);
+    }
+
+    [Fact]
+    public void GetUserData_EmptyNavigationRows_DoesNotConsultDatabase()
+    {
+        // An empty collection is a hydrated "this item has no rows" answer, so it is taken at face
+        // value. Querying on every empty collection instead would put a database round trip inside
+        // the user data sort comparers, which call this once per comparison.
+        var item = CreateAudioBook();
+        SeedDatabase(item, CreateUserDataRow(item, item.GetUserDataKeys()[0], 222, isFavorite: true));
+
+        var detached = CreateAudioBook(item.Id);
+        Assert.Empty(detached.UserData);
+
+        var userData = _userDataManager.GetUserData(_user, detached);
+
+        Assert.NotNull(userData);
+        Assert.False(userData.IsFavorite);
+        Assert.Equal(item.GetUserDataKeys()[0], userData.Key);
+    }
+
+    [Fact]
+    public void GetUserDataBatch_AfterSaveThroughAnotherInstance_ReturnsSavedData()
+    {
+        var item = CreateAudioBook();
+        SeedDatabase(item);
+
+        var userData = _userDataManager.GetUserData(_user, item);
+        Assert.NotNull(userData);
+        userData.IsFavorite = true;
+        _userDataManager.SaveUserData(_user, item, userData, UserDataSaveReason.UpdateUserRating, CancellationToken.None);
+
+        var sessionView = CreateAudioBook(item.Id);
+
+        var result = _userDataManager.GetUserDataBatch([sessionView], _user);
+
+        Assert.True(result[item.Id].IsFavorite);
+    }
+
+    [Fact]
+    public void SaveUserData_MultiKeyItem_KeepsPrimaryKeyOnSubsequentReads()
+    {
+        var item = CreateAudioBook();
+        SeedDatabase(item);
+        Assert.Equal(2, item.GetUserDataKeys().Count);
+
+        var userData = _userDataManager.GetUserData(_user, item);
+        Assert.NotNull(userData);
+        userData.PlayCount = 3;
+        _userDataManager.SaveUserData(_user, item, userData, UserDataSaveReason.TogglePlayed, CancellationToken.None);
+
+        var reread = _userDataManager.GetUserData(_user, item);
+
+        Assert.NotNull(reread);
+        Assert.Equal(item.GetUserDataKeys()[0], reread.Key);
     }
 }


### PR DESCRIPTION
<!--
Please follow the template. Not doing so may result in your PR being closed.
-->

## Changes

This is the master-side fix for #14981 that was asked for when #15048 was approved for `release-10.11.z` only.

### The bug

`SaveUserData` writes **every column** of the user data row (`Attach(entry).State = EntityState.Modified`), and the value it writes comes from `GetUserData`, which read **only** the `UserData` rows attached to the `BaseItem` instance the caller happened to hold.

Those rows are a per-instance snapshot, and instances split routinely:

- `LibraryManager.RegisterItem` only instance-caches `Video`, `Folder`, `MusicArtist` and `LiveTvChannel`, so an `Audio` item is a fresh object on every `GetItemById`.
- Every list query builds new objects regardless of type.
- `SessionManager` pins one instance in `session.FullNowPlayingItem` for the whole of playback and re-reads user data on every progress report.

So favoriting the currently playing track wrote `IsFavorite` through one instance while the session held another whose snapshot still said `false`; the next progress report read that snapshot and wrote the whole row back with the favorite cleared. That matches what reporters found — the loss lands exactly on the `POST /Sessions/Playing/Progress` request, and favoriting a track that *isn't* playing works. It shows up first in music because `Audio` is never instance-cached, which is the same wall @theguymadmax hit in #15048: `BaseItem.UserData` cannot be the authority when several live copies of one item exist.

### The fix

`GetUserDataBatch` already resolved this correctly — cache, then the attached rows, then a single database query — so the two reads disagreed about where the truth lives. Rather than bolting `GetOrAdd` onto the old single-item read (the 10.11 shape, which predates `ResolveUserDataRow`), the first two tiers are extracted into `ResolveCachedUserData` and used by both. A save through any instance is now visible to reads through every other instance, and the key-priority behaviour of `ResolveUserDataRow` that master gained after 10.11 is preserved.

`GetUserData` additionally falls back to the database when the item's collection is **null** — that means the item was materialized without its user data (the query skipped the include), not that no rows exist, and returning defaults there let the next save wipe what was stored.

`SaveUserData` now also resets the key on the object it caches. The write loop leaves the *last* user data key on it, and most item types insert a provider id key at index 0, so reads that resolve to the first key with a row would otherwise see the wrong one once they start hitting the cache.

### Behaviour changes worth flagging to reviewers

- `GetUserData` returns the shared cached object on a cache hit rather than a fresh copy. I audited every caller in-tree — `MediaSourceManager`, the sort comparers, `UserViewBuilder`, `BaseNfoSaver`, `TVSeriesManager`, `ChannelManager` only read; `SessionManager` ×3, `MarkFavorite`, `UpdateUserItemRatingInternal`, `MarkPlayed`/`MarkUnplayed`, `PropagatePlayedState` and `BaseNfoParser` all save after mutating. None mutate without saving. `release-10.11.z` has shipped these semantics since #15048. I added a `<remarks>` on `IUserDataManager.GetUserData` so plugin authors see the contract.
- Results are now cached even when there is no row, matching what `GetUserDataBatch` already does.
- A collection that is present but **empty** is still taken at face value as "no rows". Querying on every empty collection would put a database round trip inside `PlayCountComparer`/`DatePlayedComparer`, which call this once per comparison, so that boundary is deliberate — `GetUserData_EmptyNavigationRows_DoesNotConsultDatabase` pins it.

### Deliberately not in scope

- The full-row write shape and the `Any()`-then-`Attach` TOCTOU in `SaveUserData`. Both reads now share one authority, so the read-modify-write cycle operates on current data and #14981 stops reproducing; making writes column-scoped is a larger change.
- Truly partial writes for the `UpdateUserItemDataDto` overload — its "only update the fields that are set" contract is still a full-row write underneath, but its base value is now correct.
- `NfoUserDataSaver`/`BaseNfoSaver` writing blank watch state into NFOs (#12408). `BaseNfoParser`'s three reads stop returning blanks as a side effect of this change, but the saver side is its own bug.
- Refreshing `item.UserData` on instances other than the one that saved. `LibraryManager`'s constructor takes `IUserDataManager`, so the dependency cannot go the other way, and pinned `Audio` instances are in no cache to begin with. With reads cache-first the stale arrays are only a fallback tier.
- Cache invalidation for the paths that write `UserData` rows directly (`ItemPersistenceService.ReattachUserDataAsync`, startup migrations). That staleness already exists for `GetUserDataBatch`; an additive invalidation method on `IUserDataManager` would be the follow-up.

## Code assistance

This PR was written with the assistance of an LLM (Claude). The root cause analysis and the decisions here are mine: reading the cache before the per-instance rows rather than trusting `BaseItem.UserData`, sharing one resolver between the single-item and batch reads instead of duplicating the 10.11 patch, gating the database fallback on a null collection so the sort comparers don't gain a query per comparison, and the scope boundaries listed above. The LLM was used to trace the call graph, draft the code and tests, and audit the callers for the shared-instance change. Everything was built and tested locally; the new tests were written first and confirmed to fail on `master` before the fix.

## Issues

Fixes #14981.
