### PR TITLE
Fix unit test for localization of Artists in DE

### DIFF
--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -427,7 +427,7 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
             {
                 CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de");
                 var translated = localizationManager.GetLocalizedString("Artists");
-                Assert.Equal("Interpreten", translated);
+                Assert.Equal("Künstler", translated);
             }
             finally
             {


### PR DESCRIPTION
Fix the broken localization unit test brought on by a localization change in the DE translation of Artists

**Changes**

Change expected string in unit test to match current DE localization introduced in commit 21fec95b07f04e70dc2a6250f3f00d7b63003650

**Code assistance**

None

**Issues**

Failed unit test in unrelated PR https://github.com/jellyfin/jellyfin/actions/runs/31748124023/job/94607420341?pr=17632#step:4:166