### PR TITLE
Treat empty library roots as accessible for monitoring

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -380,10 +380,12 @@ namespace MediaBrowser.Controller.Entities
                 return true;
             }
 
-            // For top parents i.e. Library folders, skip the validation if it's empty or inaccessible
+            // For top parents i.e. Library folders, skip only when the path is missing/unreadable.
+            // Empty directories are valid — realtime monitoring must still register so the first
+            // import is discovered without a manual library refresh.
             if (item.IsTopParent && !directoryService.IsAccessible(item.ContainingFolderPath))
             {
-                Logger.LogWarning("Library folder {LibraryFolderPath} is inaccessible or empty, skipping", item.ContainingFolderPath);
+                Logger.LogWarning("Library folder {LibraryFolderPath} is inaccessible, skipping", item.ContainingFolderPath);
                 return false;
             }
 

--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -132,7 +132,11 @@ namespace MediaBrowser.Controller.Providers
 
         public bool IsAccessible(string path)
         {
-            return _fileSystem.GetFileSystemEntryPaths(path).Any();
+            // Existence is enough. Requiring children made empty library roots look
+            // "inaccessible", so ValidateChildren skipped them and LibraryMonitor never
+            // watched the path — first imports into a new root stayed invisible until a
+            // manual refresh after the folder was non-empty.
+            return _fileSystem.DirectoryExists(path);
         }
     }
 }


### PR DESCRIPTION
## Summary
`DirectoryService.IsAccessible` required at least one filesystem entry in the path. An **empty** library root therefore failed `IsLibraryFolderAccessible`, so `ValidateChildren` skipped it and logged `Library folder … is inaccessible or empty, skipping`.

In practice that also meant **LibraryMonitor never watched** the root for the lifetime of the process until a later successful refresh when the folder was non-empty. The first import into a new library root (common with *arr* + a freshly created `movies-4k`-style path) stayed invisible until a manual `POST /Library/Refresh`.

## Changes
- `IsAccessible`: use `DirectoryExists` instead of `GetFileSystemEntryPaths(…).Any()`.
- Warning text: drop “or empty” — only inaccessible paths are skipped.

## How to test
1. Add an empty directory as a library path (or empty a library root of all media except optionally nothing).
2. Restart / validate libraries.
3. **Before:** warning `inaccessible or empty, skipping`; drop a file in → no realtime refresh.
4. **After:** no skip warning; drop a file in → LibraryMonitor refreshes within debounce.

## Related
Workaround today: place a `.keep` file in every media root. This removes the need for that for watcher registration.


Made with [Cursor](https://cursor.com)