### PR TITLE
Allow direct play for HDHomeRun Live TV tuners

### DIFF
--- a/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
+++ b/src/Jellyfin.LiveTv/TunerHosts/HdHomerun/HdHomerunHost.cs
@@ -326,7 +326,7 @@ namespace Jellyfin.LiveTv.TunerHosts.HdHomerun
                 BufferMs = 0,
                 Container = "ts",
                 Id = id,
-                SupportsDirectPlay = false,
+                SupportsDirectPlay = true,
                 SupportsDirectStream = true,
                 SupportsTranscoding = true,
                 IsInfiniteStream = true,


### PR DESCRIPTION
**Changes**
Don't blindly say that direct play is not supported for  HDHomeRun tuners

**Code assistance**
N/A

**Issues**
Fixes: https://github.com/jellyfin/jellyfin-androidtv/issues/3423