### PR TITLE
Resolve StartupHelpers/Program type cycle for resource lookup

### DIFF
--- a/Jellyfin.Server/Helpers/StartupHelpers.cs
+++ b/Jellyfin.Server/Helpers/StartupHelpers.cs
@@ -236,7 +236,7 @@ public static class StartupHelpers
         // Get a stream of the resource contents
         // NOTE: The .csproj name is used instead of the assembly name in the resource path
         const string ResourcePath = "Jellyfin.Server.Resources.Configuration.logging.json";
-        Stream resource = typeof(Program).Assembly.GetManifestResourceStream(ResourcePath)
+        Stream resource = typeof(StartupHelpers).Assembly.GetManifestResourceStream(ResourcePath)
                           ?? throw new InvalidOperationException($"Invalid resource path: '{ResourcePath}'");
         await using (resource.ConfigureAwait(false))
         {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**

InitLoggingConfigFile used typeof(Program).Assembly to resolve the assembly containing the embedded logging.json resource, even though Program has no other relationship to this method. Dependency-graph analysis (type-level SCC over CALLS/USES_TYPE/etc. edges) shows this was the only edge running Helpers -> Program; all 7 real edges between the two types run Program -> Helpers (Program.StartApp/StartServer calling into StartupHelpers). The lone back-edge made the pair a 2-node strongly connected component instead of a clean one-directional dependency.

Using typeof(StartupHelpers) instead resolves the same assembly (both types are in Jellyfin.Server) with no behavior change, and removes the only cycle between these two types.

**Code assistance**

Found via static dependency-graph analysis of the solution (type-level call/uses graph, strongly-connected-component detection). Claude was used to help verify the reasoning and draft this PR description.

**Issues**

None — small, self-contained cleanup with no associated issue.

