### PR TITLE
Upgrade SQLitePCLRaw.lib.e_sqlite3 to 2.1.12

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,6 +79,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.ReDoc" Version="10.2.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
     <PackageVersion Include="z440.atl.core" Version="7.16.0" />
     <PackageVersion Include="TMDbLib" Version="3.0.0" />

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Jellyfin.Database.Providers.Sqlite.csproj
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Jellyfin.Database.Providers.Sqlite.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Fixes outstanding SqlitePCLRaw CVEs

```
  Jellyfin.Database.Providers.Sqlite net10.0 succeeded with 1 warning(s) (3.8s) → src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/bin/Release/net10.0/Jellyfin.Database.Providers.Sqlite.dll
    /workspaces/jellyfin-jellyfin/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/Jellyfin.Database.Providers.Sqlite.csproj : warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
```

Per:
https://github.com/dotnet/efcore/issues/38257#issuecomment-4896893046

**Changes**

- Add explicit version reference to Directory.Packages.props
- Add explicit package reference for SQLitePCLRaw.lib.e_sqlite3 in Jellyfin.Database.Providers.Sqlite.csproj

**Code assistance**

None

**Issues**

Resolved build warnings about vulnerabilities