### PR TITLE
fix: bound remote provider pagination

### DIFF
--- a/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
+++ b/Emby.Server.Implementations/Library/SimilarItems/SimilarItemsManager.cs
@@ -183,6 +183,7 @@ public class SimilarItemsManager : ISimilarItemsManager
                     // Collect references in batches and resolve against local library.
                     // Stop fetching once we have enough resolved local items.
                     const int BatchSize = 20;
+                    const int MaxRemoteReferenceFetchLimit = 500;
                     var remaining = requestedLimit - allResults.Count;
                     var collectedReferences = new List<SimilarItemReference>();
                     var pendingBatch = new List<SimilarItemReference>();
@@ -199,7 +200,7 @@ public class SimilarItemsManager : ISimilarItemsManager
                             remaining -= resolvedItems.Count;
                             pendingBatch.Clear();
 
-                            if (remaining <= 0)
+                            if (remaining <= 0 || collectedReferences.Count >= MaxRemoteReferenceFetchLimit)
                             {
                                 break;
                             }


### PR DESCRIPTION
Bound remote provider pagination

**Changes**
`/Items/{id}/Similar` never returns when a remote provider like TMDb is enabled and few of its suggestions exist in the local library, I gave up after 5 minutes every time.

The endpoint keeps fetching page after page from the provider until it has enough local matches, so on a small library it just keeps going until the provider runs out of pages.

This PR stops once enough suggestions have been fetched, and caps the total at 500 per provider.

Same endpoint and library: over 5 minutes → 280 ms.

If this exhaustive retrieval was intentional, I would close this PR, but it makes the endpoint too slow when used with small libraries.

Given the time it takes with 500 items, it's entirely possible to increase this value, but I don't know how it will perform on less powerful servers or devices.

**Code assistance**
N/A