### PR TITLE
fix: correct IsAiring negation to exclude airing items

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -356,7 +356,7 @@ public sealed partial class BaseItemRepository
             }
             else
             {
-                baseQuery = baseQuery.Where(e => e.StartDate > now && e.EndDate < now);
+                baseQuery = baseQuery.Where(e => e.StartDate > now || e.EndDate < now);
             }
         }
 


### PR DESCRIPTION
Correct IsAiring negation to exclude airing items

**Changes**
Fix the `IsAiring == false` filter, which used a contradictory condition (`StartDate > now && EndDate < now`) that required an item to start in the future and end in the past simultaneously, impossible for any item with StartDate <= EndDate, so the filter matched (almost) nothing. The correct negation of the airing condition (`StartDate <= now && EndDate >= now`) is `StartDate > now || EndDate < now`

**Code assistance**
N/A

