### PR TITLE
Honor DOVIWithHDR10Plus rangetype declarations during stream copy

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1431,6 +1431,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             var requestHasDOVI = requestedRangeTypes.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase);
             var requestHasDOVIwithEL = requestedRangeTypes.Contains(VideoRangeType.DOVIWithEL.ToString(), StringComparison.OrdinalIgnoreCase);
             var requestHasDOVIwithELHDR10plus = requestedRangeTypes.Contains(VideoRangeType.DOVIWithELHDR10Plus.ToString(), StringComparison.OrdinalIgnoreCase);
+            var requestHasDOVIwithHDR10plus = requestedRangeTypes.Contains(VideoRangeType.DOVIWithHDR10Plus.ToString(), StringComparison.OrdinalIgnoreCase);
 
             var shouldRemoveHdr10Plus = false;
             // Case 1: Client supports HDR10, does not support DOVI with EL but EL presets
@@ -1454,8 +1455,9 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return DynamicHdrMetadataRemovalPlan.RemoveDovi;
             }
 
-            // If the client is a Dolby Vision Player, remove the HDR10+ metadata to avoid playback issues
-            shouldRemoveHdr10Plus = shouldRemoveHdr10Plus || (requestHasDOVI && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10Plus);
+            // If the client is a Dolby Vision Player, remove the HDR10+ metadata to avoid playback issues,
+            // unless the client explicitly declares support for their coexistence (DOVIWithHDR10Plus)
+            shouldRemoveHdr10Plus = shouldRemoveHdr10Plus || (requestHasDOVI && !requestHasDOVIwithHDR10plus && videoStream.VideoRangeType == VideoRangeType.DOVIWithHDR10Plus);
             return shouldRemoveHdr10Plus ? DynamicHdrMetadataRemovalPlan.RemoveHdr10Plus : DynamicHdrMetadataRemovalPlan.None;
         }
 

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperHdrMetadataTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperHdrMetadataTests.cs
@@ -1,0 +1,134 @@
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+using IConfigurationManager = MediaBrowser.Common.Configuration.IConfigurationManager;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding;
+
+public class EncodingHelperHdrMetadataTests
+{
+    private static EncodingHelper CreateEncodingHelper()
+    {
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder
+            .Setup(e => e.SupportsBitStreamFilterWithOption(It.IsAny<BitStreamFilterOptionType>()))
+            .Returns(true);
+
+        return new EncodingHelper(
+            Mock.Of<IApplicationPaths>(),
+            mediaEncoder.Object,
+            Mock.Of<ISubtitleEncoder>(),
+            Mock.Of<IConfiguration>(),
+            Mock.Of<IConfigurationManager>(),
+            Mock.Of<IPathManager>());
+    }
+
+    /// <summary>
+    /// HEVC Main 10, Dolby Vision Profile 8.1 (bl compat id 1) with HDR10+ metadata,
+    /// which resolves to VideoRangeType.DOVIWithHDR10Plus.
+    /// </summary>
+    private static MediaStream CreateDoviWithHdr10PlusStream() => new()
+    {
+        Type = MediaStreamType.Video,
+        Codec = "hevc",
+        Profile = "Main 10",
+        Width = 3840,
+        Height = 1606,
+        BitDepth = 10,
+        ColorPrimaries = "bt2020",
+        ColorSpace = "bt2020nc",
+        ColorTransfer = "smpte2084",
+        DvProfile = 8,
+        DvBlSignalCompatibilityId = 1,
+        RpuPresentFlag = 1,
+        BlPresentFlag = 1,
+        Hdr10PlusPresentFlag = true
+    };
+
+    private static EncodingJobInfo CreateHlsStreamCopyState(MediaStream videoStream, string? hevcRangeTypes)
+    {
+        var state = new EncodingJobInfo(TranscodingJobType.Hls)
+        {
+            VideoStream = videoStream,
+            SupportedVideoCodecs = new[] { "hevc" },
+            BaseRequest = new BaseEncodingJobOptions
+            {
+                AllowVideoStreamCopy = true,
+                Context = EncodingContext.Streaming
+            }
+        };
+
+        if (hevcRangeTypes is not null)
+        {
+            state.BaseRequest.StreamOptions["hevc-rangetype"] = hevcRangeTypes;
+        }
+
+        return state;
+    }
+
+    [Theory]
+    // Dolby Vision client that does not declare the coexistence range type: keep stripping HDR10+.
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10", "-bsf:v hevc_mp4toannexb,hevc_metadata=remove_hdr10plus=1")]
+    // Dolby Vision client that explicitly declares DOVIWithHDR10Plus: copy the bitstream untouched.
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10,DOVIWithHDR10Plus,HDR10Plus", "-bsf:v hevc_mp4toannexb")]
+    // HDR10-only client: the HDR10 base layer is compatible, copy untouched.
+    [InlineData("SDR,HDR10,HLG", "-bsf:v hevc_mp4toannexb")]
+    // Client without range type conditions: copy untouched.
+    [InlineData(null, "-bsf:v hevc_mp4toannexb")]
+    public void GetBitStreamArgs_DoviWithHdr10PlusSource_RemovesHdr10PlusOnlyWhenCoexistenceNotDeclared(string? hevcRangeTypes, string expectedArgs)
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateHlsStreamCopyState(CreateDoviWithHdr10PlusStream(), hevcRangeTypes);
+
+        Assert.Equal(expectedArgs, helper.GetBitStreamArgs(state, MediaStreamType.Video));
+    }
+
+    [Theory]
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10", true)]
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10,DOVIWithHDR10Plus,HDR10Plus", true)]
+    [InlineData("SDR,HDR10,HLG", true)]
+    [InlineData(null, true)]
+    // SDR-only clients must never receive an HDR bitstream via stream copy.
+    [InlineData("SDR", false)]
+    public void CanStreamCopyVideo_DoviWithHdr10PlusSource_MatchesRangeSupport(string? hevcRangeTypes, bool expectedCanCopy)
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateHlsStreamCopyState(CreateDoviWithHdr10PlusStream(), hevcRangeTypes);
+
+        Assert.Equal(expectedCanCopy, helper.CanStreamCopyVideo(state, state.VideoStream));
+    }
+
+    [Theory]
+    // Without the coexistence declaration the server plans an HDR10+ removal, and the
+    // HLS playlist must not advertise HDR10+ via SUPPLEMENTAL-CODECS.
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10", true)]
+    // With the declaration the metadata survives, so the playlist may advertise it.
+    [InlineData("SDR,HDR10,HLG,DOVI,DOVIWithHDR10,DOVIWithHDR10Plus,HDR10Plus", false)]
+    [InlineData("SDR,HDR10,HLG", false)]
+    [InlineData(null, false)]
+    public void IsHdr10PlusRemoved_DoviWithHdr10PlusSource_TracksCoexistenceDeclaration(string? hevcRangeTypes, bool expectedRemoved)
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateHlsStreamCopyState(CreateDoviWithHdr10PlusStream(), hevcRangeTypes);
+
+        Assert.Equal(expectedRemoved, helper.IsHdr10PlusRemoved(state));
+    }
+
+    [Fact]
+    public void IsDoviRemoved_DoviWithHdr10PlusSource_CoexistenceDeclared_KeepsDoviMetadata()
+    {
+        var helper = CreateEncodingHelper();
+        var state = CreateHlsStreamCopyState(
+            CreateDoviWithHdr10PlusStream(),
+            "SDR,HDR10,HLG,DOVI,DOVIWithHDR10,DOVIWithHDR10Plus,HDR10Plus");
+
+        // The dvh1 tagging and the DV SUPPLEMENTAL-CODECS entry both require the
+        // Dolby Vision metadata to survive the copy.
+        Assert.False(helper.IsDoviRemoved(state));
+    }
+}


### PR DESCRIPTION
**Changes**

`ShouldRemoveDynamicHdrMetadata` plans an HDR10+ removal (`hevc_metadata=remove_hdr10plus=1`, or `av1_metadata=remove_hdr10plus=1` for AV1) for every `DOVIWithHDR10Plus` stream copy as soon as the client declares `DOVI` in its rangetype. The client's own `DOVIWithHDR10Plus` declaration is never consulted, so declaring the coexistence range type currently has no effect on the copy path — the enum value is effectively dead code there.

This PR honors an explicit `DOVIWithHDR10Plus` declaration the same way the `DOVIWithELHDR10Plus` coexistence case already honors its own: the removal is now only planned for DOVI clients that did **not** declare the coexistence range type. Clients that don't declare it keep the current protective behavior, and the `mp4toannexb` part of the bsf chain is intentionally left untouched per the conclusion in #16361.

Why this matters:

- First-party clients already declare the range type and get their dynamic metadata stripped anyway. Swiftfin's native (AVPlayer) profile declares both `dovi` and `doviWithHDR10Plus` on Dolby Vision capable Apple TVs (`Shared/Objects/VideoPlayerType/VideoPlayerType+Native.swift`), and jellyfin-roku declares `DOVIWithHDR10Plus` when the display reports HDR10+ support (`source/utils/deviceCapabilities.bs`, gated on `dp.Hdr10Plus`).
- The removal rewrites the bitstream while copying it and destroys HDR10+ dynamic metadata that the client explicitly declared it can handle. A client has no way to opt out: dropping `DOVI` from its declaration kills the `dvh1` tagging (which the HLS controller requires) and stream copy of pure DV titles altogether, so the only practical escape today is to stop requesting the copy and eat a full tonemap transcode to SDR — which loses the same metadata and burns an encode for nothing.
- Regarding webOS: jellyfin-web declares `DOVIWithHDR10Plus` for DV Profile 8 capable TVs, so those now receive the coexisting metadata on the copy path. If a device declares the range type but cannot actually handle coexistence, Direct Play already delivers the exact same bits today (the removal never protected that path), so the over-broad declaration itself would be the bug — I'm happy to follow up in jellyfin-web with a webOS gate if that's a concern.

Added unit tests covering `GetBitStreamArgs`, `CanStreamCopyVideo`, `IsHdr10PlusRemoved` and `IsDoviRemoved` for a DV 8.1 + HDR10+ stream across client rangetype declarations; this logic had no existing coverage.

End-to-end verification (jellyfin-ffmpeg 7.1.4, against a synthetic HEVC Main 10 DV P8.1 + HDR10+ MKV that probes as `DOVIWithHDR10Plus`, using the real device profile of a tvOS AVPlayer client):

- Declaring `DOVIWithHDR10Plus`: ffmpeg runs `-codec:v:0 copy -tag:v:0 dvh1 -strict -2 -bsf:v hevc_mp4toannexb` (no metadata rewrite); the produced fMP4 segments keep the `dvh1` sample entry, the DOVI configuration record (profile 8, compat id 1), the DV RPUs **and** the HDR10+ SEI (verified with ffprobe), and the copied variant plays via AVFoundation. The master advertises `SUPPLEMENTAL-CODECS="dvh1.08.03/db1p"` with an SDR fallback variant.
- Not declaring it (all else equal): same copy but with `-bsf:v hevc_mp4toannexb,hevc_metadata=remove_hdr10plus=1`, and the HDR10+ SEI is gone from the output — the current behavior, preserved for clients that don't declare the coexistence range.

Verified on device (Apple TV, tvOS AVPlayer client, real DV P8.1 bl-compat-1 + HDR10+ 4K HEVC title, Jellyfin 10.11.11 with this patch cherry-picked vs an unpatched 10.11.11 control):

- Patched server: clean stream copy from the first segment, video and audio direct for the whole session, display switches to HDR, no playback errors — with the HDR10+ SEI intact end to end.
- Unpatched control, same title and client: identical copy command plus the `remove_hdr10plus` rewrite; playback also succeeds. The removal is not protecting this client from anything — for a declaring client its only observable effect is destroying the dynamic metadata it asked to keep.

**Issues**

Related: #16687 (DOVIWithHDR10Plus profile negotiation), #13277 (where the unconditional removal was introduced), #17236 / jellyfin/Swiftfin#2229 (adjacent Apple DV-remux problem with a different mechanism, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
