### PR TITLE
Fix person metadata not being fetched on demand or by the people task

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -243,8 +243,8 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
 
             var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
             {
-                ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default,
-                MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.Default
+                ImageRefreshMode = hasImage ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.FullRefresh,
+                MetadataRefreshMode = hasOverview ? MetadataRefreshMode.ValidationOnly : MetadataRefreshMode.FullRefresh
             };
 
             await item.RefreshMetadata(options, cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Api/Controllers/UserLibraryController.cs
+++ b/Jellyfin.Api/Controllers/UserLibraryController.cs
@@ -34,6 +34,8 @@ namespace Jellyfin.Api.Controllers;
 [Tags("Library")]
 public class UserLibraryController : BaseJellyfinApiController
 {
+    private static readonly TimeSpan RefreshOnDemandTimeout = TimeSpan.FromSeconds(3);
+
     private readonly IUserManager _userManager;
     private readonly IUserDataManager _userDataRepository;
     private readonly ILibraryManager _libraryManager;
@@ -79,7 +81,7 @@ public class UserLibraryController : BaseJellyfinApiController
     /// <returns>An <see cref="OkResult"/> containing the item.</returns>
     [HttpGet("Items/{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public ActionResult<BaseItemDto> GetItem(
+    public async Task<ActionResult<BaseItemDto>> GetItem(
         [FromQuery] Guid? userId,
         [FromRoute, Required] Guid itemId)
     {
@@ -98,7 +100,7 @@ public class UserLibraryController : BaseJellyfinApiController
             return NotFound();
         }
 
-        QueueRefreshOnDemandIfNeeded(item);
+        await RefreshOnDemandIfNeeded(item).ConfigureAwait(false);
 
         var dtoOptions = new DtoOptions();
 
@@ -116,7 +118,7 @@ public class UserLibraryController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [Obsolete("Kept for backwards compatibility")]
     [ApiExplorerSettings(IgnoreApi = true)]
-    public ActionResult<BaseItemDto> GetItemLegacy(
+    public Task<ActionResult<BaseItemDto>> GetItemLegacy(
         [FromRoute, Required] Guid userId,
         [FromRoute, Required] Guid itemId)
         => GetItem(userId, itemId);
@@ -643,7 +645,7 @@ public class UserLibraryController : BaseJellyfinApiController
             limit,
             groupItems);
 
-    private void QueueRefreshOnDemandIfNeeded(BaseItem item)
+    private async Task RefreshOnDemandIfNeeded(BaseItem item)
     {
         if (item is not Person)
         {
@@ -656,15 +658,24 @@ public class UserLibraryController : BaseJellyfinApiController
             return;
         }
 
-        _providerManager.QueueRefresh(
-            item.Id,
-            new MetadataRefreshOptions(new DirectoryService(_fileSystem))
-            {
-                MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
-                ImageRefreshMode = MetadataRefreshMode.FullRefresh,
-                ForceSave = true
-            },
-            RefreshPriority.High);
+        var options = new MetadataRefreshOptions(new DirectoryService(_fileSystem))
+        {
+            MetadataRefreshMode = MetadataRefreshMode.FullRefresh,
+            ImageRefreshMode = MetadataRefreshMode.FullRefresh,
+            ForceSave = true
+        };
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(HttpContext.RequestAborted);
+        timeout.CancelAfter(RefreshOnDemandTimeout);
+
+        try
+        {
+            await item.RefreshMetadata(options, timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            _providerManager.QueueRefresh(item.Id, options, RefreshPriority.High);
+        }
     }
 
     /// <summary>

--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -209,7 +209,10 @@ namespace MediaBrowser.Providers.Manager
                 }
             }
 
-            if (hasRefreshedMetadata && hasRefreshedImages)
+            var attemptedFetch = refreshOptions.MetadataRefreshMode > MetadataRefreshMode.ValidationOnly
+                || refreshOptions.ImageRefreshMode > MetadataRefreshMode.ValidationOnly;
+
+            if (hasRefreshedMetadata && hasRefreshedImages && attemptedFetch)
             {
                 item.DateLastRefreshed = DateTime.UtcNow;
                 updateType |= item.OnMetadataChanged();


### PR DESCRIPTION
Logic error where we never refreshed people data under some circumstances.

**Changes**
Trigger people metadata refresh on missing metadata, gate it with a timeout and refresh in background if we reach the timeout

**Code assistance**
None

**Issues**
