### PR TITLE
Fix PersonTypes not applied when filtering by person

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -370,14 +370,16 @@ public sealed partial class BaseItemRepository
                     p => p.Name,
                     (b, p) => p.Id);
 
+            var personTypes = filter.PersonTypes;
             baseQuery = baseQuery
                 .Where(e => context.PeopleBaseItemMap
-                    .Any(m => m.ItemId == e.Id && peopleEntityIds.Contains(m.PeopleId)));
+                    .Any(m => m.ItemId == e.Id && peopleEntityIds.Contains(m.PeopleId) && (personTypes.Length == 0 || personTypes.Contains(m.People.PersonType))));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.Person))
         {
-            baseQuery = baseQuery.Where(e => e.Peoples!.Any(f => f.People.Name == filter.Person));
+            var personTypes = filter.PersonTypes;
+            baseQuery = baseQuery.Where(e => e.Peoples!.Any(f => f.People.Name == filter.Person && (personTypes.Length == 0 || personTypes.Contains(f.People.PersonType))));
         }
 
         if (!string.IsNullOrWhiteSpace(filter.ExternalSeriesId))


### PR DESCRIPTION
When filtering items by Person alongside `PersonTypes` (e.g., Director), we returned results matched on name/id, so in the Movie suggestions page, the request for "Directed By" would return all credits regardless of the department. E.g., Directed by "James Gunn" would also return results where he was credited as a writer.

**Changes**
Add a condition to check for `PersonTypes` when filtering people

**Code assistance**
N/A

**Issues**
None Reported
