### PR TITLE
fix: resolve .m4b files as AudioBook in all library types

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Audio/AudioResolver.cs
@@ -114,16 +114,17 @@ namespace Emby.Server.Implementations.Library.Resolvers.Audio
 
                 var isMusicCollectionType = collectionType == CollectionType.music;
 
-                // Use regular audio type for mixed libraries, owned items and music
-                if (isMixedCollectionType ||
+                // .m4b is an audiobook-specific container; treat it as AudioBook in all library types
+                // so that resume position is saved correctly regardless of where the file lives.
+                if (isBooksCollectionType || extension.Equals(".m4b", StringComparison.OrdinalIgnoreCase))
+                {
+                    item = new AudioBook();
+                }
+                else if (isMixedCollectionType ||
                     args.Parent is null ||
                     isMusicCollectionType)
                 {
                     item = new MediaBrowser.Controller.Entities.Audio.Audio();
-                }
-                else if (isBooksCollectionType)
-                {
-                    item = new AudioBook();
                 }
 
                 if (item is not null)

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/AudioResolverTests.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Emby.Naming.Common;
 using Emby.Server.Implementations.Library.Resolvers.Audio;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
@@ -48,6 +49,49 @@ public class AudioResolverTests
     {
         var resolved = TestResolveChildren("/parent/book title", children);
         Assert.Null(resolved);
+    }
+
+    [Theory]
+    [InlineData(CollectionType.music)]
+    [InlineData(CollectionType.books)]
+    [InlineData(null)]
+    public void Resolve_M4bFile_ReturnsAudioBookInAllLibraryTypes(CollectionType? collectionType)
+    {
+        var resolver = new AudioResolver(_namingOptions);
+        var args = new ItemResolveArgs(null, Mock.Of<ILibraryManager>())
+        {
+            CollectionType = collectionType,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = "/audiobooks/Titan War/Titan War.m4b",
+                IsDirectory = false
+            }
+        };
+
+        var result = resolver.Resolve(args);
+
+        Assert.IsType<AudioBook>(result);
+    }
+
+    [Fact]
+    public void Resolve_Mp3InMusicLibrary_ReturnsPlainAudio()
+    {
+        var resolver = new AudioResolver(_namingOptions);
+        var args = new ItemResolveArgs(null, Mock.Of<ILibraryManager>())
+        {
+            CollectionType = CollectionType.music,
+            FileInfo = new FileSystemMetadata
+            {
+                FullName = "/music/artist/track.mp3",
+                IsDirectory = false
+            }
+        };
+
+        var result = resolver.Resolve(args);
+
+        Assert.NotNull(result);
+        Assert.IsNotType<AudioBook>(result);
+        Assert.IsType<Audio>(result);
     }
 
     private Audio? TestResolveChildren(string parent, string[] children)


### PR DESCRIPTION
**Changes**
Check for the `.m4b` extension before the library-type branch in `AudioResolver.Resolve` so that `.m4b` files are always resolved as `AudioBook`, regardless of the parent library type. This fixes resume position never being saved for `.m4b` audiobooks in Music libraries — `Audio` items return `SupportsPositionTicksResume = false`, so `UserDataManager.UpdatePlayState` always zeroed the position at the guard on line 480.

Added two regression tests: `Resolve_M4bFile_ReturnsAudioBookInAllLibraryTypes` (theory over music/books/null confirming `.m4b` always produces `AudioBook`) and `Resolve_Mp3InMusicLibrary_ReturnsPlainAudio` (confirms `.mp3` in a Music library still resolves to plain `Audio`). All 22 `AudioResolverTests` pass.

**Code assistance**
AI assistance (Claude Code, Anthropic) used for root-cause analysis, identifying the relevant `SupportsPositionTicksResume` guard in `UserDataManager`, and writing tests. Logic reviewed and confirmed correct before submission.

**Issues**
Fixes #17545