### PR TITLE
Add Collections metadata path setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,5 @@ mono_crash.*.json
 # Devcontainer temp files
 .devcontainer/devcontainer-lock.json
 dotnet/
+
+jellyfin-amd64/

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -9,6 +9,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Collections;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Library;
@@ -35,6 +36,7 @@ namespace Emby.Server.Implementations.Collections
         private readonly ILinkedChildrenService _linkedChildrenService;
         private readonly ILocalizationManager _localizationManager;
         private readonly IApplicationPaths _appPaths;
+        private readonly IServerConfigurationManager _serverConfigurationManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CollectionManager"/> class.
@@ -47,6 +49,7 @@ namespace Emby.Server.Implementations.Collections
         /// <param name="loggerFactory">The logger factory.</param>
         /// <param name="providerManager">The provider manager.</param>
         /// <param name="linkedChildrenService">The linked children service.</param>
+        /// <param name="serverConfigurationManager">The server configuration manager.</param>
         public CollectionManager(
             ILibraryManager libraryManager,
             IApplicationPaths appPaths,
@@ -55,7 +58,8 @@ namespace Emby.Server.Implementations.Collections
             ILibraryMonitor iLibraryMonitor,
             ILoggerFactory loggerFactory,
             IProviderManager providerManager,
-            ILinkedChildrenService linkedChildrenService)
+            ILinkedChildrenService linkedChildrenService,
+            IServerConfigurationManager serverConfigurationManager)
         {
             _libraryManager = libraryManager;
             _fileSystem = fileSystem;
@@ -65,6 +69,7 @@ namespace Emby.Server.Implementations.Collections
             _linkedChildrenService = linkedChildrenService;
             _localizationManager = localizationManager;
             _appPaths = appPaths;
+            _serverConfigurationManager = serverConfigurationManager;
         }
 
         /// <inheritdoc />
@@ -118,6 +123,12 @@ namespace Emby.Server.Implementations.Collections
 
         internal string GetCollectionsFolderPath()
         {
+            var configuredCollectionsPath = _serverConfigurationManager.Configuration.CollectionsPath;
+            if (!string.IsNullOrWhiteSpace(configuredCollectionsPath))
+            {
+                return configuredCollectionsPath;
+            }
+
             return Path.Combine(_appPaths.DataPath, "collections");
         }
 

--- a/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
+++ b/Emby.Server.Implementations/Configuration/ServerConfigurationManager.cs
@@ -30,6 +30,7 @@ namespace Emby.Server.Implementations.Configuration
             : base(applicationPaths, loggerFactory, xmlSerializer)
         {
             UpdateMetadataPath();
+            UpdateCollectionsPath();
         }
 
         /// <summary>
@@ -61,6 +62,7 @@ namespace Emby.Server.Implementations.Configuration
         protected override void OnConfigurationUpdated()
         {
             UpdateMetadataPath();
+            UpdateCollectionsPath();
 
             base.OnConfigurationUpdated();
         }
@@ -80,6 +82,17 @@ namespace Emby.Server.Implementations.Configuration
         }
 
         /// <summary>
+        /// Ensures the configured collections path exists.
+        /// </summary>
+        private void UpdateCollectionsPath()
+        {
+            if (!string.IsNullOrWhiteSpace(Configuration.CollectionsPath))
+            {
+                Directory.CreateDirectory(Configuration.CollectionsPath);
+            }
+        }
+
+        /// <summary>
         /// Replaces the configuration.
         /// </summary>
         /// <param name="newConfiguration">The new configuration.</param>
@@ -89,6 +102,7 @@ namespace Emby.Server.Implementations.Configuration
             var newConfig = (ServerConfiguration)newConfiguration;
 
             ValidateMetadataPath(newConfig);
+            ValidateCollectionsPath(newConfig);
 
             ConfigurationUpdating?.Invoke(this, new GenericEventArgs<ServerConfiguration>(newConfig));
 
@@ -106,6 +120,31 @@ namespace Emby.Server.Implementations.Configuration
 
             if (!string.IsNullOrWhiteSpace(newPath)
                 && !string.Equals(Configuration.MetadataPath, newPath, StringComparison.Ordinal))
+            {
+                if (!Directory.Exists(newPath))
+                {
+                    throw new DirectoryNotFoundException(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{0} does not exist.",
+                            newPath));
+                }
+
+                EnsureWriteAccess(newPath);
+            }
+        }
+
+        /// <summary>
+        /// Validates the collections path.
+        /// </summary>
+        /// <param name="newConfig">The new configuration.</param>
+        /// <exception cref="DirectoryNotFoundException">The new config path doesn't exist.</exception>
+        private void ValidateCollectionsPath(ServerConfiguration newConfig)
+        {
+            var newPath = newConfig.CollectionsPath;
+
+            if (!string.IsNullOrWhiteSpace(newPath)
+                && !string.Equals(Configuration.CollectionsPath, newPath, StringComparison.Ordinal))
             {
                 if (!Directory.Exists(newPath))
                 {

--- a/MediaBrowser.Model/Configuration/ServerConfiguration.cs
+++ b/MediaBrowser.Model/Configuration/ServerConfiguration.cs
@@ -97,6 +97,12 @@ public class ServerConfiguration : BaseApplicationConfiguration
     public string MetadataPath { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the collections path.
+    /// </summary>
+    /// <value>The collections path.</value>
+    public string CollectionsPath { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the preferred metadata language.
     /// </summary>
     /// <value>The preferred metadata language.</value>

--- a/tests/Jellyfin.Api.Tests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/ConfigurationControllerTests.cs
@@ -1,0 +1,51 @@
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Configuration;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class ConfigurationControllerTests
+{
+    [Fact]
+    public void GetConfiguration_ReturnsCollectionsPath()
+    {
+        var configuration = new ServerConfiguration
+        {
+            CollectionsPath = @"D:\Media\Collections"
+        };
+
+        var controller = new ConfigurationController(
+            Mock.Of<IServerConfigurationManager>(manager => manager.Configuration == configuration),
+            Mock.Of<IMediaEncoder>());
+
+        var result = controller.GetConfiguration();
+
+        Assert.Equal(configuration.CollectionsPath, result.Value!.CollectionsPath);
+    }
+
+    [Fact]
+    public void UpdateConfiguration_ForwardsCollectionsPath()
+    {
+        ServerConfiguration? updatedConfiguration = null;
+        var configurationManager = new Mock<IServerConfigurationManager>();
+        configurationManager.SetupGet(manager => manager.Configuration).Returns(new ServerConfiguration());
+        configurationManager
+            .Setup(manager => manager.ReplaceConfiguration(It.IsAny<BaseApplicationConfiguration>()))
+            .Callback<BaseApplicationConfiguration>(configuration => updatedConfiguration = (ServerConfiguration)configuration);
+
+        var controller = new ConfigurationController(configurationManager.Object, Mock.Of<IMediaEncoder>());
+
+        var result = controller.UpdateConfiguration(new ServerConfiguration
+        {
+            CollectionsPath = @"D:\Media\Collections"
+        });
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.NotNull(updatedConfiguration);
+        Assert.Equal(@"D:\Media\Collections", updatedConfiguration!.CollectionsPath);
+    }
+}


### PR DESCRIPTION
Adds the ability to set the path for the Collections metadata. This allows the data to be stored with the media if desired.

Defaults, if blank, to the current server data/collections directory, so until set it changes nothing.

Added UI for setting this in https://github.com/jellyfin/jellyfin-web/pull/8359

**Changes**

Add CollectionsPath to the ServerConfiguration
Add UpdateCollectionsPath to the ServerConfigurationManager
Use new setting in the GetCollectionsFolderPath of CollectionManager
Add unit tests for the ConfigurationController

**Code assistance**

None

**Issues**

None