### PR TITLE
Respect SaveLocalMetadata when MetadataSavers is explicitly set

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -902,6 +902,26 @@ namespace MediaBrowser.Providers.Manager
                         {
                             return false;
                         }
+
+                        // An explicit MetadataSavers enable-list must still respect SaveLocalMetadata.
+                        // Otherwise SaveLocalMetadata=false + MetadataSavers=["Nfo"] writes sidecars
+                        // even on read-only library mounts (IOException), which can leave locked
+                        // episode items without season/episode numbers.
+                        if (!item.IsSaveLocalMetadataEnabled())
+                        {
+                            if (updateType >= ItemUpdateType.MetadataEdit)
+                            {
+                                // Manual edit occurred — allow updating an existing sidecar only.
+                                if (saver is not IMetadataFileSaver fileSaver || !File.Exists(fileSaver.GetSavePath(item)))
+                                {
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                return false;
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
When a library has an explicit `MetadataSavers` enable-list (e.g. `["Nfo"]`), `IsSaverEnabledForItem` previously skipped the `SaveLocalMetadata` check entirely. That meant `SaveLocalMetadata=false` + `MetadataSavers=["Nfo"]` still wrote NFO sidecars on every metadata save.

On a **read-only** media mount this throws `IOException: Read-only file system`, and we have seen locked episode items left with null `IndexNumber`/`ParentIndexNumber` (UI shows only the series name) while Emby on the same files indexes correctly.

This change applies the same `SaveLocalMetadata` / existing-sidecar rules used when `MetadataSavers` is null to the explicit enable-list path.

## Changes
- `ProviderManager.IsSaverEnabledForItem`: after confirming the saver is in `MetadataSavers`, still require `IsSaveLocalMetadataEnabled()` (with the existing MetadataEdit + existing-file exception).

## How to test
1. Library with media on a read-only mount, `SaveLocalMetadata=false`, `MetadataSavers` containing `Nfo`.
2. Refresh an episode / import a new `SxxExx` file.
3. **Before:** log spam `Read-only file system : '….nfo'`; possible locked null-index episode.
4. **After:** no NFO write attempts; episode keeps/gets season+episode from the filename path parser.

## Related
DarkFlux production repro 2026-08-12 (Lucky S01E06). Same RO mount worked under Emby.


Made with [Cursor](https://cursor.com)