### PR TITLE
Add numeric user ratings to the API

### DIFF
--- a/Emby.Server.Implementations/Sorting/UserRatingComparer.cs
+++ b/Emby.Server.Implementations/Sorting/UserRatingComparer.cs
@@ -1,0 +1,64 @@
+#nullable disable
+
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Sorting;
+using MediaBrowser.Model.Querying;
+
+namespace Emby.Server.Implementations.Sorting
+{
+    /// <summary>
+    /// Class UserRatingComparer.
+    /// </summary>
+    public class UserRatingComparer : IUserBaseItemComparer
+    {
+        /// <summary>
+        /// Gets or sets the user.
+        /// </summary>
+        /// <value>The user.</value>
+        public User User { get; set; }
+
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>The name.</value>
+        public ItemSortBy Type => ItemSortBy.UserRating;
+
+        /// <summary>
+        /// Gets or sets the user data manager.
+        /// </summary>
+        /// <value>The user data manager.</value>
+        public IUserDataManager UserDataManager { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user manager.
+        /// </summary>
+        /// <value>The user manager.</value>
+        public IUserManager UserManager { get; set; }
+
+        /// <summary>
+        /// Compares the specified x.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <returns>System.Int32.</returns>
+        public int Compare(BaseItem x, BaseItem y)
+        {
+            return GetValue(x).CompareTo(GetValue(y));
+        }
+
+        /// <summary>
+        /// Gets the user's rating.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <returns>System.Double.</returns>
+        private double GetValue(BaseItem x)
+        {
+            var userdata = UserDataManager.GetUserData(User, x);
+
+            return userdata?.Rating ?? 0;
+        }
+    }
+}

--- a/Jellyfin.Api/Controllers/ItemsController.cs
+++ b/Jellyfin.Api/Controllers/ItemsController.cs
@@ -98,6 +98,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="isUnaired">Optional filter by items that are unaired episodes or not.</param>
     /// <param name="minCommunityRating">Optional filter by minimum community rating.</param>
     /// <param name="minCriticRating">Optional filter by minimum critic rating.</param>
+    /// <param name="minUserRating">Optional filter by minimum personal rating of the requesting user.</param>
     /// <param name="minPremiereDate">Optional. The minimum premiere date. Format = ISO.</param>
     /// <param name="minDateLastSaved">Optional. The minimum last saved date. Format = ISO.</param>
     /// <param name="minDateLastSavedForUser">Optional. The minimum last saved date for the current user. Format = ISO.</param>
@@ -190,6 +191,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] bool? isUnaired,
         [FromQuery] double? minCommunityRating,
         [FromQuery] double? minCriticRating,
+        [FromQuery] double? minUserRating,
         [FromQuery] DateTime? minPremiereDate,
         [FromQuery] DateTime? minDateLastSaved,
         [FromQuery] DateTime? minDateLastSavedForUser,
@@ -438,6 +440,7 @@ public class ItemsController : BaseJellyfinApiController
             ItemIds = itemIds,
             MinCommunityRating = minCommunityRating,
             MinCriticRating = minCriticRating,
+            MinUserRating = minUserRating,
             ParentId = parentId ?? Guid.Empty,
             IndexNumber = indexNumber,
             ParentIndexNumber = parentIndexNumber,
@@ -650,6 +653,7 @@ public class ItemsController : BaseJellyfinApiController
     /// <param name="isUnaired">Optional filter by items that are unaired episodes or not.</param>
     /// <param name="minCommunityRating">Optional filter by minimum community rating.</param>
     /// <param name="minCriticRating">Optional filter by minimum critic rating.</param>
+    /// <param name="minUserRating">Optional filter by minimum personal rating of the requesting user.</param>
     /// <param name="minPremiereDate">Optional. The minimum premiere date. Format = ISO.</param>
     /// <param name="minDateLastSaved">Optional. The minimum last saved date. Format = ISO.</param>
     /// <param name="minDateLastSavedForUser">Optional. The minimum last saved date for the current user. Format = ISO.</param>
@@ -741,6 +745,7 @@ public class ItemsController : BaseJellyfinApiController
         [FromQuery] bool? isUnaired,
         [FromQuery] double? minCommunityRating,
         [FromQuery] double? minCriticRating,
+        [FromQuery] double? minUserRating,
         [FromQuery] DateTime? minPremiereDate,
         [FromQuery] DateTime? minDateLastSaved,
         [FromQuery] DateTime? minDateLastSavedForUser,
@@ -828,6 +833,7 @@ public class ItemsController : BaseJellyfinApiController
             isUnaired,
             minCommunityRating,
             minCriticRating,
+            minUserRating,
             minPremiereDate,
             minDateLastSaved,
             minDateLastSavedForUser,

--- a/Jellyfin.Api/Controllers/TrailersController.cs
+++ b/Jellyfin.Api/Controllers/TrailersController.cs
@@ -51,6 +51,7 @@ public class TrailersController : BaseJellyfinApiController
     /// <param name="isUnaired">Optional filter by items that are unaired episodes or not.</param>
     /// <param name="minCommunityRating">Optional filter by minimum community rating.</param>
     /// <param name="minCriticRating">Optional filter by minimum critic rating.</param>
+    /// <param name="minUserRating">Optional filter by minimum personal rating of the requesting user.</param>
     /// <param name="minPremiereDate">Optional. The minimum premiere date. Format = ISO.</param>
     /// <param name="minDateLastSaved">Optional. The minimum last saved date. Format = ISO.</param>
     /// <param name="minDateLastSavedForUser">Optional. The minimum last saved date for the current user. Format = ISO.</param>
@@ -142,6 +143,7 @@ public class TrailersController : BaseJellyfinApiController
         [FromQuery] bool? isUnaired,
         [FromQuery] double? minCommunityRating,
         [FromQuery] double? minCriticRating,
+        [FromQuery] double? minUserRating,
         [FromQuery] DateTime? minPremiereDate,
         [FromQuery] DateTime? minDateLastSaved,
         [FromQuery] DateTime? minDateLastSavedForUser,
@@ -234,6 +236,7 @@ public class TrailersController : BaseJellyfinApiController
                 isUnaired,
                 minCommunityRating,
                 minCriticRating,
+                minUserRating,
                 minPremiereDate,
                 minDateLastSaved,
                 minDateLastSavedForUser,

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -333,7 +333,7 @@ public class UserLibraryController : BaseJellyfinApiController
             return NotFound();
         }
 
-        return UpdateUserItemRatingInternal(user, item, null);
+        return UpdateUserItemRatingInternal(user, item, null, null);
     }
 
     /// <summary>
@@ -357,16 +357,20 @@ public class UserLibraryController : BaseJellyfinApiController
     /// </summary>
     /// <param name="userId">User id.</param>
     /// <param name="itemId">Item id.</param>
-    /// <param name="likes">Whether this <see cref="UpdateUserItemRating" /> is likes.</param>
+    /// <param name="likes">Whether this <see cref="UpdateUserItemRating" /> is likes. Ignored when <paramref name="rating"/> is supplied.</param>
+    /// <param name="rating">The user's personal rating for the item, from 0 to 10. Takes precedence over <paramref name="likes"/>.</param>
     /// <response code="200">Item rating updated.</response>
+    /// <response code="400">Rating is outside the range 0 to 10.</response>
     /// <returns>An <see cref="OkResult"/> containing the <see cref="UserItemDataDto"/>.</returns>
     [HttpPost("UserItems/{itemId}/Rating")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [Tags("UserData")]
     public ActionResult<UserItemDataDto?> UpdateUserItemRating(
         [FromQuery] Guid? userId,
         [FromRoute, Required] Guid itemId,
-        [FromQuery] bool? likes)
+        [FromQuery] bool? likes,
+        [FromQuery, Range(0.0, 10.0)] double? rating)
     {
         userId = RequestHelpers.GetUserId(User, userId);
         var user = _userManager.GetUserById(userId.Value);
@@ -383,7 +387,7 @@ public class UserLibraryController : BaseJellyfinApiController
             return NotFound();
         }
 
-        return UpdateUserItemRatingInternal(user, item, likes);
+        return UpdateUserItemRatingInternal(user, item, likes, rating);
     }
 
     /// <summary>
@@ -402,7 +406,7 @@ public class UserLibraryController : BaseJellyfinApiController
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] Guid itemId,
         [FromQuery] bool? likes)
-        => UpdateUserItemRating(userId, itemId, likes);
+        => UpdateUserItemRating(userId, itemId, likes, null);
 
     /// <summary>
     /// Gets local trailers for an item.
@@ -694,15 +698,24 @@ public class UserLibraryController : BaseJellyfinApiController
     /// </summary>
     /// <param name="user">The user.</param>
     /// <param name="item">The item.</param>
-    /// <param name="likes">if set to <c>true</c> [likes].</param>
-    private UserItemDataDto? UpdateUserItemRatingInternal(User user, BaseItem item, bool? likes)
+    /// <param name="likes">if set to <c>true</c> [likes]. Ignored when <paramref name="rating"/> has a value.</param>
+    /// <param name="rating">The 0 to 10 rating to store. Takes precedence over <paramref name="likes"/>.</param>
+    private UserItemDataDto? UpdateUserItemRatingInternal(User user, BaseItem item, bool? likes, double? rating)
     {
         // Get the user data for this item
         var data = _userDataRepository.GetUserData(user, item);
 
         if (data is not null)
         {
-            data.Likes = likes;
+            // Likes is derived from Rating, so an explicit rating always wins.
+            if (rating.HasValue)
+            {
+                data.Rating = rating;
+            }
+            else
+            {
+                data.Likes = likes;
+            }
 
             _userDataRepository.SaveUserData(user, item, data, UserDataSaveReason.UpdateUserRating, CancellationToken.None);
         }

--- a/Jellyfin.Data/Enums/ItemSortBy.cs
+++ b/Jellyfin.Data/Enums/ItemSortBy.cs
@@ -154,4 +154,9 @@ public enum ItemSortBy
     /// The index number.
     /// </summary>
     IndexNumber = 29,
+
+    /// <summary>
+    /// The user's personal rating.
+    /// </summary>
+    UserRating = 30,
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -449,6 +449,16 @@ public sealed partial class BaseItemRepository
                 : baseQuery.Where(e => !likedIds.Contains(e.Id));
         }
 
+        if (filter.MinUserRating.HasValue && filter.User is not null)
+        {
+            var minUserRating = filter.MinUserRating.Value;
+            var ratedIds = context.UserData
+                .Where(ud => ud.UserId == filter.User.Id && ud.Rating >= minUserRating)
+                .Select(ud => ud.ItemId);
+
+            baseQuery = baseQuery.Where(e => ratedIds.Contains(e.Id));
+        }
+
         if (filter.IsFavoriteOrLiked.HasValue || filter.IsFavorite.HasValue)
         {
             var favoriteIds = context.UserData

--- a/Jellyfin.Server.Implementations/Item/OrderMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/OrderMapper.cs
@@ -55,7 +55,12 @@ public static class OrderMapper
             (ItemSortBy.Random, _) => e => EF.Functions.Random(),
             (ItemSortBy.PlayCount, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.PlayCount,
             (ItemSortBy.IsFavoriteOrLiked, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).Select(f => (bool?)f.IsFavorite).FirstOrDefault() ?? false,
-            (ItemSortBy.UserRating, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).Select(f => f.Rating).FirstOrDefault(),
+            (ItemSortBy.UserRating, not null) => e =>
+                jellyfinDbContext.UserData
+                    .Where(w => w.UserId == query.User.Id && w.ItemId == e.Id)
+                    .OrderBy(w => w.CustomDataKey)
+                    .Select(w => w.Rating)
+                    .FirstOrDefault(),
             (ItemSortBy.IsFolder, _) => e => e.IsFolder,
             (ItemSortBy.IsPlayed, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.Played,
             (ItemSortBy.IsUnplayed, _) => e => !e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.Played,

--- a/Jellyfin.Server.Implementations/Item/OrderMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/OrderMapper.cs
@@ -55,6 +55,7 @@ public static class OrderMapper
             (ItemSortBy.Random, _) => e => EF.Functions.Random(),
             (ItemSortBy.PlayCount, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.PlayCount,
             (ItemSortBy.IsFavoriteOrLiked, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).Select(f => (bool?)f.IsFavorite).FirstOrDefault() ?? false,
+            (ItemSortBy.UserRating, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).Select(f => f.Rating).FirstOrDefault(),
             (ItemSortBy.IsFolder, _) => e => e.IsFolder,
             (ItemSortBy.IsPlayed, _) => e => e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.Played,
             (ItemSortBy.IsUnplayed, _) => e => !e.UserData!.Where(f => f.UserId.Equals(query.User!.Id)).OrderBy(f => f.CustomDataKey).FirstOrDefault()!.Played,

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -1426,6 +1426,7 @@ namespace MediaBrowser.Controller.Entities
             if (request.OrderBy.Any(o =>
                 o.OrderBy == ItemSortBy.CommunityRating ||
                 o.OrderBy == ItemSortBy.CriticRating ||
+                o.OrderBy == ItemSortBy.UserRating ||
                 o.OrderBy == ItemSortBy.Runtime))
             {
                 return false;

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -138,6 +138,7 @@ namespace MediaBrowser.Controller.Entities
             || HasChapterImages.HasValue
             || MinCriticRating.HasValue
             || MinCommunityRating.HasValue
+            || MinUserRating.HasValue
             || MinParentalRating is not null
             || MinIndexNumber.HasValue
             || MinParentAndIndexNumber.HasValue
@@ -339,6 +340,8 @@ namespace MediaBrowser.Controller.Entities
         public double? MinCriticRating { get; set; }
 
         public double? MinCommunityRating { get; set; }
+
+        public double? MinUserRating { get; set; }
 
         public IReadOnlyList<Guid> ChannelIds { get; set; }
 

--- a/MediaBrowser.Controller/Entities/UserItemData.cs
+++ b/MediaBrowser.Controller/Entities/UserItemData.cs
@@ -35,7 +35,8 @@ namespace MediaBrowser.Controller.Entities
             {
                 if (value.HasValue)
                 {
-                    if (value.Value < 0 || value.Value > 10)
+                    // NaN compares false against every bound, so it must be rejected explicitly.
+                    if (!double.IsFinite(value.Value) || value.Value < 0 || value.Value > 10)
                     {
                         throw new ArgumentOutOfRangeException(nameof(value), "A 0 to 10 rating is required for UserItemData.");
                     }

--- a/MediaBrowser.Controller/Entities/UserItemData.cs
+++ b/MediaBrowser.Controller/Entities/UserItemData.cs
@@ -33,13 +33,10 @@ namespace MediaBrowser.Controller.Entities
             get => _rating;
             set
             {
-                if (value.HasValue)
+                // NaN compares false against every bound, so it must be rejected explicitly.
+                if (value.HasValue && (!double.IsFinite(value.Value) || value.Value < 0 || value.Value > 10))
                 {
-                    // NaN compares false against every bound, so it must be rejected explicitly.
-                    if (!double.IsFinite(value.Value) || value.Value < 0 || value.Value > 10)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), "A 0 to 10 rating is required for UserItemData.");
-                    }
+                    throw new ArgumentOutOfRangeException(nameof(value), "A 0 to 10 rating is required for UserItemData.");
                 }
 
                 _rating = value;

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -575,6 +575,16 @@ namespace MediaBrowser.Controller.Entities
                 }
             }
 
+            if (query.MinUserRating.HasValue)
+            {
+                userData ??= userDataManager.GetUserData(user, item);
+
+                if (!userData.Rating.HasValue || userData.Rating < query.MinUserRating.Value)
+                {
+                    return false;
+                }
+            }
+
             if (query.IsFavoriteOrLiked.HasValue)
             {
                 userData ??= userDataManager.GetUserData(user, item);

--- a/tests/Jellyfin.Api.Tests/Helpers/RequestHelpersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/RequestHelpersTests.cs
@@ -134,6 +134,20 @@ namespace Jellyfin.Api.Tests.Helpers
                     (ItemSortBy.ProductionYear, SortOrder.Descending),
                 });
 
+            data.Add(
+                new[]
+                {
+                    ItemSortBy.UserRating
+                },
+                new[]
+                {
+                    SortOrder.Descending
+                },
+                new (ItemSortBy, SortOrder)[]
+                {
+                    (ItemSortBy.UserRating, SortOrder.Descending),
+                });
+
             return data;
         }
     }

--- a/tests/Jellyfin.Controller.Tests/Entities/UserItemDataTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/UserItemDataTests.cs
@@ -1,0 +1,158 @@
+using System;
+using MediaBrowser.Controller.Entities;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.Entities;
+
+public class UserItemDataTests
+{
+    public static TheoryData<double> ValidRatings => new()
+    {
+        0,
+        0.1,
+        1,
+        5,
+        6.4,
+        6.49,
+        UserItemData.MinLikeValue,
+        6.51,
+        9.9,
+        10
+    };
+
+    public static TheoryData<double> OutOfRangeRatings => new()
+    {
+        -0.1,
+        -1,
+        10.1,
+        11,
+        100,
+        double.MaxValue,
+        double.MinValue,
+        double.NaN,
+        double.PositiveInfinity,
+        double.NegativeInfinity
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidRatings))]
+    public void Rating_WithinRange_IsAccepted(double rating)
+    {
+        var data = new UserItemData { Key = "key", Rating = rating };
+
+        Assert.Equal(rating, data.Rating);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeRatings))]
+    public void Rating_OutsideRange_Throws(double rating)
+    {
+        var data = new UserItemData { Key = "key" };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => data.Rating = rating);
+    }
+
+    [Fact]
+    public void Rating_Null_IsAccepted()
+    {
+        var data = new UserItemData { Key = "key", Rating = 5 };
+
+        data.Rating = null;
+
+        Assert.Null(data.Rating);
+        Assert.Null(data.Likes);
+    }
+
+    [Theory]
+    // Below the like threshold.
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(6, false)]
+    [InlineData(6.4, false)]
+    [InlineData(6.49, false)]
+    // At and above the like threshold. MinLikeValue itself counts as liked.
+    [InlineData(6.5, true)]
+    [InlineData(6.51, true)]
+    [InlineData(7, true)]
+    [InlineData(10, true)]
+    public void Likes_IsDerivedFromRating(double rating, bool expectedLikes)
+    {
+        var data = new UserItemData { Key = "key", Rating = rating };
+
+        Assert.Equal(expectedLikes, data.Likes);
+    }
+
+    [Fact]
+    public void Likes_JustBelowThreshold_IsNotLiked()
+    {
+        // BitDecrement, not double.Epsilon: 6.5 - double.Epsilon is still exactly 6.5.
+        var justBelow = Math.BitDecrement(UserItemData.MinLikeValue);
+        Assert.NotEqual(UserItemData.MinLikeValue, justBelow);
+
+        var data = new UserItemData { Key = "key", Rating = justBelow };
+
+        // Guards the exact boundary: anything strictly below MinLikeValue is a dislike.
+        Assert.False(data.Likes);
+    }
+
+    [Fact]
+    public void Likes_NoRating_IsNull()
+    {
+        var data = new UserItemData { Key = "key" };
+
+        Assert.Null(data.Rating);
+        Assert.Null(data.Likes);
+    }
+
+    [Theory]
+    [InlineData(true, 10)]
+    [InlineData(false, 1)]
+    public void Likes_Set_WritesThroughToRating(bool likes, double expectedRating)
+    {
+        var data = new UserItemData { Key = "key" };
+
+        data.Likes = likes;
+
+        Assert.Equal(expectedRating, data.Rating);
+        Assert.Equal(likes, data.Likes);
+    }
+
+    [Fact]
+    public void Likes_SetNull_ClearsRating()
+    {
+        var data = new UserItemData { Key = "key", Rating = 8 };
+
+        data.Likes = null;
+
+        Assert.Null(data.Rating);
+        Assert.Null(data.Likes);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Likes_RoundTrip_IsStable(bool likes)
+    {
+        var data = new UserItemData { Key = "key" };
+
+        data.Likes = likes;
+        var rating = data.Rating;
+        data.Rating = rating;
+
+        Assert.Equal(likes, data.Likes);
+        Assert.Equal(rating, data.Rating);
+    }
+
+    [Fact]
+    public void Rating_OverwritesPreviousLikes()
+    {
+        var data = new UserItemData { Key = "key" };
+
+        data.Likes = true;
+        Assert.Equal(10, data.Rating);
+
+        // An explicit low rating must flip the derived like state.
+        data.Rating = 2;
+        Assert.False(data.Likes);
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/OrderMapperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/OrderMapperTests.cs
@@ -1,14 +1,42 @@
 using System;
+using System.Linq;
 using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
 using Jellyfin.Server.Implementations.Item;
 using MediaBrowser.Controller.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Jellyfin.Server.Implementations.Tests.Item;
 
-public class OrderMapperTests
+public sealed class OrderMapperTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+
+    public OrderMapperTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using var context = CreateDbContext();
+        context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
     [Fact]
     public void ShouldReturnMappedOrderForSortingByPremierDate()
     {
@@ -33,44 +61,97 @@ public class OrderMapperTests
         Assert.Null(resultWithoutEitherPremierDateOrProductionYear);
     }
 
+    /// <summary>
+    /// Runs against SQLite rather than a compiled expression, so a sort that
+    /// cannot be translated to SQL fails here rather than at runtime.
+    /// </summary>
     [Fact]
-    public void ShouldReturnMappedOrderForSortingByUserRating()
+    public void ShouldOrderByTheRequestingUsersOwnRating()
     {
-        var user = new User("test-user", "auth-provider", "pwdreset-provider");
-        var orderFunc = OrderMapper.MapOrderByField(ItemSortBy.UserRating, new InternalItemsQuery { User = user }, null!).Compile();
+        using var context = CreateDbContext();
 
-        var ratedEntity = CreateEntityWithUserData(user, 7.5);
-        var unratedEntity = CreateEntityWithUserData(user, null);
-        var entityRatedByAnotherUser = CreateEntityWithUserData(new User("other-user", "auth-provider", "pwdreset-provider"), 9);
-        var entityWithoutUserData = new BaseItemEntity { Id = Guid.NewGuid(), Type = "Test", UserData = [] };
+        var user = new User("test-user", "auth-provider", "pwdreset-provider") { Id = Guid.NewGuid() };
+        var otherUser = new User("other-user", "auth-provider", "pwdreset-provider") { Id = Guid.NewGuid() };
+        context.Users.AddRange(user, otherUser);
 
-        Assert.Equal(7.5, orderFunc(ratedEntity));
-        Assert.Null(orderFunc(unratedEntity));
+        var ratedHigh = CreateItem("rated-high");
+        var ratedLow = CreateItem("rated-low");
+        var unrated = CreateItem("unrated");
+        var ratedByAnotherUser = CreateItem("rated-by-another-user");
+        context.BaseItems.AddRange(ratedHigh, ratedLow, unrated, ratedByAnotherUser);
 
-        // Another user's rating must not leak into this user's ordering.
-        Assert.Null(orderFunc(entityRatedByAnotherUser));
-        Assert.Null(orderFunc(entityWithoutUserData));
+        context.UserData.AddRange(
+            CreateUserData(user.Id, ratedHigh.Id, 9),
+            CreateUserData(user.Id, ratedLow.Id, 2),
+            CreateUserData(otherUser.Id, ratedByAnotherUser.Id, 10));
+        context.SaveChanges();
+
+        var order = OrderMapper.MapOrderByField(ItemSortBy.UserRating, new InternalItemsQuery { User = user }, context);
+
+        // The schema seeds a placeholder BaseItem, so scope to the fixtures.
+        var itemIds = new[] { ratedHigh.Id, ratedLow.Id, unrated.Id, ratedByAnotherUser.Id };
+        var ordered = context.BaseItems
+            .Where(e => itemIds.Contains(e.Id))
+            .OrderByDescending(order)
+            .Select(e => e.Name)
+            .ToList();
+
+        Assert.Equal("rated-high", ordered[0]);
+        Assert.Equal("rated-low", ordered[1]);
+
+        // Another user's rating must not leak into this user's ordering, so it
+        // sorts alongside the unrated item rather than ahead of everything.
+        Assert.Equal(
+            new[] { "rated-by-another-user", "unrated" },
+            ordered.Skip(2).Order().ToArray());
     }
 
-    private static BaseItemEntity CreateEntityWithUserData(User user, double? rating)
+    /// <summary>
+    /// The sort is only defined for a user, so it must fall back rather than
+    /// dereference a null one.
+    /// </summary>
+    [Fact]
+    public void ShouldFallBackToSortNameWhenThereIsNoUser()
     {
-        var itemId = Guid.NewGuid();
+        using var context = CreateDbContext();
+
+        var order = OrderMapper.MapOrderByField(ItemSortBy.UserRating, new InternalItemsQuery(), context).Compile();
+
+        var entity = new BaseItemEntity { Id = Guid.NewGuid(), Type = "Test", SortName = "a-sort-name" };
+
+        Assert.Equal("a-sort-name", order(entity));
+    }
+
+    private static BaseItemEntity CreateItem(string name)
+    {
         return new BaseItemEntity
         {
-            Id = itemId,
+            Id = Guid.NewGuid(),
             Type = "Test",
-            UserData =
-            [
-                new UserData
-                {
-                    CustomDataKey = "key",
-                    ItemId = itemId,
-                    Item = null,
-                    UserId = user.Id,
-                    User = null,
-                    Rating = rating
-                }
-            ]
+            Name = name,
+            SortName = name
         };
+    }
+
+    private static UserData CreateUserData(Guid userId, Guid itemId, double rating)
+    {
+        return new UserData
+        {
+            CustomDataKey = "key",
+            ItemId = itemId,
+            Item = null,
+            UserId = userId,
+            User = null,
+            Rating = rating
+        };
+    }
+
+    private JellyfinDbContext CreateDbContext()
+    {
+        return new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/OrderMapperTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/OrderMapperTests.cs
@@ -32,4 +32,45 @@ public class OrderMapperTests
         Assert.Equal(resultWithBothPremierDateAndProductionYear, expectedDate);
         Assert.Null(resultWithoutEitherPremierDateOrProductionYear);
     }
+
+    [Fact]
+    public void ShouldReturnMappedOrderForSortingByUserRating()
+    {
+        var user = new User("test-user", "auth-provider", "pwdreset-provider");
+        var orderFunc = OrderMapper.MapOrderByField(ItemSortBy.UserRating, new InternalItemsQuery { User = user }, null!).Compile();
+
+        var ratedEntity = CreateEntityWithUserData(user, 7.5);
+        var unratedEntity = CreateEntityWithUserData(user, null);
+        var entityRatedByAnotherUser = CreateEntityWithUserData(new User("other-user", "auth-provider", "pwdreset-provider"), 9);
+        var entityWithoutUserData = new BaseItemEntity { Id = Guid.NewGuid(), Type = "Test", UserData = [] };
+
+        Assert.Equal(7.5, orderFunc(ratedEntity));
+        Assert.Null(orderFunc(unratedEntity));
+
+        // Another user's rating must not leak into this user's ordering.
+        Assert.Null(orderFunc(entityRatedByAnotherUser));
+        Assert.Null(orderFunc(entityWithoutUserData));
+    }
+
+    private static BaseItemEntity CreateEntityWithUserData(User user, double? rating)
+    {
+        var itemId = Guid.NewGuid();
+        return new BaseItemEntity
+        {
+            Id = itemId,
+            Type = "Test",
+            UserData =
+            [
+                new UserData
+                {
+                    CustomDataKey = "key",
+                    ItemId = itemId,
+                    Item = null,
+                    UserId = user.Id,
+                    User = null,
+                    Rating = rating
+                }
+            ]
+        };
+    }
 }

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/UserLibraryControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/UserLibraryControllerTests.cs
@@ -121,4 +121,136 @@ public sealed class UserLibraryControllerTests : IClassFixture<JellyfinApplicati
         var rootDto = await response.Content.ReadFromJsonAsync<BaseItemDto[]>(_jsonOptions, TestContext.Current.CancellationToken);
         Assert.NotNull(rootDto);
     }
+
+    [Theory]
+    // Bounds of the accepted range.
+    [InlineData(0, false)]
+    [InlineData(10, true)]
+    // Either side of MinLikeValue (6.5), where the derived Likes flag flips.
+    [InlineData(6.49, false)]
+    [InlineData(6.5, true)]
+    [InlineData(6.51, true)]
+    [InlineData(3, false)]
+    [InlineData(7, true)]
+    public async Task UpdateUserItemRating_NumericRating_StoresRatingAndDerivesLikes(double rating, bool expectedLikes)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var rootFolderDto = await AuthHelper.GetRootFolderDtoAsync(client);
+
+        var response = await client.PostAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating?rating={1}", rootFolderDto.Id, rating),
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userData = await response.Content.ReadFromJsonAsync<UserItemDataDto>(_jsonOptions, TestContext.Current.CancellationToken);
+        Assert.NotNull(userData);
+        Assert.Equal(rating, userData.Rating);
+
+        // Likes remains derived from Rating via UserItemData.MinLikeValue.
+        Assert.Equal(expectedLikes, userData.Likes);
+    }
+
+    [Theory]
+    // Just outside each bound.
+    [InlineData("-0.1")]
+    [InlineData("10.1")]
+    [InlineData("-1")]
+    [InlineData("10.5")]
+    [InlineData("11")]
+    // Non-finite values: NaN compares false against every bound, so it must be rejected explicitly.
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    // Not a number at all.
+    [InlineData("abc")]
+    public async Task UpdateUserItemRating_RatingOutOfRange_BadRequest(string rating)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var rootFolderDto = await AuthHelper.GetRootFolderDtoAsync(client);
+
+        var response = await client.PostAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating?rating={1}", rootFolderDto.Id, rating),
+            null,
+            TestContext.Current.CancellationToken);
+
+        // Must be rejected at the model-binding/[Range] layer. If it reaches
+        // UserItemData.Rating the setter throws, which would surface as a 500.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(true, 10)]
+    [InlineData(false, 1)]
+    public async Task UpdateUserItemRating_Likes_RetainsLegacyBehaviour(bool likes, double expectedRating)
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var rootFolderDto = await AuthHelper.GetRootFolderDtoAsync(client);
+
+        var response = await client.PostAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating?likes={1}", rootFolderDto.Id, likes),
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userData = await response.Content.ReadFromJsonAsync<UserItemDataDto>(_jsonOptions, TestContext.Current.CancellationToken);
+        Assert.NotNull(userData);
+        Assert.Equal(expectedRating, userData.Rating);
+        Assert.Equal(likes, userData.Likes);
+    }
+
+    [Fact]
+    public async Task UpdateUserItemRating_RatingAndLikes_RatingWins()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var rootFolderDto = await AuthHelper.GetRootFolderDtoAsync(client);
+
+        var response = await client.PostAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating?likes=true&rating={1}", rootFolderDto.Id, 2),
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userData = await response.Content.ReadFromJsonAsync<UserItemDataDto>(_jsonOptions, TestContext.Current.CancellationToken);
+        Assert.NotNull(userData);
+        Assert.Equal(2, userData.Rating);
+        Assert.False(userData.Likes);
+    }
+
+    [Fact]
+    public async Task DeleteUserItemRating_ClearsRating()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        var rootFolderDto = await AuthHelper.GetRootFolderDtoAsync(client);
+
+        var setResponse = await client.PostAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating?rating={1}", rootFolderDto.Id, 8),
+            null,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, setResponse.StatusCode);
+
+        var response = await client.DeleteAsync(
+            string.Format(CultureInfo.InvariantCulture, "UserItems/{0}/Rating", rootFolderDto.Id),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var userData = await response.Content.ReadFromJsonAsync<UserItemDataDto>(_jsonOptions, TestContext.Current.CancellationToken);
+        Assert.NotNull(userData);
+        Assert.Null(userData.Rating);
+        Assert.Null(userData.Likes);
+    }
 }


### PR DESCRIPTION
**Changes**

`UserItemData.Rating` is already a persisted 0-10 double, but `POST /UserItems/{itemId}/Rating` only took a `likes` boolean, which writes 10 or 1. This adds an optional `rating` parameter, plus `ItemSortBy.UserRating` and a `minUserRating` filter on `/Items` and `/Trailers`.

`rating` is additive rather than replacing `likes`, so the OpenAPI diff stays non-breaking; `rating` wins when both are given. `Likes` remains derived at `MinLikeValue` (6.5), so no migration is needed and existing clients are unaffected.

Non-finite ratings are now rejected. `NaN` compares false against every bound, so it passed the existing range check in the setter. Catching it also needed `Range(0.0, 10.0)`: `Range(0, 10)` binds the `int` overload, which let `NaN` and `Infinity` through as a 500.

Continues #14064 and #8933, both closed for inactivity rather than on design.

**Code assistance**

Implemented with Claude Code. It located the existing plumbing and the prior PRs, wrote the implementation and tests, and ran the suites. Its boundary tests surfaced both `NaN` issues.

**Issues**
