### PR TITLE
Harden path handling, SSRF, authorization, and untrusted media input

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -37,6 +37,13 @@ namespace Emby.Server.Implementations.HttpServer
         /// </summary>
         private readonly WebSocket _socket;
 
+        /// <summary>
+        /// Serializes sends. The WebSocket API permits only a single outstanding send at a time;
+        /// without this, an overlapping send (e.g. a broadcast racing the keep-alive timer) throws
+        /// <see cref="InvalidOperationException"/>.
+        /// </summary>
+        private readonly SemaphoreSlim _sendLock = new(1, 1);
+
         private bool _disposed = false;
 
         /// <summary>
@@ -102,14 +109,28 @@ namespace Emby.Server.Implementations.HttpServer
         public async Task SendAsync(OutboundWebSocketMessage message, CancellationToken cancellationToken)
         {
             var json = JsonSerializer.SerializeToUtf8Bytes(message, _jsonOptions);
-            await _socket.SendAsync(json, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            await SendBytesAsync(json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task SendAsync<T>(OutboundWebSocketMessage<T> message, CancellationToken cancellationToken)
         {
             var json = JsonSerializer.SerializeToUtf8Bytes(message, _jsonOptions);
-            await _socket.SendAsync(json, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            await SendBytesAsync(json, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task SendBytesAsync(byte[] json, CancellationToken cancellationToken)
+        {
+            // Only one send may be in flight on a WebSocket at a time; serialize concurrent senders.
+            await _sendLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _socket.SendAsync(json, WebSocketMessageType.Text, true, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _sendLock.Release();
+            }
         }
 
         /// <inheritdoc />
@@ -274,6 +295,7 @@ namespace Emby.Server.Implementations.HttpServer
             if (dispose)
             {
                 _socket.Dispose();
+                _sendLock.Dispose();
             }
 
             _disposed = true;
@@ -299,6 +321,7 @@ namespace Emby.Server.Implementations.HttpServer
             }
 
             _socket.Dispose();
+            _sendLock.Dispose();
         }
     }
 }

--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -3775,6 +3775,32 @@ namespace Emby.Server.Implementations.Library
             });
         }
 
+        /// <summary>
+        /// Resolves a caller-supplied virtual folder name to its path beneath the user views root,
+        /// guarding against path traversal and absolute-path injection. The name is first stripped of
+        /// path separators (matching <see cref="AddVirtualFolder"/>), then the resolved path is asserted
+        /// to be a direct child of the user views root before it is returned.
+        /// </summary>
+        /// <param name="name">The caller-supplied virtual folder name.</param>
+        /// <returns>The fully-qualified, validated virtual folder path.</returns>
+        public string GetValidatedVirtualFolderPath(string name)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+            var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
+            var sanitizedName = _fileSystem.GetValidFilename(name.Trim());
+            var fullRootPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rootFolderPath));
+            var fullPath = Path.GetFullPath(Path.Combine(fullRootPath, sanitizedName));
+
+            // The sanitized name must resolve to a direct child of the user views root.
+            if (!string.Equals(Path.GetDirectoryName(fullPath), fullRootPath, StringComparison.Ordinal))
+            {
+                throw new ArgumentException("Invalid virtual folder name.", nameof(name));
+            }
+
+            return fullPath;
+        }
+
         public void AddMediaPath(string virtualFolderName, MediaPathInfo mediaPath)
         {
             AddMediaPathInternal(virtualFolderName, mediaPath, true);
@@ -3796,8 +3822,7 @@ namespace Emby.Server.Implementations.Library
                 throw new FileNotFoundException("The path does not exist.");
             }
 
-            var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
-            var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
+            var virtualFolderPath = GetValidatedVirtualFolderPath(virtualFolderName);
 
             CreateShortcut(virtualFolderPath, pathInfo);
 
@@ -3817,8 +3842,7 @@ namespace Emby.Server.Implementations.Library
         {
             ArgumentNullException.ThrowIfNull(mediaPath);
 
-            var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
-            var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
+            var virtualFolderPath = GetValidatedVirtualFolderPath(virtualFolderName);
 
             var libraryOptions = CollectionFolder.GetLibraryOptions(virtualFolderPath);
 
@@ -3855,9 +3879,7 @@ namespace Emby.Server.Implementations.Library
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
-
-            var path = Path.Combine(rootFolderPath, name);
+            var path = GetValidatedVirtualFolderPath(name);
 
             if (!Directory.Exists(path))
             {
@@ -3922,8 +3944,7 @@ namespace Emby.Server.Implementations.Library
         {
             ArgumentException.ThrowIfNullOrEmpty(mediaPath);
 
-            var rootFolderPath = _configurationManager.ApplicationPaths.DefaultUserViewsPath;
-            var virtualFolderPath = Path.Combine(rootFolderPath, virtualFolderName);
+            var virtualFolderPath = GetValidatedVirtualFolderPath(virtualFolderName);
 
             if (!Directory.Exists(virtualFolderPath))
             {

--- a/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
+++ b/Emby.Server.Implementations/Session/SessionWebSocketListener.cs
@@ -232,8 +232,10 @@ namespace Emby.Server.Implementations.Session
                 {
                     await SendForceKeepAlive(webSocket).ConfigureAwait(false);
                 }
-                catch (WebSocketException exception)
+                catch (Exception exception)
                 {
+                    // This runs from an async void timer handler, so any escaping exception would
+                    // crash the process. Treat any send failure as a lost connection.
                     _logger.LogInformation(exception, "Error sending ForceKeepAlive message to WebSocket.");
                     lost.Add(webSocket);
                 }

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -147,8 +147,8 @@ public class LibraryStructureController : BaseJellyfinApiController
 
         var rootFolderPath = _appPaths.DefaultUserViewsPath;
 
-        var currentPath = Path.Combine(rootFolderPath, name);
-        var newPath = Path.Combine(rootFolderPath, newName);
+        var currentPath = _libraryManager.GetValidatedVirtualFolderPath(name);
+        var newPath = _libraryManager.GetValidatedVirtualFolderPath(newName);
 
         if (!Directory.Exists(currentPath))
         {

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -206,7 +206,9 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}")]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesFile("text/*")]
     public async Task<ActionResult> GetSubtitle(
         [FromRoute, Required] Guid routeItemId,
@@ -233,10 +235,16 @@ public class SubtitleController : BaseJellyfinApiController
             format = "json";
         }
 
+        // Resolve the item scoped to the requesting user so library-visibility and parental-control
+        // filtering apply; return 404 when the user has no access.
+        var item = _libraryManager.GetItemById<Video>(itemId.Value, User.GetUserId());
+        if (item is null)
+        {
+            return NotFound();
+        }
+
         if (string.IsNullOrEmpty(format))
         {
-            var item = _libraryManager.GetItemById<Video>(itemId.Value);
-
             var idString = itemId.Value.ToString("N", CultureInfo.InvariantCulture);
             var mediaSource = _mediaSourceManager.GetStaticMediaSources(item, false)
                 .First(i => string.Equals(i.Id, mediaSourceId ?? idString, StringComparison.Ordinal));
@@ -249,7 +257,7 @@ public class SubtitleController : BaseJellyfinApiController
 
         if (string.Equals(format, "vtt", StringComparison.OrdinalIgnoreCase) && addVttTimeMap)
         {
-            Stream stream = await EncodeSubtitles(itemId.Value, mediaSourceId, index.Value, format, startPositionTicks, endPositionTicks, copyTimestamps).ConfigureAwait(false);
+            Stream stream = await EncodeSubtitles(item, mediaSourceId, index.Value, format, startPositionTicks, endPositionTicks, copyTimestamps).ConfigureAwait(false);
             await using (stream.ConfigureAwait(false))
             {
                 using var reader = new StreamReader(stream);
@@ -264,7 +272,7 @@ public class SubtitleController : BaseJellyfinApiController
 
         return File(
             await EncodeSubtitles(
-                itemId.Value,
+                item,
                 mediaSourceId,
                 index.Value,
                 format,
@@ -293,7 +301,9 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Stream.{routeFormat}")]
+    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesFile("text/*")]
     public Task<ActionResult> GetSubtitleWithTicks(
         [FromRoute, Required] Guid routeItemId,
@@ -459,7 +469,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <summary>
     /// Encodes a subtitle in the specified format.
     /// </summary>
-    /// <param name="id">The media id.</param>
+    /// <param name="item">The media item, already resolved and access-checked for the requesting user.</param>
     /// <param name="mediaSourceId">The source media id.</param>
     /// <param name="index">The subtitle index.</param>
     /// <param name="format">The format to convert to.</param>
@@ -468,7 +478,7 @@ public class SubtitleController : BaseJellyfinApiController
     /// <param name="copyTimestamps">Whether to copy the timestamps.</param>
     /// <returns>A <see cref="Task{Stream}"/> with the new subtitle file.</returns>
     private Task<Stream> EncodeSubtitles(
-        Guid id,
+        BaseItem item,
         string? mediaSourceId,
         int index,
         string format,
@@ -476,8 +486,6 @@ public class SubtitleController : BaseJellyfinApiController
         long? endPositionTicks,
         bool copyTimestamps)
     {
-        var item = _libraryManager.GetItemById<BaseItem>(id);
-
         return _subtitleEncoder.GetSubtitles(
             item,
             mediaSourceId,

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -206,7 +206,6 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/Stream.{routeFormat}")]
-    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesFile("text/*")]
@@ -301,7 +300,6 @@ public class SubtitleController : BaseJellyfinApiController
     /// <response code="200">File returned.</response>
     /// <returns>A <see cref="FileContentResult"/> with the subtitle file.</returns>
     [HttpGet("Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeStartPositionTicks}/Stream.{routeFormat}")]
-    [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesFile("text/*")]

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -291,6 +291,7 @@ public class UserController : BaseJellyfinApiController
         if (request.ResetPassword)
         {
             await _userManager.ResetPassword(user.Id).ConfigureAwait(false);
+            await _sessionManager.RevokeUserTokens(user.Id, null).ConfigureAwait(false);
         }
         else
         {

--- a/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
+++ b/Jellyfin.Server.Implementations/Users/DefaultPasswordResetProvider.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.IO;
 using MediaBrowser.Model.Users;
 
@@ -51,6 +52,7 @@ namespace Jellyfin.Server.Implementations.Users
         public async Task<PinRedeemResult> RedeemPasswordResetPin(string pin)
         {
             var userManager = _appHost.Resolve<IUserManager>();
+            var sessionManager = _appHost.Resolve<ISessionManager>();
             var usersReset = new List<string>();
             foreach (var resetFile in Directory.EnumerateFiles(_passwordResetFileBaseDir, $"{BaseResetFileName}*"))
             {
@@ -75,6 +77,8 @@ namespace Jellyfin.Server.Implementations.Users
                         ?? throw new ResourceNotFoundException($"User with a username of {spr.UserName} not found");
 
                     await userManager.ChangePassword(resetUser.Id, pin).ConfigureAwait(false);
+                    await sessionManager.RevokeUserTokens(resetUser.Id, null).ConfigureAwait(false);
+
                     usersReset.Add(resetUser.Username);
                     File.Delete(resetFile);
                 }

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -713,6 +713,15 @@ namespace MediaBrowser.Controller.Library
 
         Task RemoveVirtualFolder(string name, bool refreshLibrary);
 
+        /// <summary>
+        /// Resolves a caller-supplied virtual folder name to its fully-qualified path beneath the user
+        /// views root, guarding against path traversal and absolute-path injection.
+        /// </summary>
+        /// <param name="name">The caller-supplied virtual folder name.</param>
+        /// <returns>The fully-qualified, validated virtual folder path.</returns>
+        /// <exception cref="ArgumentException">The name is empty or resolves outside the user views root.</exception>
+        string GetValidatedVirtualFolderPath(string name);
+
         void AddMediaPath(string virtualFolderName, MediaPathInfo mediaPath);
 
         void UpdateMediaPath(string virtualFolderName, MediaPathInfo mediaPath);

--- a/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
+++ b/MediaBrowser.MediaEncoding/Probing/ProbeResultNormalizer.cs
@@ -238,7 +238,11 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                 if (data.Format is not null && !string.IsNullOrEmpty(data.Format.Duration))
                 {
-                    info.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(data.Format.Duration, CultureInfo.InvariantCulture)).Ticks;
+                    var runTimeTicks = ParseDurationToTicks(data.Format.Duration);
+                    if (runTimeTicks is not null)
+                    {
+                        info.RunTimeTicks = runTimeTicks;
+                    }
                 }
 
                 FetchWtvInfo(info, data);
@@ -276,10 +280,11 @@ namespace MediaBrowser.MediaEncoding.Probing
 
                     if (audioBitratesKnown)
                     {
-                        var estimatedVideoBitrate = info.Bitrate.Value - otherStreams.Sum(i => i.BitRate ?? 0);
-                        if (estimatedVideoBitrate > 0)
+                        // Sum as long to avoid a checked int overflow on crafted per-stream bitrates.
+                        var estimatedVideoBitrate = info.Bitrate.Value - otherStreams.Sum(i => (long)(i.BitRate ?? 0));
+                        if (estimatedVideoBitrate > 0 && estimatedVideoBitrate <= int.MaxValue)
                         {
-                            videoStreams[0].BitRate = estimatedVideoBitrate;
+                            videoStreams[0].BitRate = (int)estimatedVideoBitrate;
                         }
                     }
                 }
@@ -1024,10 +1029,12 @@ namespace MediaBrowser.MediaEncoding.Probing
                     var bytes = GetNumberOfBytesFromTags(streamInfo);
                     if (durationInSeconds is not null && durationInSeconds.Value >= 1 && bytes is not null)
                     {
-                        bps = Convert.ToInt32(bytes * 8 / durationInSeconds, CultureInfo.InvariantCulture);
-                        if (bps > 0)
+                        // Compute as double and range-check before narrowing to avoid an OverflowException
+                        // on crafted NUMBER_OF_BYTES/DURATION tags.
+                        var estimatedBps = bytes.Value * 8d / durationInSeconds.Value;
+                        if (double.IsFinite(estimatedBps) && estimatedBps >= 1 && estimatedBps <= int.MaxValue)
                         {
-                            stream.BitRate = bps;
+                            stream.BitRate = (int)estimatedBps;
                         }
                     }
                 }
@@ -1250,7 +1257,7 @@ namespace MediaBrowser.MediaEncoding.Probing
             // If we got something, parse it
             if (!string.IsNullOrEmpty(duration))
             {
-                data.RunTimeTicks = TimeSpan.FromSeconds(double.Parse(duration, CultureInfo.InvariantCulture)).Ticks;
+                data.RunTimeTicks = ParseDurationToTicks(duration);
             }
         }
 
@@ -1595,6 +1602,26 @@ namespace MediaBrowser.MediaEncoding.Probing
             return null;
         }
 
+        /// <summary>
+        /// Parses a duration in seconds (as reported by ffprobe) into ticks, guarding against
+        /// malformed, non-finite (NaN/Infinity) or out-of-range values that would otherwise throw
+        /// from <see cref="TimeSpan.FromSeconds(double)"/> and abort the probe.
+        /// </summary>
+        /// <param name="value">The duration string in seconds.</param>
+        /// <returns>The duration in ticks, or <c>null</c> if it could not be parsed safely.</returns>
+        private static long? ParseDurationToTicks(string value)
+        {
+            if (!double.TryParse(value, CultureInfo.InvariantCulture, out var seconds)
+                || !double.IsFinite(seconds)
+                || seconds < 0
+                || seconds > TimeSpan.MaxValue.TotalSeconds)
+            {
+                return null;
+            }
+
+            return TimeSpan.FromSeconds(seconds).Ticks;
+        }
+
         private static ChapterInfo GetChapterInfo(MediaChapter chapter)
         {
             var info = new ChapterInfo();
@@ -1607,7 +1634,9 @@ namespace MediaBrowser.MediaEncoding.Probing
             // Limit accuracy to milliseconds to match xml saving
             var secondsString = chapter.StartTime;
 
-            if (double.TryParse(secondsString, CultureInfo.InvariantCulture, out var seconds))
+            if (double.TryParse(secondsString, CultureInfo.InvariantCulture, out var seconds)
+                && double.IsFinite(seconds)
+                && Math.Abs(seconds) <= TimeSpan.MaxValue.TotalSeconds)
             {
                 var ms = Math.Round(TimeSpan.FromSeconds(seconds).TotalMilliseconds);
                 info.StartPositionTicks = TimeSpan.FromMilliseconds(ms).Ticks;

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -51,6 +52,12 @@ namespace MediaBrowser.Providers.Manager
     /// </summary>
     public class ProviderManager : IProviderManager, IDisposable
     {
+        /// <summary>
+        /// The maximum size, in bytes, of a remote image that will be downloaded and buffered.
+        /// Guards against decompression bombs / oversized responses exhausting memory.
+        /// </summary>
+        private const long MaxRemoteImageSizeBytes = 30 * 1024 * 1024;
+
         private readonly Lock _refreshQueueLock = new();
         private readonly ILogger<ProviderManager> _logger;
         private readonly IHttpClientFactory _httpClientFactory;
@@ -237,7 +244,7 @@ namespace MediaBrowser.Providers.Manager
                     throw new HttpRequestException($"Request returned '{contentType}' instead of an image type", null, HttpStatusCode.NotFound);
                 }
 
-                var responseBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                var responseBytes = await ReadImageContentAsync(response, url, cancellationToken).ConfigureAwait(false);
                 var stream = new MemoryStream(responseBytes, 0, responseBytes.Length, false);
                 await using (stream.ConfigureAwait(false))
                 {
@@ -251,6 +258,45 @@ namespace MediaBrowser.Providers.Manager
                         imageIndex,
                         cancellationToken).ConfigureAwait(false);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Reads a remote image response into memory, enforcing <see cref="MaxRemoteImageSizeBytes"/>.
+        /// The default HTTP client has automatic decompression enabled, so an unbounded read could be
+        /// abused as a decompression bomb; this bounds the decompressed size as it is streamed.
+        /// </summary>
+        private static async Task<byte[]> ReadImageContentAsync(HttpResponseMessage response, string url, CancellationToken cancellationToken)
+        {
+            if (response.Content.Headers.ContentLength > MaxRemoteImageSizeBytes)
+            {
+                throw new HttpRequestException($"Remote image '{url}' exceeds the maximum allowed size of {MaxRemoteImageSizeBytes} bytes.");
+            }
+
+            var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            await using (contentStream.ConfigureAwait(false))
+            {
+                using var memoryStream = new MemoryStream();
+                var buffer = ArrayPool<byte>.Shared.Rent(81920);
+                try
+                {
+                    int bytesRead;
+                    while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+                    {
+                        if (memoryStream.Length + bytesRead > MaxRemoteImageSizeBytes)
+                        {
+                            throw new HttpRequestException($"Remote image '{url}' exceeds the maximum allowed size of {MaxRemoteImageSizeBytes} bytes.");
+                        }
+
+                        await memoryStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+
+                return memoryStream.ToArray();
             }
         }
 

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -58,6 +58,12 @@ namespace MediaBrowser.Providers.Manager
         /// </summary>
         private const long MaxRemoteImageSizeBytes = 30 * 1024 * 1024;
 
+        /// <summary>
+        /// Copy buffer size for remote image downloads. Kept small so the rented array stays in a
+        /// pooled bucket well below the large object heap threshold.
+        /// </summary>
+        private const int RemoteImageCopyBufferSize = 8192;
+
         private readonly Lock _refreshQueueLock = new();
         private readonly ILogger<ProviderManager> _logger;
         private readonly IHttpClientFactory _httpClientFactory;
@@ -276,8 +282,11 @@ namespace MediaBrowser.Providers.Manager
             var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
             await using (contentStream.ConfigureAwait(false))
             {
-                using var memoryStream = new MemoryStream();
-                var buffer = ArrayPool<byte>.Shared.Rent(81920);
+                // Pre-size from the advertised length when it is present and sane, so the common case
+                // does not repeatedly double the backing array.
+                var initialCapacity = (int)Math.Clamp(response.Content.Headers.ContentLength ?? 0, 0, MaxRemoteImageSizeBytes);
+                using var memoryStream = new MemoryStream(initialCapacity);
+                var buffer = ArrayPool<byte>.Shared.Rent(RemoteImageCopyBufferSize);
                 try
                 {
                     int bytesRead;

--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -21,6 +21,14 @@ namespace Jellyfin.Drawing.Skia;
 public class SkiaEncoder : IImageEncoder
 {
     private const string SvgFormat = "svg";
+
+    /// <summary>
+    /// The maximum number of pixels (width * height) an image may declare before it is rejected.
+    /// Guards against tiny "dimension bomb" images whose header advertises enormous dimensions,
+    /// which would otherwise cause a huge bitmap allocation and OOM/crash before any pixels are read.
+    /// </summary>
+    private const long MaxImagePixels = 100_000_000L;
+
     private static readonly HashSet<string> _transparentImageTypes = new(StringComparer.OrdinalIgnoreCase) { ".png", ".gif", ".webp" };
     private readonly ILogger<SkiaEncoder> _logger;
     private readonly IApplicationPaths _appPaths;
@@ -337,6 +345,20 @@ public class SkiaEncoder : IImageEncoder
         return (SKEncodedOrigin)orientation.Value;
     }
 
+    private void ValidateImageDimensions(string path, int width, int height)
+    {
+        if (width <= 0 || height <= 0 || (long)width * height > MaxImagePixels)
+        {
+            throw new ArgumentException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Image dimensions {0}x{1} for '{2}' are invalid or exceed the maximum allowed size",
+                    width,
+                    height,
+                    path));
+        }
+    }
+
     /// <summary>
     /// Decode an image.
     /// </summary>
@@ -368,6 +390,8 @@ public class SkiaEncoder : IImageEncoder
                 throw new ArgumentException("Cannot decode images with multiple frames");
             }
 
+            ValidateImageDimensions(path, codec.Info.Width, codec.Info.Height);
+
             // create the bitmap
             SKBitmap? bitmap = null;
             try
@@ -389,7 +413,18 @@ public class SkiaEncoder : IImageEncoder
             }
         }
 
-        var resultBitmap = SKBitmap.Decode(NormalizePath(path));
+        var normalizedPath = NormalizePath(path);
+
+        // Validate the advertised dimensions before letting Skia allocate the full bitmap internally.
+        using (var boundsCodec = SKCodec.Create(normalizedPath, out SKCodecResult boundsResult))
+        {
+            if (boundsCodec is not null && boundsResult == SKCodecResult.Success)
+            {
+                ValidateImageDimensions(path, boundsCodec.Info.Width, boundsCodec.Info.Height);
+            }
+        }
+
+        var resultBitmap = SKBitmap.Decode(normalizedPath);
 
         if (resultBitmap is null)
         {

--- a/src/Jellyfin.Networking/HappyEyeballs/HttpClientExtension.cs
+++ b/src/Jellyfin.Networking/HappyEyeballs/HttpClientExtension.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 */
 
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading;
@@ -105,7 +106,27 @@ public static class HttpClientExtension
 
         try
         {
-            await socket.ConnectAsync(context.DnsEndPoint, cancellationToken).ConfigureAwait(false);
+            var dnsEndPoint = context.DnsEndPoint;
+
+            // Resolve the destination ourselves and connect to the validated address so that the
+            // SSRF guard below cannot be bypassed via DNS rebinding (the connection targets the
+            // exact address that was checked). Resolving per address family also preserves the
+            // Happy Eyeballs fallback behaviour.
+            var addresses = await ResolveAddressesAsync(dnsEndPoint.Host, addressFamily, cancellationToken).ConfigureAwait(false);
+
+            // Reject loopback and link-local destinations (the latter includes the cloud metadata
+            // endpoint 169.254.169.254). Private/RFC1918 ranges are intentionally left reachable to
+            // preserve LAN tuners and local metadata services. Fail closed if any resolved address
+            // is restricted.
+            foreach (var address in addresses)
+            {
+                if (IsRestrictedAddress(address))
+                {
+                    throw new HttpRequestException($"Blocked attempt to connect to a restricted address '{address}' for host '{dnsEndPoint.Host}'.");
+                }
+            }
+
+            await socket.ConnectAsync(addresses, dnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
             // The stream should take the ownership of the underlying socket,
             // closing it when it's disposed.
             return new NetworkStream(socket, ownsSocket: true);
@@ -115,5 +136,39 @@ public static class HttpClientExtension
             socket.Dispose();
             throw;
         }
+    }
+
+    private static async Task<IPAddress[]> ResolveAddressesAsync(string host, AddressFamily addressFamily, CancellationToken cancellationToken)
+    {
+        if (IPAddress.TryParse(host, out var literal))
+        {
+            return literal.AddressFamily == addressFamily ? [literal] : [];
+        }
+
+        return await Dns.GetHostAddressesAsync(host, addressFamily, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsRestrictedAddress(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
+        // Loopback (127.0.0.0/8, ::1), IPv6 link-local (fe80::/10) and IPv4 link-local (169.254.0.0/16).
+        return IPAddress.IsLoopback(address)
+            || address.IsIPv6LinkLocal
+            || IsIPv4LinkLocal(address);
+    }
+
+    private static bool IsIPv4LinkLocal(IPAddress address)
+    {
+        if (address.AddressFamily != AddressFamily.InterNetwork)
+        {
+            return false;
+        }
+
+        var bytes = address.GetAddressBytes();
+        return bytes[0] == 169 && bytes[1] == 254;
     }
 }

--- a/src/Jellyfin.Networking/HappyEyeballs/HttpClientExtension.cs
+++ b/src/Jellyfin.Networking/HappyEyeballs/HttpClientExtension.cs
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -113,11 +114,13 @@ public static class HttpClientExtension
             // exact address that was checked). Resolving per address family also preserves the
             // Happy Eyeballs fallback behaviour.
             var addresses = await ResolveAddressesAsync(dnsEndPoint.Host, addressFamily, cancellationToken).ConfigureAwait(false);
+            if (addresses.Length == 0)
+            {
+                // Nothing to try for this family; let the other Happy Eyeballs attempt win.
+                throw new SocketException((int)SocketError.HostNotFound);
+            }
 
-            // Reject loopback and link-local destinations (the latter includes the cloud metadata
-            // endpoint 169.254.169.254). Private/RFC1918 ranges are intentionally left reachable to
-            // preserve LAN tuners and local metadata services. Fail closed if any resolved address
-            // is restricted.
+            // Fail closed if any resolved address.
             foreach (var address in addresses)
             {
                 if (IsRestrictedAddress(address))
@@ -142,33 +145,77 @@ public static class HttpClientExtension
     {
         if (IPAddress.TryParse(host, out var literal))
         {
-            return literal.AddressFamily == addressFamily ? [literal] : [];
+            // An IPv4-mapped literal is reachable from the IPv6 socket, everything else has to match.
+            var usable = literal.AddressFamily == addressFamily
+                || (addressFamily == AddressFamily.InterNetworkV6 && literal.AddressFamily == AddressFamily.InterNetwork);
+            return usable ? [literal] : [];
         }
 
         return await Dns.GetHostAddressesAsync(host, addressFamily, cancellationToken).ConfigureAwait(false);
     }
 
-    private static bool IsRestrictedAddress(IPAddress address)
+    /// <summary>
+    /// Returns whether the address must not be connected to.
+    /// Unique local addresses (fc00::/7) and RFC1918 ranges are deliberately allowed so LAN tuners
+    /// and local metadata services keep working; only host-scoped and link-scoped destinations,
+    /// which is where the interesting server-side targets live, are rejected.
+    /// </summary>
+    /// <param name="address">The resolved destination address.</param>
+    /// <returns><c>true</c> if the address must not be connected to; otherwise <c>false</c>.</returns>
+    internal static bool IsRestrictedAddress(IPAddress address)
     {
         if (address.IsIPv4MappedToIPv6)
         {
             address = address.MapToIPv4();
         }
 
-        // Loopback (127.0.0.0/8, ::1), IPv6 link-local (fe80::/10) and IPv4 link-local (169.254.0.0/16).
-        return IPAddress.IsLoopback(address)
-            || address.IsIPv6LinkLocal
-            || IsIPv4LinkLocal(address);
-    }
-
-    private static bool IsIPv4LinkLocal(IPAddress address)
-    {
-        if (address.AddressFamily != AddressFamily.InterNetwork)
+        if (address.AddressFamily == AddressFamily.InterNetwork)
         {
-            return false;
+            var bytes = address.GetAddressBytes();
+            return bytes[0] switch
+            {
+                // "This network" (0.0.0.0/8). 0.0.0.0 reaches the local host on Linux and Windows.
+                0 => true,
+                // Loopback (127.0.0.0/8).
+                127 => true,
+                // Link-local (169.254.0.0/16), which contains the 169.254.169.254 cloud metadata endpoint.
+                169 when bytes[1] == 254 => true,
+                // Multicast (224.0.0.0/4) plus reserved and limited broadcast (240.0.0.0/4).
+                >= 224 => true,
+                _ => false
+            };
         }
 
+        return IPAddress.IsLoopback(address)
+            || address.IsIPv6LinkLocal
+            || address.IsIPv6SiteLocal
+            || address.IsIPv6Multicast
+            || IsRestrictedEmbeddedIPv4(address);
+    }
+
+    private static bool IsRestrictedEmbeddedIPv4(IPAddress address)
+    {
         var bytes = address.GetAddressBytes();
-        return bytes[0] == 169 && bytes[1] == 254;
+
+        // 6to4 (2002::/16) carries the IPv4 address in the next four bytes.
+        if (bytes[0] == 0x20 && bytes[1] == 0x02)
+        {
+            return IsRestrictedAddress(new IPAddress(bytes.AsSpan(2, 4)));
+        }
+
+        // NAT64 well-known prefix (64:ff9b::/96).
+        if (bytes[0] == 0x00 && bytes[1] == 0x64 && bytes[2] == 0xFF && bytes[3] == 0x9B
+            && !bytes.AsSpan(4, 8).ContainsAnyExcept((byte)0))
+        {
+            return IsRestrictedAddress(new IPAddress(bytes.AsSpan(12, 4)));
+        }
+
+        // Deprecated IPv4-compatible form (::a.b.c.d). Also catches the unspecified address (::).
+        if (!bytes.AsSpan(0, 12).ContainsAnyExcept((byte)0))
+        {
+            return IsRestrictedAddress(new IPAddress(bytes.AsSpan(12, 4)));
+        }
+
+        return false;
     }
 }

--- a/src/Jellyfin.Networking/Properties/AssemblyInfo.cs
+++ b/src/Jellyfin.Networking/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Jellyfin.Networking.Tests")]

--- a/tests/Jellyfin.Networking.Tests/HttpClientExtensionTests.cs
+++ b/tests/Jellyfin.Networking.Tests/HttpClientExtensionTests.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using Jellyfin.Networking.HappyEyeballs;
+using Xunit;
+
+namespace Jellyfin.Networking.Tests
+{
+    public static class HttpClientExtensionTests
+    {
+        [Theory]
+        [InlineData("127.0.0.1")]
+        [InlineData("127.1.2.3")]
+        [InlineData("0.0.0.0")]
+        [InlineData("0.1.2.3")]
+        [InlineData("169.254.169.254")]
+        [InlineData("169.254.0.1")]
+        [InlineData("224.0.0.1")]
+        [InlineData("239.255.255.250")]
+        [InlineData("255.255.255.255")]
+        [InlineData("::1")]
+        [InlineData("::")]
+        [InlineData("fe80::1")]
+        [InlineData("fec0::1")]
+        [InlineData("ff02::1")]
+        [InlineData("::ffff:127.0.0.1")]
+        [InlineData("::ffff:169.254.169.254")]
+        [InlineData("::127.0.0.1")]
+        [InlineData("2002:7f00:1::")]
+        [InlineData("2002:a9fe:a9fe::")]
+        [InlineData("64:ff9b::7f00:1")]
+        [InlineData("64:ff9b::a9fe:a9fe")]
+        public static void IsRestrictedAddress_RestrictedTarget_True(string address)
+        {
+            Assert.True(HttpClientExtension.IsRestrictedAddress(IPAddress.Parse(address)));
+        }
+
+        [Theory]
+        // Public addresses.
+        [InlineData("1.1.1.1")]
+        [InlineData("93.184.216.34")]
+        [InlineData("2606:4700:4700::1111")]
+        // RFC1918 and the IPv6 unique local range stay reachable for LAN tuners and local services.
+        [InlineData("10.0.0.5")]
+        [InlineData("172.16.0.5")]
+        [InlineData("192.168.1.10")]
+        [InlineData("fd00::1")]
+        [InlineData("::ffff:192.168.1.10")]
+        // 6to4 and NAT64 wrapping a routable address are not restricted.
+        [InlineData("2002:0101:0101::")]
+        [InlineData("64:ff9b::0101:0101")]
+        public static void IsRestrictedAddress_AllowedTarget_False(string address)
+        {
+            Assert.False(HttpClientExtension.IsRestrictedAddress(IPAddress.Parse(address)));
+        }
+    }
+}


### PR DESCRIPTION
I let claude do an audit at some point and validated all of this.

**Changes**
- AddVirtualFolder/media-path handling accepted traversal and absolute paths; validate them before touching the filesystem.
- The endpoints were unauthenticated and didn't check user access to the item; require both.
- The HTTP client connected to any resolved address, so provider-supplied URLs (NFO artwork, LiveTV logos, remote images, redirects) could reach internal services. Resolve and connect to a validated address, rejecting loopback/link-local while leaving RFC1918 reachable for LAN tuners. Also caps remote image downloads.
- Crafted duration/bitrate values threw unhandled Overflow/FormatException and aborted item import; parse via range-checked helpers.
- `SkiaEncoder.Decode` allocated from attacker-controlled header dimensions, so a tiny crafted image could OOM native Skia. Validate against a pixel budget first.
- The keep-alive timer could overlap a broadcast send, and the resulting `InvalidOperationException` escaped an async void handler and crashed the process. Serialize sends per connection and widen the catch.
- Both reset paths cleared the password without invalidating existing tokens; revoke them, matching the change-password path.

**Code assistance**
Claude Opus 5 was used to analyze and trace some of this.

**Issues**

