### PR TITLE
Cut redundant work from item queries

### DIFF
--- a/Jellyfin.Api/Controllers/LibraryController.cs
+++ b/Jellyfin.Api/Controllers/LibraryController.cs
@@ -155,56 +155,13 @@ public class LibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[]? sortBy = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] SortOrder[]? sortOrder = null)
     {
-        userId = RequestHelpers.GetUserId(User, userId);
-        var user = userId.IsNullOrEmpty()
-            ? null
-            : _userManager.GetUserById(userId.Value);
-
-        var item = itemId.IsEmpty()
-            ? (userId.IsNullOrEmpty()
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
-            : _libraryManager.GetItemById<BaseItem>(itemId, user);
+        var (item, user) = ResolveThemeMediaOwner(itemId, userId);
         if (item is null)
         {
             return NotFound();
         }
 
-        sortOrder ??= [];
-        sortBy ??= [];
-        var orderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder);
-
-        IReadOnlyList<BaseItem> themeItems;
-
-        while (true)
-        {
-            themeItems = item.GetThemeSongs(user, orderBy);
-
-            if (themeItems.Count > 0 || !inheritFromParent)
-            {
-                break;
-            }
-
-            var parent = item.GetParent();
-            if (parent is null)
-            {
-                break;
-            }
-
-            item = parent;
-        }
-
-        var dtoOptions = new DtoOptions();
-        var items = themeItems
-            .Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user, item))
-            .ToArray();
-
-        return new ThemeMediaResult
-        {
-            Items = items,
-            TotalRecordCount = items.Length,
-            OwnerId = item.Id
-        };
+        return GetThemeMediaResult(item, user, ExtraType.ThemeSong, inheritFromParent, sortBy, sortOrder);
     }
 
     /// <summary>
@@ -229,31 +186,50 @@ public class LibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[]? sortBy = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] SortOrder[]? sortOrder = null)
     {
-        userId = RequestHelpers.GetUserId(User, userId);
-        var user = userId.IsNullOrEmpty()
-            ? null
-            : _userManager.GetUserById(userId.Value);
-        var item = itemId.IsEmpty()
-            ? (userId.IsNullOrEmpty()
-                ? _libraryManager.RootFolder
-                : _libraryManager.GetUserRootFolder())
-            : _libraryManager.GetItemById<BaseItem>(itemId, user);
+        var (item, user) = ResolveThemeMediaOwner(itemId, userId);
         if (item is null)
         {
             return NotFound();
         }
 
-        sortOrder ??= [];
-        sortBy ??= [];
-        var orderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder);
+        return GetThemeMediaResult(item, user, ExtraType.ThemeVideo, inheritFromParent, sortBy, sortOrder);
+    }
 
-        IEnumerable<BaseItem> themeItems;
+    private (BaseItem? Item, User? User) ResolveThemeMediaOwner(Guid itemId, Guid? userId)
+    {
+        userId = RequestHelpers.GetUserId(User, userId);
+        var user = userId.IsNullOrEmpty()
+            ? null
+            : _userManager.GetUserById(userId.Value);
+
+        var item = itemId.IsEmpty()
+            ? (userId.IsNullOrEmpty()
+                ? _libraryManager.RootFolder
+                : _libraryManager.GetUserRootFolder())
+            : _libraryManager.GetItemById<BaseItem>(itemId, user);
+
+        return (item, user);
+    }
+
+    private ThemeMediaResult GetThemeMediaResult(
+        BaseItem item,
+        User? user,
+        ExtraType extraType,
+        bool inheritFromParent,
+        ItemSortBy[]? sortBy,
+        SortOrder[]? sortOrder)
+    {
+        var orderBy = RequestHelpers.GetOrderBy(sortBy ?? [], sortOrder ?? []);
+
+        IReadOnlyList<BaseItem> themeItems;
 
         while (true)
         {
-            themeItems = item.GetThemeVideos(user, orderBy);
+            themeItems = extraType == ExtraType.ThemeSong
+                ? item.GetThemeSongs(user, orderBy)
+                : item.GetThemeVideos(user, orderBy);
 
-            if (themeItems.Any() || !inheritFromParent)
+            if (themeItems.Count > 0 || !inheritFromParent)
             {
                 break;
             }
@@ -301,30 +277,16 @@ public class LibraryController : BaseJellyfinApiController
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[]? sortBy = null,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] SortOrder[]? sortOrder = null)
     {
-        var themeSongs = GetThemeSongs(
-            itemId,
-            userId,
-            inheritFromParent,
-            sortBy,
-            sortOrder);
-
-        var themeVideos = GetThemeVideos(
-            itemId,
-            userId,
-            inheritFromParent,
-            sortBy,
-            sortOrder);
-
-        if (themeSongs.Result is StatusCodeResult { StatusCode: StatusCodes.Status404NotFound }
-            || themeVideos.Result is StatusCodeResult { StatusCode: StatusCodes.Status404NotFound })
+        var (item, user) = ResolveThemeMediaOwner(itemId, userId);
+        if (item is null)
         {
             return NotFound();
         }
 
         return new AllThemeMediaResult
         {
-            ThemeSongsResult = themeSongs.Value,
-            ThemeVideosResult = themeVideos.Value,
+            ThemeSongsResult = GetThemeMediaResult(item, user, ExtraType.ThemeSong, inheritFromParent, sortBy, sortOrder),
+            ThemeVideosResult = GetThemeMediaResult(item, user, ExtraType.ThemeVideo, inheritFromParent, sortBy, sortOrder),
             SoundtrackSongsResult = new ThemeMediaResult()
         };
     }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -146,22 +146,26 @@ public sealed partial class BaseItemRepository
 
         using var context = _dbProvider.CreateDbContext();
 
-        var innerQueryFilter = TranslateQuery(context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId)), context, new InternalItemsQuery(filter.User)
-        {
-            ExcludeItemTypes = filter.ExcludeItemTypes,
-            IncludeItemTypes = filter.IncludeItemTypes,
-            MediaTypes = filter.MediaTypes,
-            AncestorIds = filter.AncestorIds,
-            ItemIds = filter.ItemIds,
-            TopParentIds = filter.TopParentIds,
-            ParentId = filter.ParentId,
-            IsAiring = filter.IsAiring,
-            IsMovie = filter.IsMovie,
-            IsSports = filter.IsSports,
-            IsKids = filter.IsKids,
-            IsNews = filter.IsNews,
-            IsSeries = filter.IsSeries
-        });
+        var innerQueryFilter = TranslateQuery(
+            context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId)),
+            context,
+            new InternalItemsQuery(filter.User)
+            {
+                ExcludeItemTypes = filter.ExcludeItemTypes,
+                IncludeItemTypes = filter.IncludeItemTypes,
+                MediaTypes = filter.MediaTypes,
+                AncestorIds = filter.AncestorIds,
+                ItemIds = filter.ItemIds,
+                TopParentIds = filter.TopParentIds,
+                ParentId = filter.ParentId,
+                IsAiring = filter.IsAiring,
+                IsMovie = filter.IsMovie,
+                IsSports = filter.IsSports,
+                IsKids = filter.IsKids,
+                IsNews = filter.IsNews,
+                IsSeries = filter.IsSeries
+            },
+            isCorrelatedSubQuery: true);
 
         var innerQuery = PrepareItemQuery(context, filter)
             .Where(e => e.Type == returnType)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -148,22 +148,26 @@ public sealed partial class BaseItemRepository
 
         using var context = _dbProvider.CreateDbContext();
 
-        var innerQueryFilter = TranslateQuery(context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId)), context, new InternalItemsQuery(filter.User)
-        {
-            ExcludeItemTypes = filter.ExcludeItemTypes,
-            IncludeItemTypes = filter.IncludeItemTypes,
-            MediaTypes = filter.MediaTypes,
-            AncestorIds = filter.AncestorIds,
-            ItemIds = filter.ItemIds,
-            TopParentIds = filter.TopParentIds,
-            ParentId = filter.ParentId,
-            IsAiring = filter.IsAiring,
-            IsMovie = filter.IsMovie,
-            IsSports = filter.IsSports,
-            IsKids = filter.IsKids,
-            IsNews = filter.IsNews,
-            IsSeries = filter.IsSeries
-        });
+        var innerQueryFilter = TranslateQuery(
+            context.BaseItems.Where(e => e.Id != EF.Constant(PlaceholderId)),
+            context,
+            new InternalItemsQuery(filter.User)
+            {
+                ExcludeItemTypes = filter.ExcludeItemTypes,
+                IncludeItemTypes = filter.IncludeItemTypes,
+                MediaTypes = filter.MediaTypes,
+                AncestorIds = filter.AncestorIds,
+                ItemIds = filter.ItemIds,
+                TopParentIds = filter.TopParentIds,
+                ParentId = filter.ParentId,
+                IsAiring = filter.IsAiring,
+                IsMovie = filter.IsMovie,
+                IsSports = filter.IsSports,
+                IsKids = filter.IsKids,
+                IsNews = filter.IsNews,
+                IsSeries = filter.IsSeries
+            },
+            isCorrelatedSubQuery: true);
 
         var innerQuery = PrepareItemQuery(context, filter)
             .Where(e => e.Type == returnType)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -680,4 +680,34 @@ public sealed partial class BaseItemRepository
                 && (descendants.Any(d => d.Id == lc.ChildId)
                     || context.AncestorIds.Any(a => a.ParentItemId == lc.ChildId && descendants.Any(d => d.Id == a.ItemId))));
     }
+
+    /// <summary>
+    /// Builds the same filter as <see cref="BuildHasDescendantFilter"/> for descendants a small set of
+    /// ids already picks out, by collecting the folders those ids sit under.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="seedIds">The ids the descendants are drawn from, e.g. a user's own played rows.</param>
+    /// <param name="descendants">The descendants that count, narrowed to <paramref name="seedIds"/>.</param>
+    /// <returns>A filter keeping items that hold at least one matching descendant.</returns>
+    private static Expression<Func<BaseItemEntity, bool>> BuildHasSeededDescendantFilter(
+        JellyfinDbContext context,
+        IQueryable<Guid> seedIds,
+        IQueryable<BaseItemEntity> descendants)
+    {
+        var matchingSeedIds = descendants.Where(d => seedIds.Contains(d.Id)).Select(d => d.Id);
+
+        var hierarchicalParentIds = context.AncestorIds
+            .Where(a => matchingSeedIds.Contains(a.ItemId))
+            .Select(a => a.ParentItemId);
+
+        var parentIds = hierarchicalParentIds
+            .Concat(context.LinkedChildren
+                .Where(lc => matchingSeedIds.Contains(lc.ChildId))
+                .Select(lc => lc.ParentId))
+            .Concat(context.LinkedChildren
+                .Where(lc => hierarchicalParentIds.Contains(lc.ChildId))
+                .Select(lc => lc.ParentId));
+
+        return e => parentIds.Contains(e.Id);
+    }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -31,14 +31,15 @@ public sealed partial class BaseItemRepository
         return dbQuery;
     }
 
-    private IQueryable<BaseItemEntity> ApplyQueryFilter(IQueryable<BaseItemEntity> dbQuery, JellyfinDbContext context, InternalItemsQuery filter)
+    private IQueryable<Guid> ApplyQueryFilter(IQueryable<BaseItemEntity> dbQuery, JellyfinDbContext context, InternalItemsQuery filter)
     {
         dbQuery = TranslateQuery(dbQuery, context, filter);
         dbQuery = ApplyGroupingFilter(context, dbQuery, filter);
         dbQuery = ApplyAdjacencyFilter(context, dbQuery, filter);
         dbQuery = ApplyQueryPaging(dbQuery, filter);
-        dbQuery = ApplyNavigations(dbQuery, filter);
-        return dbQuery;
+
+        // No navigations: nothing is deserialized, and an Include is dropped by a scalar projection anyway.
+        return dbQuery.Select(e => e.Id);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -113,10 +113,8 @@ public sealed partial class BaseItemRepository
             var groupedIds = dbQuery.GroupBy(e => e.SeriesPresentationUniqueKey).Select(e => e.Min(x => x.Id));
             dbQuery = context.BaseItems.AsNoTracking().Where(e => groupedIds.Contains(e.Id));
         }
-        else
-        {
-            dbQuery = dbQuery.Distinct();
-        }
+
+        // No else branch: without grouping there is nothing to de-duplicate.
 
         if (filter.CollapseBoxSetItems == true)
         {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -32,14 +32,15 @@ public sealed partial class BaseItemRepository
         return dbQuery;
     }
 
-    private IQueryable<BaseItemEntity> ApplyQueryFilter(IQueryable<BaseItemEntity> dbQuery, JellyfinDbContext context, InternalItemsQuery filter)
+    private IQueryable<Guid> ApplyQueryFilter(IQueryable<BaseItemEntity> dbQuery, JellyfinDbContext context, InternalItemsQuery filter)
     {
         dbQuery = TranslateQuery(dbQuery, context, filter);
         dbQuery = ApplyGroupingFilter(context, dbQuery, filter);
         dbQuery = ApplyAdjacencyFilter(context, dbQuery, filter);
         dbQuery = ApplyQueryPaging(dbQuery, filter);
-        dbQuery = ApplyNavigations(dbQuery, filter);
-        return dbQuery;
+
+        // No navigations: nothing is deserialized, and an Include is dropped by a scalar projection anyway.
+        return dbQuery.Select(e => e.Id);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -695,4 +695,34 @@ public sealed partial class BaseItemRepository
                 && (descendants.Any(d => d.Id == lc.ChildId)
                     || context.AncestorIds.Any(a => a.ParentItemId == lc.ChildId && descendants.Any(d => d.Id == a.ItemId))));
     }
+
+    /// <summary>
+    /// Builds the same filter as <see cref="BuildHasDescendantFilter"/> for descendants a small set of
+    /// ids already picks out, by collecting the folders those ids sit under.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="seedIds">The ids the descendants are drawn from, e.g. a user's own played rows.</param>
+    /// <param name="descendants">The descendants that count, narrowed to <paramref name="seedIds"/>.</param>
+    /// <returns>A filter keeping items that hold at least one matching descendant.</returns>
+    private static Expression<Func<BaseItemEntity, bool>> BuildHasSeededDescendantFilter(
+        JellyfinDbContext context,
+        IQueryable<Guid> seedIds,
+        IQueryable<BaseItemEntity> descendants)
+    {
+        var matchingSeedIds = descendants.Where(d => seedIds.Contains(d.Id)).Select(d => d.Id);
+
+        var hierarchicalParentIds = context.AncestorIds
+            .Where(a => matchingSeedIds.Contains(a.ItemId))
+            .Select(a => a.ParentItemId);
+
+        var parentIds = hierarchicalParentIds
+            .Concat(context.LinkedChildren
+                .Where(lc => matchingSeedIds.Contains(lc.ChildId))
+                .Select(lc => lc.ParentId))
+            .Concat(context.LinkedChildren
+                .Where(lc => hierarchicalParentIds.Contains(lc.ChildId))
+                .Select(lc => lc.ParentId));
+
+        return e => parentIds.Contains(e.Id);
+    }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -114,10 +114,8 @@ public sealed partial class BaseItemRepository
             var groupedIds = dbQuery.GroupBy(e => e.SeriesPresentationUniqueKey).Select(e => e.Min(x => x.Id));
             dbQuery = context.BaseItems.AsNoTracking().Where(e => groupedIds.Contains(e.Id));
         }
-        else
-        {
-            dbQuery = dbQuery.Distinct();
-        }
+
+        // No else branch: without grouping there is nothing to de-duplicate.
 
         if (filter.CollapseBoxSetItems == true)
         {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -581,44 +581,45 @@ public sealed partial class BaseItemRepository
 
         var matchingItemIds = baseQuery.Select(e => e.Id);
 
-        var years = baseQuery
-            .Where(e => e.ProductionYear != null && e.ProductionYear > 0)
-            .Select(e => e.ProductionYear!.Value)
+        var yearsAndRatings = baseQuery
+            .Select(e => new { e.ProductionYear, e.OfficialRating })
             .Distinct()
-            .OrderBy(y => y)
             .ToArray();
 
-        var officialRatings = baseQuery
-            .Where(e => e.OfficialRating != null && e.OfficialRating != string.Empty)
-            .Select(e => e.OfficialRating!)
+        var namedValues = context.ItemValuesMap
+            .Where(ivm => (ivm.ItemValue.Type == ItemValueType.Tags || ivm.ItemValue.Type == ItemValueType.Genre)
+                && matchingItemIds.Contains(ivm.ItemId))
+            .Select(ivm => new { ivm.ItemValue.Type, ivm.ItemValue.CleanValue, ivm.ItemValue.Value })
             .Distinct()
-            .OrderBy(r => r)
-            .ToArray();
-
-        var tags = context.ItemValuesMap
-            .Where(ivm => ivm.ItemValue.Type == ItemValueType.Tags)
-            .Where(ivm => matchingItemIds.Contains(ivm.ItemId))
-            .Select(ivm => ivm.ItemValue)
-            .GroupBy(iv => iv.CleanValue)
-            .Select(g => g.Min(iv => iv.Value))
-            .OrderBy(t => t)
-            .ToArray();
-
-        var genres = context.ItemValuesMap
-            .Where(ivm => ivm.ItemValue.Type == ItemValueType.Genre)
-            .Where(ivm => matchingItemIds.Contains(ivm.ItemId))
-            .Select(ivm => ivm.ItemValue)
-            .GroupBy(iv => iv.CleanValue)
-            .Select(g => g.Min(iv => iv.Value))
-            .OrderBy(g => g)
+            .ToArray()
+            .GroupBy(v => (v.Type, v.CleanValue))
+            .Select(g => new { g.Key.Type, Value = g.Select(v => v.Value).Min(StringComparer.Ordinal)! })
             .ToArray();
 
         return new QueryFiltersLegacy
         {
-            Years = years,
-            OfficialRatings = officialRatings,
-            Tags = tags,
-            Genres = genres
+            Years = yearsAndRatings
+                .Where(e => e.ProductionYear > 0)
+                .Select(e => e.ProductionYear!.Value)
+                .Distinct()
+                .Order()
+                .ToArray(),
+            OfficialRatings = yearsAndRatings
+                .Where(e => !string.IsNullOrEmpty(e.OfficialRating))
+                .Select(e => e.OfficialRating!)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            Tags = namedValues
+                .Where(v => v.Type == ItemValueType.Tags)
+                .Select(v => v.Value)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            Genres = namedValues
+                .Where(v => v.Type == ItemValueType.Genre)
+                .Select(v => v.Value)
+                .Order(StringComparer.Ordinal)
+                .ToArray()
         };
     }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -24,7 +24,7 @@ public sealed partial class BaseItemRepository
         PrepareFilterQuery(filter);
 
         using var context = _dbProvider.CreateDbContext();
-        return ApplyQueryFilter(context.BaseItems.AsNoTracking().Where(e => e.Id != EF.Constant(PlaceholderId)), context, filter).Select(e => e.Id).ToArray();
+        return ApplyQueryFilter(context.BaseItems.AsNoTracking().Where(e => e.Id != EF.Constant(PlaceholderId)), context, filter).ToArray();
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -611,52 +611,45 @@ public sealed partial class BaseItemRepository
 
         var matchingItemIds = baseQuery.Select(e => e.Id);
 
-        var years = baseQuery
-            .Where(e => e.ProductionYear != null && e.ProductionYear > 0)
-            .Select(e => e.ProductionYear!.Value)
+        var yearsAndRatings = baseQuery
+            .Select(e => new { e.ProductionYear, e.OfficialRating })
             .Distinct()
-            .OrderBy(y => y)
             .ToArray();
 
-        var officialRatings = baseQuery
-            .Where(e => e.OfficialRating != null && e.OfficialRating != string.Empty)
-            .Select(e => e.OfficialRating!)
+        var namedValues = context.ItemValuesMap
+            .Where(ivm => (ivm.ItemValue.Type == ItemValueType.Tags || ivm.ItemValue.Type == ItemValueType.Genre)
+                && matchingItemIds.Contains(ivm.ItemId))
+            .Select(ivm => new { ivm.ItemValue.Type, ivm.ItemValue.CleanValue, ivm.ItemValue.Value })
             .Distinct()
-            .OrderBy(r => r)
-            .ToArray();
-
-        var tags = context.ItemValuesMap
-            .Join(
-                context.ItemValues,
-                ivm => ivm.ItemValueId,
-                iv => iv.ItemValueId,
-                (ivm, iv) => new { ivm.ItemId, iv.Type, iv.CleanValue, iv.Value })
-            .Where(iv => iv.Type == ItemValueType.Tags)
-            .Where(iv => matchingItemIds.Contains(iv.ItemId))
-            .GroupBy(iv => iv.CleanValue)
-            .Select(g => g.Min(iv => iv.Value))
-            .OrderBy(t => t)
-            .ToArray();
-
-        var genres = context.ItemValuesMap
-            .Join(
-                context.ItemValues,
-                ivm => ivm.ItemValueId,
-                iv => iv.ItemValueId,
-                (ivm, iv) => new { ivm.ItemId, iv.Type, iv.CleanValue, iv.Value })
-            .Where(iv => iv.Type == ItemValueType.Genre)
-            .Where(iv => matchingItemIds.Contains(iv.ItemId))
-            .GroupBy(iv => iv.CleanValue)
-            .Select(g => g.Min(iv => iv.Value))
-            .OrderBy(g => g)
+            .ToArray()
+            .GroupBy(v => (v.Type, v.CleanValue))
+            .Select(g => new { g.Key.Type, Value = g.Select(v => v.Value).Min(StringComparer.Ordinal)! })
             .ToArray();
 
         return new QueryFiltersLegacy
         {
-            Years = years,
-            OfficialRatings = officialRatings,
-            Tags = tags,
-            Genres = genres
+            Years = yearsAndRatings
+                .Where(e => e.ProductionYear > 0)
+                .Select(e => e.ProductionYear!.Value)
+                .Distinct()
+                .Order()
+                .ToArray(),
+            OfficialRatings = yearsAndRatings
+                .Where(e => !string.IsNullOrEmpty(e.OfficialRating))
+                .Select(e => e.OfficialRating!)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            Tags = namedValues
+                .Where(v => v.Type == ItemValueType.Tags)
+                .Select(v => v.Value)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            Genres = namedValues
+                .Where(v => v.Type == ItemValueType.Genre)
+                .Select(v => v.Value)
+                .Order(StringComparer.Ordinal)
+                .ToArray()
         };
     }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -988,12 +988,19 @@ public sealed partial class BaseItemRepository
 
         baseQuery = ApplyTopParentFiltering(context, baseQuery, filter);
 
-        if (filter.AncestorIds.Length > 0)
+        if (filter.AncestorIds.Length == 1)
         {
-            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against that.
+            var ancestorId = filter.AncestorIds[0];
+            baseQuery = baseQuery.Join(
+                context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
+                e => e.Id,
+                a => a.ItemId,
+                (e, a) => e);
+        }
+        else if (filter.AncestorIds.Length > 1)
+        {
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
-            var descendantIds = context.AncestorIds.Where(ancestorFilter).Select(a => a.ItemId);
-            baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
+            baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
         }
 
         if (filter.LinkedChildAncestorIds.Length > 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -990,8 +990,10 @@ public sealed partial class BaseItemRepository
 
         if (filter.AncestorIds.Length > 0)
         {
+            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against that.
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
-            baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
+            var descendantIds = context.AncestorIds.Where(ancestorFilter).Select(a => a.ItemId);
+            baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
         }
 
         if (filter.LinkedChildAncestorIds.Length > 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -25,6 +25,8 @@ namespace Jellyfin.Server.Implementations.Item;
 
 public sealed partial class BaseItemRepository
 {
+    private const int AncestorProbeLimit = 10000;
+
     private static readonly IReadOnlyList<char> SearchWildcardTerms = ['%', '_', '[', ']', '^'];
 
     private static readonly string ImdbProviderName = MetadataProvider.Imdb.ToString().ToLowerInvariant();
@@ -1005,8 +1007,9 @@ public sealed partial class BaseItemRepository
 
         baseQuery = ApplyTopParentFiltering(context, baseQuery, filter);
 
-        if (filter.AncestorIds.Length == 1)
+        if (filter.AncestorIds.Length == 1 && AncestorShouldDriveQuery(context, filter))
         {
+            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against those.
             var ancestorId = filter.AncestorIds[0];
             baseQuery = baseQuery.Join(
                 context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
@@ -1014,7 +1017,7 @@ public sealed partial class BaseItemRepository
                 a => a.ItemId,
                 (e, a) => e);
         }
-        else if (filter.AncestorIds.Length > 1)
+        else if (filter.AncestorIds.Length > 0)
         {
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
             baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
@@ -1205,5 +1208,39 @@ public sealed partial class BaseItemRepository
         }
 
         return baseQuery;
+    }
+
+    /// <summary>
+    /// Decides whether an ancestor filter should drive the query or be tested per row.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="filter">The query filter, carrying exactly one ancestor id.</param>
+    /// <returns><c>true</c> when reading the ancestor's descendants is the cheaper way round.</returns>
+    private bool AncestorShouldDriveQuery(JellyfinDbContext context, InternalItemsQuery filter)
+    {
+        // A join reads every descendant of the ancestor; an EXISTS runs once per row the rest of the
+        // query keeps. The smaller side should drive, and SQLite cannot work that out on its own
+        // because statistics are averaged across the whole table.
+        var otherSideCount = filter.ItemIds.Length > 0 ? filter.ItemIds.Length : AncestorProbeLimit;
+
+        if (filter.IncludeItemTypes.Length > 0)
+        {
+            var typeNames = filter.IncludeItemTypes
+                .Select(f => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(f))
+                .Where(e => e is not null)
+                .ToArray()!;
+
+            otherSideCount = Math.Min(
+                otherSideCount,
+                context.BaseItems.WhereOneOrMany(typeNames, e => e.Type!).Take(AncestorProbeLimit).Count());
+        }
+
+        var ancestorId = filter.AncestorIds[0];
+        var descendantCount = context.AncestorIds
+            .Where(a => a.ParentItemId == ancestorId)
+            .Take(AncestorProbeLimit)
+            .Count();
+
+        return descendantCount <= otherSideCount;
     }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -501,30 +501,44 @@ public sealed partial class BaseItemRepository
             var inProgress = context.UserData
                 .Where(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0);
 
+            // Resume queries surface the version that was actually played, which may be an alternate.
+            // Match each version on its own progress rather than coalescing onto the primary.
+            var inProgressIds = inProgress.Select(ud => ud.ItemId);
+            var playedIds = context.UserData
+                .Where(ud => ud.UserId == userId && ud.Played)
+                .Select(ud => ud.ItemId);
+
+            var canReturnFolders = filter.IsFolder != false
+                && (filter.MediaTypes.Length == 0 || filter.MediaTypes.Contains(MediaType.Unknown))
+                && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Any(_resumableFolderKinds.Contains));
+
             // Series and Seasons are resumable when a descendant is in progress, or when they hold both
             // played and unplayed descendants (partially watched). Alternate versions keep their own
             // progress, so they count towards the in-progress check but not towards the played/unplayed one.
-            var leafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!);
-            var inProgressLeafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!, includeOwnedItems: true)
-                .Where(e => e.UserData!.Any(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0));
+            Expression<Func<BaseItemEntity, bool>>? folderIsResumableFilter = null;
+            if (canReturnFolders)
+            {
+                var leafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!);
+                var ownedLeafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!, includeOwnedItems: true);
 
-            // Every other folder kind is a container rather than one continuous piece of media
-            var resumableFolderTypes = _resumableFolderKinds
-                .Select(kind => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(kind))
-                .ToArray();
-            var folderIsResumableFilter = IsFolderFilter.And(e => resumableFolderTypes.Contains(e.Type))
-                .And(BuildHasDescendantFilter(context, inProgressLeafItems)
-                    .Or(BuildHasDescendantFilter(context, leafItems.Where(e => e.UserData!.Any(ud => ud.UserId == userId && ud.Played)))
-                        .And(BuildHasDescendantFilter(context, leafItems.Where(e => !e.UserData!.Any(ud => ud.UserId == userId && ud.Played))))));
+                // Every other folder kind is a container rather than one continuous piece of media
+                var resumableFolderTypes = _resumableFolderKinds
+                    .Select(kind => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(kind))
+                    .ToArray();
+
+                folderIsResumableFilter = IsFolderFilter.And(e => resumableFolderTypes.Contains(e.Type))
+                    .And(BuildHasSeededDescendantFilter(context, inProgressIds, ownedLeafItems)
+                        .Or(BuildHasSeededDescendantFilter(context, playedIds, leafItems)
+                            .And(BuildHasDescendantFilter(context, leafItems.Where(e => !e.UserData!.Any(ud => ud.UserId == userId && ud.Played))))));
+            }
 
             if (isResumable)
             {
-                // Resume queries surface the version that was actually played, which may be an alternate.
-                // Match each version on its own progress rather than coalescing onto the primary.
-                var inProgressIds = inProgress.Select(ud => ud.ItemId);
+                var leafIsResumableFilter = IsFolderFilter.Not().And(e => inProgressIds.Contains(e.Id));
 
-                baseQuery = baseQuery.Where(folderIsResumableFilter
-                    .Or(IsFolderFilter.Not().And(e => inProgressIds.Contains(e.Id))));
+                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                    ? leafIsResumableFilter
+                    : folderIsResumableFilter.Or(leafIsResumableFilter));
 
                 // When several versions of the same item are in progress, keep only the most recently played one, use id as tiebreaker.
                 // Only in-progress siblings can eliminate a candidate: a version without progress has a NULL max LastPlayedDate,
@@ -550,8 +564,11 @@ public sealed partial class BaseItemRepository
                 var resumableMovieIds = inProgress
                     .Join(context.BaseItems, ud => ud.ItemId, bi => bi.Id, (ud, bi) => bi.PrimaryVersionId ?? bi.Id);
 
-                baseQuery = baseQuery.Where(IsFolderFilter.And(folderIsResumableFilter.Not())
-                    .Or(IsFolderFilter.Not().And(e => !resumableMovieIds.Contains(e.Id))));
+                var leafIsNotResumableFilter = IsFolderFilter.Not().And(e => !resumableMovieIds.Contains(e.Id));
+
+                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                    ? leafIsNotResumableFilter
+                    : IsFolderFilter.And(folderIsResumableFilter.Not()).Or(leafIsNotResumableFilter));
             }
         }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -42,6 +42,25 @@ public sealed partial class BaseItemRepository
         IQueryable<BaseItemEntity> baseQuery,
         JellyfinDbContext context,
         InternalItemsQuery filter)
+        => TranslateQuery(baseQuery, context, filter, isCorrelatedSubQuery: false);
+
+    /// <summary>
+    /// Translates a query filter onto a queryable.
+    /// </summary>
+    /// <param name="baseQuery">The query to filter.</param>
+    /// <param name="context">The database context.</param>
+    /// <param name="filter">The query filter.</param>
+    /// <param name="isCorrelatedSubQuery">
+    /// Whether the result will be embedded in a subquery that runs once per row of an outer query.
+    /// Filters that read a set of ids have to be materialised there, so that the set is built once
+    /// rather than rebuilt for every correlated row.
+    /// </param>
+    /// <returns>The filtered query.</returns>
+    private IQueryable<BaseItemEntity> TranslateQuery(
+        IQueryable<BaseItemEntity> baseQuery,
+        JellyfinDbContext context,
+        InternalItemsQuery filter,
+        bool isCorrelatedSubQuery)
     {
         const int HDWidth = 1200;
         const int UHDWidth = 3800;
@@ -1009,13 +1028,19 @@ public sealed partial class BaseItemRepository
 
         if (filter.AncestorIds.Length == 1 && AncestorShouldDriveQuery(context, filter))
         {
-            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against those.
+            // Read the descendants through IX_AncestorIds_ParentItemId.
             var ancestorId = filter.AncestorIds[0];
-            baseQuery = baseQuery.Join(
-                context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
-                e => e.Id,
-                a => a.ItemId,
-                (e, a) => e);
+            var ancestorRows = context.AncestorIds.Where(a => a.ParentItemId == ancestorId);
+
+            if (isCorrelatedSubQuery)
+            {
+                var descendantIds = ancestorRows.Select(a => a.ItemId);
+                baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
+            }
+            else
+            {
+                baseQuery = baseQuery.Join(ancestorRows, e => e.Id, a => a.ItemId, (e, a) => e);
+            }
         }
         else if (filter.AncestorIds.Length > 0)
         {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -25,6 +25,8 @@ namespace Jellyfin.Server.Implementations.Item;
 
 public sealed partial class BaseItemRepository
 {
+    private const int AncestorProbeLimit = 10000;
+
     private static readonly IReadOnlyList<char> SearchWildcardTerms = ['%', '_', '[', ']', '^'];
 
     private static readonly string ImdbProviderName = MetadataProvider.Imdb.ToString().ToLowerInvariant();
@@ -1112,8 +1114,9 @@ public sealed partial class BaseItemRepository
 
         baseQuery = ApplyTopParentFiltering(context, baseQuery, filter);
 
-        if (filter.AncestorIds.Length == 1)
+        if (filter.AncestorIds.Length == 1 && AncestorShouldDriveQuery(context, filter))
         {
+            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against those.
             var ancestorId = filter.AncestorIds[0];
             baseQuery = baseQuery.Join(
                 context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
@@ -1121,7 +1124,7 @@ public sealed partial class BaseItemRepository
                 a => a.ItemId,
                 (e, a) => e);
         }
-        else if (filter.AncestorIds.Length > 1)
+        else if (filter.AncestorIds.Length > 0)
         {
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
             baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
@@ -1318,5 +1321,39 @@ public sealed partial class BaseItemRepository
         }
 
         return baseQuery;
+    }
+
+    /// <summary>
+    /// Decides whether an ancestor filter should drive the query or be tested per row.
+    /// </summary>
+    /// <param name="context">The database context.</param>
+    /// <param name="filter">The query filter, carrying exactly one ancestor id.</param>
+    /// <returns><c>true</c> when reading the ancestor's descendants is the cheaper way round.</returns>
+    private bool AncestorShouldDriveQuery(JellyfinDbContext context, InternalItemsQuery filter)
+    {
+        // A join reads every descendant of the ancestor; an EXISTS runs once per row the rest of the
+        // query keeps. The smaller side should drive, and SQLite cannot work that out on its own
+        // because statistics are averaged across the whole table.
+        var otherSideCount = filter.ItemIds.Length > 0 ? filter.ItemIds.Length : AncestorProbeLimit;
+
+        if (filter.IncludeItemTypes.Length > 0)
+        {
+            var typeNames = filter.IncludeItemTypes
+                .Select(f => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(f))
+                .Where(e => e is not null)
+                .ToArray()!;
+
+            otherSideCount = Math.Min(
+                otherSideCount,
+                context.BaseItems.WhereOneOrMany(typeNames, e => e.Type!).Take(AncestorProbeLimit).Count());
+        }
+
+        var ancestorId = filter.AncestorIds[0];
+        var descendantCount = context.AncestorIds
+            .Where(a => a.ParentItemId == ancestorId)
+            .Take(AncestorProbeLimit)
+            .Count();
+
+        return descendantCount <= otherSideCount;
     }
 }

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -1095,12 +1095,19 @@ public sealed partial class BaseItemRepository
 
         baseQuery = ApplyTopParentFiltering(context, baseQuery, filter);
 
-        if (filter.AncestorIds.Length > 0)
+        if (filter.AncestorIds.Length == 1)
         {
-            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against that.
+            var ancestorId = filter.AncestorIds[0];
+            baseQuery = baseQuery.Join(
+                context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
+                e => e.Id,
+                a => a.ItemId,
+                (e, a) => e);
+        }
+        else if (filter.AncestorIds.Length > 1)
+        {
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
-            var descendantIds = context.AncestorIds.Where(ancestorFilter).Select(a => a.ItemId);
-            baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
+            baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
         }
 
         if (filter.DescendantOfId.HasValue)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -568,30 +568,44 @@ public sealed partial class BaseItemRepository
             var inProgress = context.UserData
                 .Where(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0);
 
+            // Resume queries surface the version that was actually played, which may be an alternate.
+            // Match each version on its own progress rather than coalescing onto the primary.
+            var inProgressIds = inProgress.Select(ud => ud.ItemId);
+            var playedIds = context.UserData
+                .Where(ud => ud.UserId == userId && ud.Played)
+                .Select(ud => ud.ItemId);
+
+            var canReturnFolders = filter.IsFolder != false
+                && (filter.MediaTypes.Length == 0 || filter.MediaTypes.Contains(MediaType.Unknown))
+                && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Any(_resumableFolderKinds.Contains));
+
             // Series and Seasons are resumable when a descendant is in progress, or when they hold both
             // played and unplayed descendants (partially watched). Alternate versions keep their own
             // progress, so they count towards the in-progress check but not towards the played/unplayed one.
-            var leafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!);
-            var inProgressLeafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!, includeOwnedItems: true)
-                .Where(e => e.UserData!.Any(ud => ud.UserId == userId && ud.PlaybackPositionTicks > 0));
+            Expression<Func<BaseItemEntity, bool>>? folderIsResumableFilter = null;
+            if (canReturnFolders)
+            {
+                var leafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!);
+                var ownedLeafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!, includeOwnedItems: true);
 
-            // Every other folder kind is a container rather than one continuous piece of media
-            var resumableFolderTypes = _resumableFolderKinds
-                .Select(kind => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(kind))
-                .ToArray();
-            var folderIsResumableFilter = IsFolderFilter.And(e => resumableFolderTypes.Contains(e.Type))
-                .And(BuildHasDescendantFilter(context, inProgressLeafItems)
-                    .Or(BuildHasDescendantFilter(context, leafItems.Where(e => e.UserData!.Any(ud => ud.UserId == userId && ud.Played)))
-                        .And(BuildHasDescendantFilter(context, leafItems.Where(e => !e.UserData!.Any(ud => ud.UserId == userId && ud.Played))))));
+                // Every other folder kind is a container rather than one continuous piece of media
+                var resumableFolderTypes = _resumableFolderKinds
+                    .Select(kind => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(kind))
+                    .ToArray();
+
+                folderIsResumableFilter = IsFolderFilter.And(e => resumableFolderTypes.Contains(e.Type))
+                    .And(BuildHasSeededDescendantFilter(context, inProgressIds, ownedLeafItems)
+                        .Or(BuildHasSeededDescendantFilter(context, playedIds, leafItems)
+                            .And(BuildHasDescendantFilter(context, leafItems.Where(e => !e.UserData!.Any(ud => ud.UserId == userId && ud.Played))))));
+            }
 
             if (isResumable)
             {
-                // Resume queries surface the version that was actually played, which may be an alternate.
-                // Match each version on its own progress rather than coalescing onto the primary.
-                var inProgressIds = inProgress.Select(ud => ud.ItemId);
+                var leafIsResumableFilter = IsFolderFilter.Not().And(e => inProgressIds.Contains(e.Id));
 
-                baseQuery = baseQuery.Where(folderIsResumableFilter
-                    .Or(IsFolderFilter.Not().And(e => inProgressIds.Contains(e.Id))));
+                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                    ? leafIsResumableFilter
+                    : folderIsResumableFilter.Or(leafIsResumableFilter));
 
                 // When several versions of the same item are in progress, keep only the most recently played one, use id as tiebreaker.
                 // Only in-progress siblings can eliminate a candidate: a version without progress has a NULL max LastPlayedDate,
@@ -617,8 +631,11 @@ public sealed partial class BaseItemRepository
                 var resumableMovieIds = inProgress
                     .Join(context.BaseItems, ud => ud.ItemId, bi => bi.Id, (ud, bi) => bi.PrimaryVersionId ?? bi.Id);
 
-                baseQuery = baseQuery.Where(IsFolderFilter.And(folderIsResumableFilter.Not())
-                    .Or(IsFolderFilter.Not().And(e => !resumableMovieIds.Contains(e.Id))));
+                var leafIsNotResumableFilter = IsFolderFilter.Not().And(e => !resumableMovieIds.Contains(e.Id));
+
+                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                    ? leafIsNotResumableFilter
+                    : IsFolderFilter.And(folderIsResumableFilter.Not()).Or(leafIsNotResumableFilter));
             }
         }
 

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -1097,8 +1097,10 @@ public sealed partial class BaseItemRepository
 
         if (filter.AncestorIds.Length > 0)
         {
+            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against that.
             var ancestorFilter = filter.AncestorIds.OneOrManyExpressionBuilder<AncestorId, Guid>(f => f.ParentItemId);
-            baseQuery = baseQuery.Where(e => e.Parents!.AsQueryable().Any(ancestorFilter));
+            var descendantIds = context.AncestorIds.Where(ancestorFilter).Select(a => a.ItemId);
+            baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
         }
 
         if (filter.DescendantOfId.HasValue)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -85,6 +85,25 @@ public sealed partial class BaseItemRepository
         IQueryable<BaseItemEntity> baseQuery,
         JellyfinDbContext context,
         InternalItemsQuery filter)
+        => TranslateQuery(baseQuery, context, filter, isCorrelatedSubQuery: false);
+
+    /// <summary>
+    /// Translates a query filter onto a queryable.
+    /// </summary>
+    /// <param name="baseQuery">The query to filter.</param>
+    /// <param name="context">The database context.</param>
+    /// <param name="filter">The query filter.</param>
+    /// <param name="isCorrelatedSubQuery">
+    /// Whether the result will be embedded in a subquery that runs once per row of an outer query.
+    /// Filters that read a set of ids have to be materialised there, so that the set is built once
+    /// rather than rebuilt for every correlated row.
+    /// </param>
+    /// <returns>The filtered query.</returns>
+    private IQueryable<BaseItemEntity> TranslateQuery(
+        IQueryable<BaseItemEntity> baseQuery,
+        JellyfinDbContext context,
+        InternalItemsQuery filter,
+        bool isCorrelatedSubQuery)
     {
         const int HDWidth = 1200;
         const int UHDWidth = 3800;
@@ -1116,13 +1135,19 @@ public sealed partial class BaseItemRepository
 
         if (filter.AncestorIds.Length == 1 && AncestorShouldDriveQuery(context, filter))
         {
-            // Read the descendants through IX_AncestorIds_ParentItemId and match ids against those.
+            // Read the descendants through IX_AncestorIds_ParentItemId.
             var ancestorId = filter.AncestorIds[0];
-            baseQuery = baseQuery.Join(
-                context.AncestorIds.Where(a => a.ParentItemId == ancestorId),
-                e => e.Id,
-                a => a.ItemId,
-                (e, a) => e);
+            var ancestorRows = context.AncestorIds.Where(a => a.ParentItemId == ancestorId);
+
+            if (isCorrelatedSubQuery)
+            {
+                var descendantIds = ancestorRows.Select(a => a.ItemId);
+                baseQuery = baseQuery.Where(e => descendantIds.Contains(e.Id));
+            }
+            else
+            {
+                baseQuery = baseQuery.Join(ancestorRows, e => e.Id, a => a.ItemId, (e, a) => e);
+            }
         }
         else if (filter.AncestorIds.Length > 0)
         {

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -596,15 +596,21 @@ public sealed partial class BaseItemRepository
                 .Where(ud => ud.UserId == userId && ud.Played)
                 .Select(ud => ud.ItemId);
 
+            // Whether the query can return folders at all.
             var canReturnFolders = filter.IsFolder != false
-                && (filter.MediaTypes.Length == 0 || filter.MediaTypes.Contains(MediaType.Unknown))
+                && (filter.MediaTypes.Length == 0 || filter.MediaTypes.Contains(MediaType.Unknown));
+
+            // Whether any folder it can return could be resumable. Folder kinds outside
+            // _resumableFolderKinds are never resumable, but they are still folders the query returns.
+            var canReturnResumableFolders = canReturnFolders
                 && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Any(_resumableFolderKinds.Contains));
 
             // Series and Seasons are resumable when a descendant is in progress, or when they hold both
             // played and unplayed descendants (partially watched). Alternate versions keep their own
             // progress, so they count towards the in-progress check but not towards the played/unplayed one.
-            Expression<Func<BaseItemEntity, bool>>? folderIsResumableFilter = null;
-            if (canReturnFolders)
+            // The IsFolder test is left off so the not-resumable side can negate this condition alone.
+            Expression<Func<BaseItemEntity, bool>>? resumableFolderCondition = null;
+            if (canReturnResumableFolders)
             {
                 var leafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!);
                 var ownedLeafItems = GetAccessFilteredLeafItemsQuery(context, filter.User!, includeOwnedItems: true);
@@ -614,7 +620,9 @@ public sealed partial class BaseItemRepository
                     .Select(kind => _itemTypeLookup.BaseItemKindNames.GetValueOrDefault(kind))
                     .ToArray();
 
-                folderIsResumableFilter = IsFolderFilter.And(e => resumableFolderTypes.Contains(e.Type))
+                Expression<Func<BaseItemEntity, bool>> isResumableFolderType = e => resumableFolderTypes.Contains(e.Type);
+
+                resumableFolderCondition = isResumableFolderType
                     .And(BuildHasSeededDescendantFilter(context, inProgressIds, ownedLeafItems)
                         .Or(BuildHasSeededDescendantFilter(context, playedIds, leafItems)
                             .And(BuildHasDescendantFilter(context, leafItems.Where(e => !e.UserData!.Any(ud => ud.UserId == userId && ud.Played))))));
@@ -624,9 +632,9 @@ public sealed partial class BaseItemRepository
             {
                 var leafIsResumableFilter = IsFolderFilter.Not().And(e => inProgressIds.Contains(e.Id));
 
-                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                baseQuery = baseQuery.Where(resumableFolderCondition is null
                     ? leafIsResumableFilter
-                    : folderIsResumableFilter.Or(leafIsResumableFilter));
+                    : IsFolderFilter.And(resumableFolderCondition).Or(leafIsResumableFilter));
 
                 // When several versions of the same item are in progress, keep only the most recently played one, use id as tiebreaker.
                 // Only in-progress siblings can eliminate a candidate: a version without progress has a NULL max LastPlayedDate,
@@ -654,9 +662,16 @@ public sealed partial class BaseItemRepository
 
                 var leafIsNotResumableFilter = IsFolderFilter.Not().And(e => !resumableMovieIds.Contains(e.Id));
 
-                baseQuery = baseQuery.Where(folderIsResumableFilter is null
+                // A folder the query can return but that is never resumable (MusicAlbum, BoxSet, ...)
+                // still belongs in a not-resumable result, so keep every folder when no resumable
+                // folder kind is in play instead of dropping the folder side of the predicate.
+                Expression<Func<BaseItemEntity, bool>>? folderIsNotResumableFilter = resumableFolderCondition is not null
+                    ? IsFolderFilter.And(resumableFolderCondition.Not())
+                    : canReturnFolders ? IsFolderFilter : null;
+
+                baseQuery = baseQuery.Where(folderIsNotResumableFilter is null
                     ? leafIsNotResumableFilter
-                    : IsFolderFilter.And(folderIsResumableFilter.Not()).Or(leafIsNotResumableFilter));
+                    : folderIsNotResumableFilter.Or(leafIsNotResumableFilter));
             }
         }
 
@@ -1359,6 +1374,14 @@ public sealed partial class BaseItemRepository
         // A join reads every descendant of the ancestor; an EXISTS runs once per row the rest of the
         // query keeps. The smaller side should drive, and SQLite cannot work that out on its own
         // because statistics are averaged across the whole table.
+
+        // A direct-parent filter narrows to the ancestor's children, which are a subset of its
+        // descendants, so testing those rows can never cost more than reading the whole subtree.
+        if (!filter.ParentId.IsEmpty())
+        {
+            return false;
+        }
+
         var otherSideCount = filter.ItemIds.Length > 0 ? filter.ItemIds.Length : AncestorProbeLimit;
 
         if (filter.IncludeItemTypes.Length > 0)
@@ -1379,6 +1402,11 @@ public sealed partial class BaseItemRepository
             .Take(AncestorProbeLimit)
             .Count();
 
+        // Both probes stop at AncestorProbeLimit, so two saturated counts compare equal and pick the
+        // join. That is deliberate: at that size the join walks IX_AncestorIds_ParentItemId once,
+        // while an EXISTS pays a correlated index probe for every row of an equally large type set.
+        // Measured on a 330k-item library, Episode under a 42k-descendant folder is 63ms joined
+        // against 150ms per-row, and Audio under a 26k-descendant folder is 38ms against 90ms.
         return descendantCount <= otherSideCount;
     }
 }

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2970,7 +2970,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IReadOnlyList<BaseItem> GetThemeSongs(User user, IEnumerable<(ItemSortBy SortBy, SortOrder SortOrder)> orderBy)
         {
-            return LibraryManager.Sort(GetExtras(user).Where(e => e.ExtraType == Model.Entities.ExtraType.ThemeSong), user, orderBy).ToArray();
+            return LibraryManager.Sort(GetExtras([Model.Entities.ExtraType.ThemeSong], user), user, orderBy).ToArray();
         }
 
         public IReadOnlyList<BaseItem> GetThemeVideos(User user = null)
@@ -2980,7 +2980,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IReadOnlyList<BaseItem> GetThemeVideos(User user, IEnumerable<(ItemSortBy SortBy, SortOrder SortOrder)> orderBy)
         {
-            return LibraryManager.Sort(GetExtras(user).Where(e => e.ExtraType == Model.Entities.ExtraType.ThemeVideo), user, orderBy).ToArray();
+            return LibraryManager.Sort(GetExtras([Model.Entities.ExtraType.ThemeVideo], user), user, orderBy).ToArray();
         }
 
         /// <summary>

--- a/MediaBrowser.Controller/Entities/BaseItem.cs
+++ b/MediaBrowser.Controller/Entities/BaseItem.cs
@@ -2929,7 +2929,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IReadOnlyList<BaseItem> GetThemeSongs(User user, IEnumerable<(ItemSortBy SortBy, SortOrder SortOrder)> orderBy)
         {
-            return LibraryManager.Sort(GetExtras(user).Where(e => e.ExtraType == Model.Entities.ExtraType.ThemeSong), user, orderBy).ToArray();
+            return LibraryManager.Sort(GetExtras([Model.Entities.ExtraType.ThemeSong], user), user, orderBy).ToArray();
         }
 
         public IReadOnlyList<BaseItem> GetThemeVideos(User user = null)
@@ -2939,7 +2939,7 @@ namespace MediaBrowser.Controller.Entities
 
         public IReadOnlyList<BaseItem> GetThemeVideos(User user, IEnumerable<(ItemSortBy SortBy, SortOrder SortOrder)> orderBy)
         {
-            return LibraryManager.Sort(GetExtras(user).Where(e => e.ExtraType == Model.Entities.ExtraType.ThemeVideo), user, orderBy).ToArray();
+            return LibraryManager.Sort(GetExtras([Model.Entities.ExtraType.ThemeVideo], user), user, orderBy).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
While validating the changes from other PRs with efcore debugging enabled, some bad queries showed themself.

**Changes**
- `ApplyGroupingFilter`'s no-grouping fallback called `Distinct()` on the entity query, which EF emits as `SELECT DISTINCT` over every `BaseItems` column as a subquery - when using split queries this is repeated in each statement. This is unnecessary because every filter we apply only uses `WHERE` or `EXISTS` and no joins, meaning the result is already unique rows.

- `GetItemIdsList` built the full entity query, applied `Include`s, and then projected ids. It now projects ids through the pipeline and skips `ApplyNavigations` (an `Include` is dropped by a scalar projection anyway).

```sql
-- before
SELECT b0.Id FROM (SELECT DISTINCT b.Id, b.Album, … b.Width FROM BaseItems AS b WHERE …) AS b0 ORDER BY b0.SortName, b0.Id
-- after
SELECT b.Id FROM BaseItems AS b WHERE … ORDER BY b.SortName, b.Id
```

- The `AncestorIds` filter was a correlated `EXISTS` over the `Parents` navigation, which plans as `SCAN b` across every row of `BaseItems` however few descendants the ancestor has. It now reads the descendants through `IX_AncestorIds_ParentItemId`.

**Statistics**
Warm timings for the ancestor filter, interleaved runs of the exact statements the repository now emits, identical row counts in each case:

| query | before | after |
|---|---|---|
| series, 1 episode | 151–156 ms | 1 ms |
| series, 1254 episodes | 148–154 ms | 3 ms |
| library, 38 209 episodes | 154–158 ms | 84 ms |

**Code assistance**
Claude Opus 5 was used to analyse the server's EF command log, locate the redundant work and benchmark before and after against a copy of my production database. I reviewed the resulting changes, the emitted SQL and the query plans.

**Issues**