### PR TITLE
Fix: Optimize FFmpeg HLS stream startup time

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1640,7 +1640,7 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
+            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 500000 -hls_init_time 1 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
             inputModifier,
             _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer),
             threads,

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -7270,6 +7270,11 @@ namespace MediaBrowser.Controller.MediaEncoding
             {
                 analyzeDurationArgument = "-analyzeduration " + ffmpegAnalyzeDuration;
             }
+            else
+            {
+                // Provide a fast default (1.5s) instead of letting ffmpeg use its 5s default
+                analyzeDurationArgument = "-analyzeduration 1500000";
+            }
 
             return analyzeDurationArgument;
         }


### PR DESCRIPTION
This PR optimizes the FFmpeg startup time (TTFF) for HLS streams by:

1. Reducing `-max_delay` allowance from 5 seconds to 0.5 seconds.
2. Injecting `-hls_init_time 1` to generate a shorter first segment for faster client playback start.
3. Specifying a fallback `-analyzeduration` (1.5s) to bypass FFmpeg default 5-second stream probing.

This significantly improves the time to first frame for live transcodes.