### PR TITLE
Fix startup crash with IPv6-only binding when addresses are still in DAD

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -239,6 +239,7 @@
  - [rwebster85](https://github.com/rwebster85)
  - [Florin-Popescu](https://github.com/Florin-Popescu)
  - [martin-77](https://github.com/martin-77)
+ - [Joduus](https://github.com/Joduus)
 
 # Emby Contributors
 

--- a/Jellyfin.Server/Extensions/WebHostBuilderExtensions.cs
+++ b/Jellyfin.Server/Extensions/WebHostBuilderExtensions.cs
@@ -2,14 +2,18 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using Jellyfin.Server.Helpers;
 using MediaBrowser.Common.Configuration;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Model.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -37,6 +41,8 @@ public static class WebHostBuilderExtensions
         ILogger logger)
     {
         return builder
+            .ConfigureServices((_, services) =>
+                services.ConfigureIPv6OnlyWildcardSocket(appHost.ConfigurationManager.GetNetworkConfiguration()))
             .UseKestrel((builderContext, options) =>
             {
                 SetupJellyfinWebServer(
@@ -51,6 +57,38 @@ public static class WebHostBuilderExtensions
                     options);
             })
             .UseStartup(context => new Startup(appHost, context.Configuration));
+    }
+
+    /// <summary>
+    /// Configures Kestrel's socket transport to keep an <see cref="IPAddress.IPv6Any"/> bind IPv6-only when
+    /// IPv4 is disabled. Kestrel upgrades an IPv6Any bind to dual-mode by default, which would otherwise
+    /// also listen on all IPv4 addresses.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="networkConfiguration">The network configuration.</param>
+    public static void ConfigureIPv6OnlyWildcardSocket(this IServiceCollection services, NetworkConfiguration networkConfiguration)
+    {
+        if (networkConfiguration.EnableIPv4 || !networkConfiguration.EnableIPv6)
+        {
+            return;
+        }
+
+        services.Configure<SocketTransportOptions>(options => options.CreateBoundListenSocket = CreateIPv6OnlyBoundListenSocket);
+    }
+
+    private static Socket CreateIPv6OnlyBoundListenSocket(EndPoint endpoint)
+    {
+        if (endpoint is not IPEndPoint ipEndPoint || !ipEndPoint.Address.Equals(IPAddress.IPv6Any))
+        {
+            return SocketTransportOptions.CreateDefaultBoundListenSocket(endpoint);
+        }
+
+        var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp)
+        {
+            DualMode = false
+        };
+        socket.Bind(ipEndPoint);
+        return socket;
     }
 
     /// <summary>

--- a/Jellyfin.Server/ServerSetupApp/SetupServer.cs
+++ b/Jellyfin.Server/ServerSetupApp/SetupServer.cs
@@ -106,6 +106,7 @@ public sealed class SetupServer : IDisposable
                 serv.AddSingleton(this);
                 serv.AddHealthChecks()
                     .AddCheck<SetupHealthcheck>("StartupCheck");
+                serv.ConfigureIPv6OnlyWildcardSocket(config);
                 serv.Configure<ForwardedHeadersOptions>(options =>
                 {
                     ApiServiceCollectionExtensions.ConfigureForwardHeaders(config, options);

--- a/src/Jellyfin.Networking/Manager/NetworkManager.cs
+++ b/src/Jellyfin.Networking/Manager/NetworkManager.cs
@@ -828,25 +828,17 @@ public class NetworkManager : INetworkManager, IDisposable
 
         // No bind address and no exclusions, so listen on all interfaces.
         var result = new List<IPData>();
-        if (readIpv4 && readIpv6)
+        if (readIpv6)
         {
-            // Kestrel source code shows it uses Sockets.DualMode - so this also covers IPAddress.Any by default
+            // Kestrel upgrades an IPv6Any bind to dual-mode by default; when IPv4 is disabled the server
+            // keeps the wildcard socket IPv6-only via SocketTransportOptions.CreateBoundListenSocket.
+            // Binding the wildcard instead of individual addresses also avoids bind failures for addresses
+            // that are enumerated but not (yet) usable, e.g. during IPv6 duplicate address detection.
             result.Add(new IPData(IPAddress.IPv6Any, NetworkConstants.IPv6Any));
         }
         else if (readIpv4)
         {
             result.Add(new IPData(IPAddress.Any, NetworkConstants.IPv4Any));
-        }
-        else if (readIpv6)
-        {
-            // Cannot use IPv6Any as Kestrel will bind to IPv4 addresses too.
-            foreach (var iface in knownInterfaces)
-            {
-                if (iface.AddressFamily == AddressFamily.InterNetworkV6)
-                {
-                    result.Add(iface);
-                }
-            }
         }
 
         return result;

--- a/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
+++ b/tests/Jellyfin.Networking.Tests/NetworkManagerTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Net;
 using Jellyfin.Networking.Manager;
 using MediaBrowser.Common.Net;
+using MediaBrowser.Model.Net;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -63,6 +65,70 @@ namespace Jellyfin.Networking.Tests
             using var networkManager = new NetworkManager(NetworkParseTests.GetMockConfig(conf), startupConf.Object, new NullLogger<NetworkManager>());
 
             Assert.False(networkManager.IsInLocalNetwork(ip));
+        }
+
+        /// <summary>
+        /// Without explicit bind addresses the wildcard address must be returned. With IPv6 enabled this is
+        /// always the IPv6 wildcard - keeping the socket IPv6-only when IPv4 is disabled is handled by the
+        /// Kestrel socket transport setup. Binding the wildcard instead of individual interface addresses
+        /// avoids bind failures for addresses that are not (yet) usable, e.g. during IPv6 duplicate address
+        /// detection.
+        /// </summary>
+        /// <param name="enableIPv4">If IPv4 is enabled.</param>
+        /// <param name="enableIPv6">If IPv6 is enabled.</param>
+        /// <param name="expected">The expected wildcard bind address.</param>
+        [Theory]
+        [InlineData(true, true, "::")]
+        [InlineData(false, true, "::")]
+        [InlineData(true, false, "0.0.0.0")]
+        public void GetAllBindInterfaces_NoExplicitBinds_ReturnsWildcard(bool enableIPv4, bool enableIPv6, string expected)
+        {
+            var conf = new NetworkConfiguration()
+            {
+                EnableIPv4 = enableIPv4,
+                EnableIPv6 = enableIPv6
+            };
+
+            var result = NetworkManager.GetAllBindInterfaces(
+                NullLogger<NetworkManager>.Instance,
+                false,
+                NetworkParseTests.GetMockConfig(conf),
+                Array.Empty<IPData>(),
+                enableIPv4,
+                enableIPv6);
+
+            Assert.Single(result);
+            Assert.Equal(IPAddress.Parse(expected), result[0].Address);
+        }
+
+        /// <summary>
+        /// Explicitly configured bind addresses must still be returned as concrete addresses,
+        /// even when only IPv6 is enabled.
+        /// </summary>
+        [Fact]
+        public void GetAllBindInterfaces_ExplicitBindAddress_ReturnsConcreteAddress()
+        {
+            var conf = new NetworkConfiguration()
+            {
+                EnableIPv4 = false,
+                EnableIPv6 = true,
+                LocalNetworkAddresses = new[] { "fd00::1" }
+            };
+            var knownInterfaces = new[]
+            {
+                new IPData(IPAddress.Parse("fd00::1"), new IPNetwork(IPAddress.Parse("fd00::1"), 64), "eth0")
+            };
+
+            var result = NetworkManager.GetAllBindInterfaces(
+                NullLogger<NetworkManager>.Instance,
+                false,
+                NetworkParseTests.GetMockConfig(conf),
+                knownInterfaces,
+                false,
+                true);
+
+            Assert.Single(result);
+            Assert.Equal(IPAddress.Parse("fd00::1"), result[0].Address);
         }
     }
 }


### PR DESCRIPTION
**Changes**

When IPv4 is disabled and IPv6 is enabled, and no explicit bind addresses are configured, bind to the IPv6 wildcard address (`::`) instead of binding every IPv6 address reported for the available interfaces.

Because Kestrel creates dual-mode sockets for `IPv6Any` by default, the IPv6-only case uses `SocketTransportOptions.CreateBoundListenSocket` to create the wildcard socket with `DualMode = false`.

Explicitly configured bind addresses are not affected.

**Root cause**

With `EnableIPv4=false` and `EnableIPv6=true`, `NetworkManager.GetAllBindInterfaces` previously returned all enumerated IPv6 addresses. Kestrel then attempted to bind each address separately, including link-local addresses.

After an interface is created or re-created, IPv6 addresses can remain in the tentative state while Duplicate Address Detection (DAD) is running. Attempting to bind one of those addresses fails with:

```text
SocketException (99): Cannot assign requested address
```

A failure on one endpoint prevents Kestrel from starting.

This explains why the issue is sensitive to restart timing. On a fast container or VM restart, Jellyfin may attempt to bind while one of the addresses is still tentative. Starting it later succeeds because DAD has completed by then.

I reproduced this in an IPv6-enabled Docker container by binding the newly created link-local address while `/proc/net/if_inet6` still reported it with `IFA_F_TENTATIVE` (`0x40`). The bind failed with `EADDRNOTAVAIL` until DAD completed.

I also reproduced the same behavior on my Proxmox LXC with Jellyfin configured for IPv6 only. Container restarts could fail during startup, while restarting Jellyfin later succeeded.

My initial suspicion in https://github.com/jellyfin/jellyfin/issues/15130#issuecomment-5308526973 was that this might be related to socket reuse or `TIME_WAIT`, but the reproduction above showed that the failure is caused by attempting to bind tentative IPv6 addresses instead.

**Fix**

* Return `IPAddress.IPv6Any` when IPv6 is enabled and no explicit bind addresses are configured.
* For the IPv6-only case, create the `IPv6Any` listen socket with `DualMode = false` (`IPV6_V6ONLY`).
* Leave Kestrel's normal socket creation unchanged for all other endpoints.
* Apply the same behavior to the main host and the setup server.
* Keep explicitly configured `LocalNetworkAddresses` unchanged.

Using the wildcard address also means Jellyfin can accept connections on IPv6 addresses added after startup instead of only on addresses that existed when the server started.

**Testing**

* Added tests for `GetAllBindInterfaces` covering:

  * IPv4 + IPv6 → `::`
  * IPv6 only → `::`
  * IPv4 only → `0.0.0.0`
  * explicitly configured bind addresses
* All 151 `Jellyfin.Networking.Tests` pass.
* Verified in a fresh IPv6-enabled Docker container that the IPv6-only wildcard bind succeeds while the interface address is still tentative.
* Verified that IPv4-mapped connections are refused, confirming that the socket is IPv6-only.
* Verified end-to-end on my Proxmox LXC with `EnableIPv4=false` and `EnableIPv6=true`; container restarts that previously failed with `EADDRNOTAVAIL` now start successfully.

**Code assistance**

I used LLM assistance while investigating the issue and for parts of the implementation and tests. I reviewed and verified the resulting changes, including reproducing the issue and testing the fix on the affected Proxmox LXC setup.

**Issues**
Fixes #15130 
