### PR TITLE
Add JELLYFIN_FFmpeg__playbackprobesize for setting transcoding probesize

### DIFF
--- a/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
+++ b/MediaBrowser.Controller/Extensions/ConfigurationExtensions.cs
@@ -30,6 +30,16 @@ namespace MediaBrowser.Controller.Extensions
         public const string FfmpegProbeSizeKey = "FFmpeg:probesize";
 
         /// <summary>
+        /// The key for the FFmpeg probe size option used during playback.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately absent from <c>ConfigurationOptions.DefaultConfiguration</c>. The accessor falls
+        /// back to <see cref="FfmpegProbeSizeKey"/> when this is unset, and a default value here would
+        /// mask that fallback and silently change behaviour for anyone who has set the existing key.
+        /// </remarks>
+        public const string FfmpegPlaybackProbeSizeKey = "FFmpeg:playbackprobesize";
+
+        /// <summary>
         /// The key for the skipping FFmpeg validation.
         /// </summary>
         public const string FfmpegSkipValidationKey = "FFmpeg:novalidation";
@@ -90,6 +100,18 @@ namespace MediaBrowser.Controller.Extensions
         /// <returns>The FFmpeg probe size option.</returns>
         public static string? GetFFmpegProbeSize(this IConfiguration configuration)
             => configuration[FfmpegProbeSizeKey];
+
+        /// <summary>
+        /// Gets the FFmpeg probe size to use during playback from the <see cref="IConfiguration" />.
+        /// </summary>
+        /// <param name="configuration">The configuration to read the setting from.</param>
+        /// <returns>The playback FFmpeg probe size option, falling back to <see cref="GetFFmpegProbeSize"/> when unset or empty.</returns>
+        public static string? GetFFmpegPlaybackProbeSize(this IConfiguration configuration)
+        {
+            var playbackProbeSize = configuration[FfmpegPlaybackProbeSizeKey];
+
+            return string.IsNullOrEmpty(playbackProbeSize) ? configuration.GetFFmpegProbeSize() : playbackProbeSize;
+        }
 
         /// <summary>
         /// Gets the FFmpeg analyze duration from the <see cref="IConfiguration" />.

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1299,7 +1299,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                     arg.Append(' ').Append(analyzeDurationArgument);
                 }
 
-                // Apply probesize, too, if configured
                 var ffmpegProbeSizeArgument = GetFfmpegProbesizeArg();
                 if (!string.IsNullOrEmpty(ffmpegProbeSizeArgument))
                 {
@@ -7276,7 +7275,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         private string GetFfmpegProbesizeArg()
         {
-            var ffmpegProbeSize = _config.GetFFmpegProbeSize();
+            var ffmpegProbeSize = _config.GetFFmpegPlaybackProbeSize();
 
             if (!string.IsNullOrEmpty(ffmpegProbeSize))
             {

--- a/tests/Jellyfin.Controller.Tests/Extensions/ConfigurationExtensionsTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Extensions/ConfigurationExtensionsTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using MediaBrowser.Controller.Extensions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+using JellyfinConfig = MediaBrowser.Controller.Extensions.ConfigurationExtensions;
+
+namespace Jellyfin.Controller.Tests.Extensions;
+
+public class ConfigurationExtensionsTests
+{
+    [Fact]
+    public void GetFFmpegPlaybackProbeSize_NeitherKeySet_ReturnsNull()
+    {
+        Assert.Null(BuildConfig().GetFFmpegPlaybackProbeSize());
+    }
+
+    [Fact]
+    public void GetFFmpegPlaybackProbeSize_OnlySharedKeySet_FallsBackToSharedValue()
+    {
+        var config = BuildConfig((JellyfinConfig.FfmpegProbeSizeKey, "1G"));
+
+        Assert.Equal("1G", config.GetFFmpegPlaybackProbeSize());
+    }
+
+    [Fact]
+    public void GetFFmpegPlaybackProbeSize_OnlyPlaybackKeySet_ReturnsPlaybackValue()
+    {
+        var config = BuildConfig((JellyfinConfig.FfmpegPlaybackProbeSizeKey, "50M"));
+
+        Assert.Equal("50M", config.GetFFmpegPlaybackProbeSize());
+    }
+
+    [Fact]
+    public void GetFFmpegPlaybackProbeSize_PlaybackKeyEmpty_FallsBackToSharedValue()
+    {
+        // An empty value is how a user clears an environment variable, so treat it as unset
+        // rather than letting it suppress the probe size entirely.
+        var config = BuildConfig(
+            (JellyfinConfig.FfmpegProbeSizeKey, "1G"),
+            (JellyfinConfig.FfmpegPlaybackProbeSizeKey, string.Empty));
+
+        Assert.Equal("1G", config.GetFFmpegPlaybackProbeSize());
+    }
+
+    [Fact]
+    public void GetFFmpegPlaybackProbeSize_BothKeysSet_PlaybackKeyWins()
+    {
+        var config = BuildConfig(
+            (JellyfinConfig.FfmpegProbeSizeKey, "1G"),
+            (JellyfinConfig.FfmpegPlaybackProbeSizeKey, "50M"));
+
+        Assert.Equal("50M", config.GetFFmpegPlaybackProbeSize());
+    }
+
+    [Fact]
+    public void GetFFmpegProbeSize_PlaybackKeySet_IsUnaffected()
+    {
+        var config = BuildConfig(
+            (JellyfinConfig.FfmpegProbeSizeKey, "1G"),
+            (JellyfinConfig.FfmpegPlaybackProbeSizeKey, "50M"));
+
+        Assert.Equal("1G", config.GetFFmpegProbeSize());
+    }
+
+    private static IConfiguration BuildConfig(params (string Key, string? Value)[] values)
+    {
+        var items = new List<KeyValuePair<string, string?>>();
+        foreach (var (key, value) in values)
+        {
+            items.Add(new KeyValuePair<string, string?>(key, value));
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(items).Build();
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -12,10 +12,13 @@ using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 
 using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
+using IConfigurationManager = MediaBrowser.Common.Configuration.IConfigurationManager;
+using JellyfinConfig = MediaBrowser.Controller.Extensions.ConfigurationExtensions;
 
 namespace Jellyfin.Controller.Tests.MediaEncoding;
 
@@ -322,12 +325,11 @@ public class EncodingHelperTests
         };
     }
 
-    private static EncodingHelper CreateHelper()
+    private static EncodingHelper CreateHelper(IConfiguration? configuration = null)
     {
         var appPaths = Mock.Of<IApplicationPaths>();
         var mediaEncoder = new Mock<IMediaEncoder>();
         var subtitleEncoder = new Mock<ISubtitleEncoder>();
-        var config = new Mock<IConfiguration>();
         var configurationManager = new Mock<IConfigurationManager>();
         var pathManager = new Mock<IPathManager>();
 
@@ -335,8 +337,54 @@ public class EncodingHelperTests
             appPaths,
             mediaEncoder.Object,
             subtitleEncoder.Object,
-            config.Object,
+            configuration ?? new Mock<IConfiguration>().Object,
             configurationManager.Object,
             pathManager.Object);
+    }
+
+    private static IConfiguration BuildConfig(params (string Key, string? Value)[] values)
+    {
+        var items = new List<KeyValuePair<string, string?>>();
+        foreach (var (key, value) in values)
+        {
+            items.Add(new KeyValuePair<string, string?>(key, value));
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(items).Build();
+    }
+
+    [Fact]
+    public void GetInputModifier_OnlySharedProbeSizeSet_FallsBackToSharedValue()
+    {
+        var config = BuildConfig((JellyfinConfig.FfmpegProbeSizeKey, "1G"));
+        var state = BuildState(subtitle: null, deliveryMethod: null);
+
+        var modifier = CreateHelper(config).GetInputModifier(state, new EncodingOptions(), "mp4");
+
+        Assert.Contains("-probesize 1G", modifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetInputModifier_PlaybackProbeSizeSet_OverridesSharedValue()
+    {
+        var config = BuildConfig(
+            (JellyfinConfig.FfmpegProbeSizeKey, "1G"),
+            (JellyfinConfig.FfmpegPlaybackProbeSizeKey, "50M"));
+        var state = BuildState(subtitle: null, deliveryMethod: null);
+
+        var modifier = CreateHelper(config).GetInputModifier(state, new EncodingOptions(), "mp4");
+
+        Assert.Contains("-probesize 50M", modifier, StringComparison.Ordinal);
+        Assert.DoesNotContain("-probesize 1G", modifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetInputModifier_NoProbeSizeConfigured_OmitsArgument()
+    {
+        var state = BuildState(subtitle: null, deliveryMethod: null);
+
+        var modifier = CreateHelper(BuildConfig()).GetInputModifier(state, new EncodingOptions(), "mp4");
+
+        Assert.DoesNotContain("-probesize", modifier, StringComparison.Ordinal);
     }
 }

--- a/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
+++ b/tests/Jellyfin.MediaEncoding.Tests/Probing/ProbeExternalSourcesTests.cs
@@ -46,5 +46,56 @@ namespace Jellyfin.MediaEncoding.Tests.Probing
 
             Assert.Contains($"-user_agent \"{userAgent}\"", extraArg, StringComparison.InvariantCulture);
         }
+
+        [Fact]
+        public void GetExtraArguments_UsesSharedProbeSize()
+        {
+            var extraArg = GetExtraArguments(new Dictionary<string, string?>
+            {
+                { MediaBrowser.Controller.Extensions.ConfigurationExtensions.FfmpegProbeSizeKey, "1G" }
+            });
+
+            Assert.Contains("-probesize 1G", extraArg, StringComparison.InvariantCulture);
+        }
+
+        [Fact]
+        public void GetExtraArguments_IgnoresPlaybackProbeSize()
+        {
+            // Scanning must keep using the shared key; the playback override applies only to playback.
+            var extraArg = GetExtraArguments(new Dictionary<string, string?>
+            {
+                { MediaBrowser.Controller.Extensions.ConfigurationExtensions.FfmpegProbeSizeKey, "1G" },
+                { MediaBrowser.Controller.Extensions.ConfigurationExtensions.FfmpegPlaybackProbeSizeKey, "50M" }
+            });
+
+            Assert.Contains("-probesize 1G", extraArg, StringComparison.InvariantCulture);
+            Assert.DoesNotContain("-probesize 50M", extraArg, StringComparison.InvariantCulture);
+        }
+
+        private static string GetExtraArguments(Dictionary<string, string?> settings)
+        {
+            var encoder = new MediaEncoder(
+                Mock.Of<ILogger<MediaEncoder>>(),
+                Mock.Of<IServerConfigurationManager>(),
+                Mock.Of<IFileSystem>(),
+                Mock.Of<IBlurayExaminer>(),
+                Mock.Of<ILocalizationManager>(),
+                new ConfigurationBuilder().AddInMemoryCollection(settings).Build(),
+                Mock.Of<IServerConfigurationManager>());
+
+            var req = new MediaBrowser.Controller.MediaEncoding.MediaInfoRequest()
+            {
+                MediaSource = new MediaBrowser.Model.Dto.MediaSourceInfo
+                {
+                    Path = "/path/to/file.mkv",
+                    Protocol = MediaProtocol.File,
+                    RequiredHttpHeaders = new Dictionary<string, string>()
+                },
+                ExtractChapters = false,
+                MediaType = MediaBrowser.Model.Dlna.DlnaProfileType.Video,
+            };
+
+            return encoder.GetExtraArguments(req);
+        }
     }
 }


### PR DESCRIPTION
**Changes**
Add a new environment variable, `JELLYFIN_FFmpeg__playbackprobesize`. This sets the probe size for transcoding, independent of the probe size setting for library scan

**Code assistance**
Developed with Claude Opus 5
- Assisting in investigation of slow playback
- Performed git archeology to collect more context
- Wrote the code and tests

All code has been human reviewed. End-to-end testing was manually performed. The associated issue, along with this PR text, were written by hand.

**Issues**
Fixes #17694
