### PR TITLE
Look up people by item via the credit map instead of a full scan

### DIFF
--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -351,7 +351,11 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!filter.ItemId.IsEmpty())
         {
-            query = query.Where(e => e.BaseItems!.Any(w => w.ItemId.Equals(filter.ItemId)));
+            var itemId = filter.ItemId;
+            query = query.Where(e => context.PeopleBaseItemMap
+                .Where(m => m.ItemId.Equals(itemId))
+                .Select(m => m.PeopleId)
+                .Contains(e.Id));
         }
 
         if (filter.ParentId != null)
@@ -361,7 +365,11 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
 
         if (!filter.AppearsInItemId.IsEmpty())
         {
-            query = query.Where(e => e.BaseItems!.Any(w => w.ItemId.Equals(filter.AppearsInItemId)));
+            var appearsInItemId = filter.AppearsInItemId;
+            query = query.Where(e => context.PeopleBaseItemMap
+                .Where(m => m.ItemId.Equals(appearsInItemId))
+                .Select(m => m.PeopleId)
+                .Contains(e.Id));
         }
 
         var queryPersonTypes = filter.PersonTypes.Where(IsValidPersonType).ToList();


### PR DESCRIPTION
**Changes**
`PeopleRepository.TranslateQuery` filtered people by asking of every person whether they were credited on the given item.  This is obviously inefficient, so we use the Mapping table instead.

**Code assistance**
None

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
