### PR TITLE
Fix VAAPI transcodes without a target bitrate

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2685,7 +2685,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             return reasons;
         }
 
-        public int GetVideoBitrateParamValue(BaseEncodingJobOptions request, MediaStream videoStream, string outputVideoCodec)
+        public int? GetVideoBitrateParamValue(BaseEncodingJobOptions request, MediaStream videoStream, string outputVideoCodec)
         {
             var bitrate = request.VideoBitRate;
 
@@ -2726,7 +2726,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             // applies when a LiveStreamId is set (M3U/HDHR sources). Plugin streams and other
             // sources that bypass the LiveTV pipeline are not covered by it.
             const int MaxSaneBitrate = 400_000_000; // 400 Mbps
-            return Math.Min(bitrate ?? 0, MaxSaneBitrate);
+            return bitrate.HasValue ? Math.Min(bitrate.Value, MaxSaneBitrate) : null;
         }
 
         private int GetMinBitrate(int sourceBitrate, int requestedBitrate)

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -261,6 +261,17 @@ public class EncodingHelperTests
         Assert.Contains("-ar 48000", args, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void GetVideoBitrateParamValue_WithoutRequestedBitrate_PreservesNullForVaapi()
+    {
+        var request = new VideoRequestDto();
+        var video = new MediaStream { Type = MediaStreamType.Video, Codec = "hevc" };
+
+        var bitrate = CreateHelper().GetVideoBitrateParamValue(request, video, "h264_vaapi");
+
+        Assert.Null(bitrate);
+    }
+
     private static EncodingJobInfo BuildAudioState(string audioCodec, int requestedSampleRate, string? outputContainer = null)
     {
         var audio = new MediaStream { Index = 0, Type = MediaStreamType.Audio, Codec = "flac", SampleRate = 96000 };


### PR DESCRIPTION
## Summary\n- preserve an omitted VideoBitRate as null instead of converting it to zero\n- allow the existing command generator to omit bitrate and VAAPI VBR flags when no target bitrate was requested\n- add a regression test for an omitted bitrate with a VAAPI encoder\n\n## Test plan\n- dotnet test tests/Jellyfin.Controller.Tests/Jellyfin.Controller.Tests.csproj --filter FullyQualifiedName~GetVideoBitrateParamValue_WithoutRequestedBitrate_PreservesNullForVaapi\n\nThe local environment does not have the .NET SDK, so this focused test is pending GitHub Actions.