### PR TITLE
Fix large playlist persistence with WhereOneOrMany

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -238,6 +238,7 @@
  - [elio42](https://github.com/elio42)
  - [rwebster85](https://github.com/rwebster85)
  - [Florin-Popescu](https://github.com/Florin-Popescu)
+ - [martin-77](https://github.com/martin-77)
 
 # Emby Contributors
 

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -538,7 +538,7 @@ public class ItemPersistenceService : IItemPersistenceService
                 var childIdsToCheck = resolvedChildren.Select(c => c.ChildId).Distinct().ToList();
                 var existingChildIds = childIdsToCheck.Count > 0
                     ? context.BaseItems
-                        .Where(e => childIdsToCheck.Contains(e.Id))
+                        .WhereOneOrMany(childIdsToCheck, e => e.Id)
                         .Select(e => e.Id)
                         .ToHashSet()
                     : [];


### PR DESCRIPTION
**Changes**

On Jellyfin 12, refreshing a very large playlist can fail with `SQLite Error 1: 'too many SQL variables'`. I ran into this with a large playlist generated by the [SmartLists plugin](https://github.com/jyourstone/jellyfin-smartlists-plugin).

The affected playlist persistence code was introduced as part of #16062 when LinkedChildren were moved into their own database table. The child lookup still uses `Contains()` with the full list of item IDs, which EF Core expands into individual SQL variables.

A similar issue in another `ItemPersistenceService` path was fixed in #17153 by switching to `WhereOneOrMany()`. The playlist lookup still used the old pattern, so I changed it to `WhereOneOrMany()` as well.

**Code assistance**

AI was used to help trace the failing query, compare it with related Jellyfin changes, and review the final change and test steps. I reviewed the change myself and tested it locally.

**Issues**

Related to #16062 and #17153.

Thanks for taking a look.

Martin