### PR TITLE
refactor: Drop redundant HasAnyProviderIds clause

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -963,17 +963,6 @@ public sealed partial class BaseItemRepository
             baseQuery = baseQuery.WhereHasAnyProviderIds(filter.HasAnyProviderIds);
         }
 
-        if (filter.HasAnyProviderIds is not null && filter.HasAnyProviderIds.Count > 0)
-        {
-            var includeAny = filter.HasAnyProviderIds
-                .SelectMany(kvp => kvp.Value.Select(v => $"{kvp.Key}:{v}"))
-                .ToArray();
-            if (includeAny.Length > 0)
-            {
-                baseQuery = baseQuery.Where(e => e.Provider!.Select(f => f.ProviderId + ":" + f.ProviderValue)!.Any(f => includeAny.Contains(f)));
-            }
-        }
-
         if (filter.HasImdbId.HasValue)
         {
             baseQuery = filter.HasImdbId.Value


### PR DESCRIPTION
Drop redundant HasAnyProviderIds clause

**Changes**
Remove a duplicate application of the `HasAnyProviderIds` filter in the query builder. Two consecutive blocks guarded on the same `HasAnyProviderIds.Count > 0` condition each added the same clause: one via the `WhereHasAnyProviderIds` extension in `JellyfinQueryHelperExtensions`, the other inlining an equivalent `Provider.Select(...).Any(...)` expression. Both produced the same correlated `EXISTS` subquery over `BaseItemProviders` with an identical `IN` list, so the generated SQL carried two identical `EXISTS` clauses. Removed the inlined block, keeping the extension method.

EXIST clause:
```
AND EXISTS (
    SELECT 1
    FROM "BaseItemProviders" AS "b0"
    WHERE "b"."Id" = "b0"."ItemId" AND "b0"."ProviderId" || ':' || "b0"."ProviderValue" IN (@providerKeys1, @providerKeys2, @providerKeys3, @providerKeys4, @providerKeys5, @providerKeys6, @providerKeys7, @providerKeys8, @providerKeys9, @providerKeys10, @providerKeys11, @providerKeys12, @providerKeys13, @providerKeys14, @providerKeys15, @providerKeys16, @providerKeys17, @providerKeys18, @providerKeys19, @providerKeys20)) AND EXISTS (
    SELECT 1
    FROM "BaseItemProviders" AS "b1"
    WHERE "b"."Id" = "b1"."ItemId" AND "b1"."ProviderId" || ':' || "b1"."ProviderValue" IN (@includeAny1, @includeAny2, @includeAny3, @includeAny4, @includeAny5, @includeAny6, @includeAny7, @includeAny8, @includeAny9, @includeAny10, @includeAny11, @includeAny12, @includeAny13, @includeAny14, @includeAny15, @includeAny16, @includeAny17, @includeAny18, @includeAny19, @includeAny20))
```

IDs:

```
SQL Query: .param set @providerKeys1 'Tmdb:259391'
.param set @providerKeys2 'Tmdb:259300'
.param set @providerKeys3 'Tmdb:620067'
.param set @providerKeys4 'Tmdb:1187186'
.param set @providerKeys5 'Tmdb:807172'
.param set @providerKeys6 'Tmdb:807182'
.param set @providerKeys7 'Tmdb:1001142'
.param set @providerKeys8 'Tmdb:259712'
.param set @providerKeys9 'Tmdb:259693'
.param set @providerKeys10 'Tmdb:620499'
.param set @providerKeys11 'Tmdb:1379077'
.param set @providerKeys12 'Tmdb:1380730'
.param set @providerKeys13 'Tmdb:699'
.param set @providerKeys14 'Tmdb:707'
.param set @providerKeys15 'Tmdb:708'
.param set @providerKeys16 'Tmdb:714'
.param set @providerKeys17 'Tmdb:747'
.param set @providerKeys18 'Tmdb:805'
.param set @providerKeys19 'Tmdb:892'
.param set @providerKeys20 'Tmdb:852'
.param set @includeAny1 'Tmdb:259391'
.param set @includeAny2 'Tmdb:259300'
.param set @includeAny3 'Tmdb:620067'
.param set @includeAny4 'Tmdb:1187186'
.param set @includeAny5 'Tmdb:807172'
.param set @includeAny6 'Tmdb:807182'
.param set @includeAny7 'Tmdb:1001142'
.param set @includeAny8 'Tmdb:259712'
.param set @includeAny9 'Tmdb:259693'
.param set @includeAny10 'Tmdb:620499'
.param set @includeAny11 'Tmdb:1379077'
.param set @includeAny12 'Tmdb:1380730'
.param set @includeAny13 'Tmdb:699'
.param set @includeAny14 'Tmdb:707'
.param set @includeAny15 'Tmdb:708'
.param set @includeAny16 'Tmdb:714'
.param set @includeAny17 'Tmdb:747'
.param set @includeAny18 'Tmdb:805'
.param set @includeAny19 'Tmdb:892'
.param set @includeAny20 'Tmdb:852'
```

**Code assistance**
N/A (A little text translation to write the PR text in English)

