### PR TITLE
Fix GitHub URL typo in CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -249,7 +249,7 @@
  - [Mark2xv](https://github.com/Mark2xv)
  - [ScottRapsey](https://github.com/ScottRapsey)
  - [skynet600](https://github.com/skynet600)
- - [Cheesegeezer](https://githum.com/Cheesegeezer)
+ - [Cheesegeezer](https://github.com/Cheesegeezer)
  - [Radeon](https://github.com/radeonorama)
  - [gcw07](https://github.com/gcw07)
  - [SivaramAdhiappan](https://github.com/shivaram1190)


### PR DESCRIPTION
**Changes**
`CONTRIBUTORS.md` linked Cheesegeezer to `https://githum.com/Cheesegeezer` (wrong TLD). That host is an unrelated parking page, not GitHub.

The intended profile `https://github.com/Cheesegeezer` returns 200. This change updates only that one URL.

**Code assistance**
Used local search and HTTP checks to confirm the mistyped host and the replacement URL.

**Issues**
N/A
