### PR TITLE
Mark breakOnNonKeyFrames as XMLIgnore

### DIFF
--- a/MediaBrowser.Model/Dlna/TranscodingProfile.cs
+++ b/MediaBrowser.Model/Dlna/TranscodingProfile.cs
@@ -141,6 +141,7 @@ public class TranscodingProfile
     /// Gets or sets a value indicating whether breaking the video stream on non-keyframes is supported.
     /// </summary>
     [DefaultValue(false)]
+    [XmlIgnore]
     [XmlAttribute("breakOnNonKeyFrames")]
     [Obsolete("This is always false")]
     public bool? BreakOnNonKeyFrames { get; set; }


### PR DESCRIPTION
Nullability breaks the XML serialized. since it is obsolet anyway, we can just not serialize it.

**Changes**
Mark `BreakOnNonKeyFrames` as `XMLIgnore`

**Code assistance**
None

**Issues**
Fixes https://github.com/jellyfin/jellyfin-plugin-dlna/issues/224