### PR TITLE
Fix fallback font endpoint crash on missing font

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -239,6 +239,7 @@
  - [rwebster85](https://github.com/rwebster85)
  - [Florin-Popescu](https://github.com/Florin-Popescu)
  - [martin-77](https://github.com/martin-77)
+ - [AleksaMCode](https://github.com/AleksaMCode)
 
 # Emby Contributors
 

--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -557,16 +557,15 @@ public class SubtitleController : BaseJellyfinApiController
         if (!string.IsNullOrEmpty(fallbackFontPath))
         {
             var fontFile = _fileSystem.GetFiles(fallbackFontPath)
-                .First(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
-            var fileSize = fontFile?.Length;
+                .FirstOrDefault(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
 
-            if (fontFile is not null && fileSize is not null && fileSize > 0)
+            if (fontFile is not null && fontFile.Length > 0)
             {
-                _logger.LogDebug("Fallback font size is {FileSize} Bytes", fileSize);
+                _logger.LogDebug("Fallback font size is {FileSize} Bytes", fontFile.Length);
                 return PhysicalFile(fontFile.FullName, MimeTypes.GetMimeType(fontFile.FullName));
             }
 
-            _logger.LogWarning("The selected font is null or empty");
+            _logger.LogWarning("The selected fallback font {Font} was not found or is empty", name);
         }
         else
         {


### PR DESCRIPTION
**Changes**

This change fixes a crash in `GetFallbackFont` when a requested fallback font file does not exist. The endpoint now handles missing fonts gracefully instead of throwing `InvalidOperationException` and returning HTTP 500.

**Code assistance**


**Issues**

Closes #17683
