### PR TITLE
Fix out-of-order migration handling

### DIFF
--- a/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
+++ b/Jellyfin.Server/Migrations/JellyfinMigrationService.cs
@@ -199,9 +199,9 @@ internal class JellyfinMigrationService
             while (true)
             {
                 // A single migration can change which migrations still apply: IMigrator.MigrateAsync treats its argument as the
-                // state to end up in, so it reverts everything applied after it, and a reverted migration can take code migrations
-                // with it (AddNormalizedUsername.Down drops the UpdateNormalizedUsername history row). Anything computed before
-                // that point is stale, so only ever run the next migration and then work out the pending set again.
+                // state to end up in, so one call can apply several database migrations at once, and a code migration can add or
+                // remove history rows. Anything computed before that point is stale, so only ever run the next migration and then
+                // work out the pending set again.
                 var appliedMigrations = await historyRepository.GetAppliedMigrationsAsync().ConfigureAwait(false);
                 var pendingCodeMigrations = migrationStage
                     .Where(e => appliedMigrations.All(f => f.MigrationId != e.BuildCodeMigrationId()))
@@ -211,8 +211,23 @@ internal class JellyfinMigrationService
                 (string Key, InternalDatabaseMigration Migration)[] pendingDatabaseMigrations = [];
                 if (stage is JellyfinMigrationStageTypes.CoreInitialisation)
                 {
+                    // IMigrator.MigrateAsync reverts every applied migration that sorts after its target. A pending migration
+                    // older than an applied one is normal whenever branches with interleaved timestamps get merged, and reverting
+                    // is never what we want there: it drops schema and data, and SQLite cannot even generate most Down operations
+                    // (AlterColumn throws), which fails startup outright. So never let the target move backwards - cap it at the
+                    // newest applied database migration, which applies the straggler and leaves everything newer in place.
+                    var newestAppliedDatabaseMigration = migrationsAssembly.Migrations.Keys
+                        .Where(key => appliedMigrations.Any(e => string.Equals(e.MigrationId, key, StringComparison.Ordinal)))
+                        .OrderByDescending(key => key, StringComparer.Ordinal)
+                        .FirstOrDefault();
+
                     pendingDatabaseMigrations = migrationsAssembly.Migrations.Where(f => appliedMigrations.All(e => e.MigrationId != f.Key))
-                       .Select(e => (Key: e.Key, Migration: new InternalDatabaseMigration(e, dbContext)))
+                       .Select(e => (
+                           Key: e.Key,
+                           Migration: new InternalDatabaseMigration(
+                               e,
+                               string.CompareOrdinal(e.Key, newestAppliedDatabaseMigration) > 0 ? e.Key : newestAppliedDatabaseMigration!,
+                               dbContext)))
                        .ToArray();
                 }
 
@@ -468,18 +483,31 @@ internal class JellyfinMigrationService
     private class InternalDatabaseMigration : IInternalMigration
     {
         private readonly JellyfinDbContext _jellyfinDbContext;
+        private readonly string _targetMigration;
         private KeyValuePair<string, TypeInfo> _databaseMigrationInfo;
 
-        public InternalDatabaseMigration(KeyValuePair<string, TypeInfo> databaseMigrationInfo, JellyfinDbContext jellyfinDbContext)
+        public InternalDatabaseMigration(KeyValuePair<string, TypeInfo> databaseMigrationInfo, string targetMigration, JellyfinDbContext jellyfinDbContext)
         {
             _databaseMigrationInfo = databaseMigrationInfo;
+            _targetMigration = targetMigration;
             _jellyfinDbContext = jellyfinDbContext;
         }
 
         public async Task PerformAsync(IStartupLogger logger)
         {
             var migrator = _jellyfinDbContext.GetService<IMigrator>();
-            await migrator.MigrateAsync(_databaseMigrationInfo.Key).ConfigureAwait(false);
+
+            // The target is this migration, or the newest applied one when this migration sorts before it: everything
+            // still pending up to that point gets applied, nothing already applied gets reverted.
+            if (!string.Equals(_targetMigration, _databaseMigrationInfo.Key, StringComparison.Ordinal))
+            {
+                logger.LogInformation(
+                    "Migration {Name} sorts before the already applied {Applied} and is applied out of order.",
+                    _databaseMigrationInfo.Key,
+                    _targetMigration);
+            }
+
+            await migrator.MigrateAsync(_targetMigration).ConfigureAwait(false);
         }
     }
 }

--- a/Jellyfin.Server/Migrations/Routines/20260113120000_MigrateLinkedChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260113120000_MigrateLinkedChildren.cs
@@ -426,9 +426,21 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
         var canRemoveUnrootedItems = inaccessiblePaths.Count == 0;
         var skippedUnrootedItems = 0;
 
+        _logger.LogInformation("Checking {Total} items for missing files...", itemsWithPaths.Count);
+
         var staleIds = new List<Guid>();
+        var checkedItems = 0;
+        const int progressLogStep = 10000;
         foreach (var item in itemsWithPaths)
         {
+            // One filesystem stat per item, so a large library spends minutes in this loop.
+            if (checkedItems > 0 && checkedItems % progressLogStep == 0)
+            {
+                _logger.LogInformation("Checking items for missing files: {Checked}/{Total}", checkedItems, itemsWithPaths.Count);
+            }
+
+            checkedItems++;
+
             // Expand virtual path placeholders (%AppDataPath%, %MetadataPath%) to real paths
             var path = _appHost.ExpandVirtualPath(item.Path!);
 
@@ -480,7 +492,7 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
             return;
         }
 
-        _logger.LogInformation("Found {Count} stale items to remove.", staleIds.Count);
+        _logger.LogInformation("Found {Count} stale items to remove, resolving them for deletion...", staleIds.Count);
 
         var itemsToDelete = staleIds
             .Select(id => _libraryManager.GetItemById(id))
@@ -500,8 +512,17 @@ internal class MigrateLinkedChildren : IDatabaseMigrationRoutine
 
         var options = new DeleteOptions { DeleteFileLocation = false, DeleteFromExternalProvider = false };
         var deleted = 0;
+        var processed = 0;
+        const int progressLogStep = 500;
         foreach (var item in items)
         {
+            if (processed > 0 && processed % progressLogStep == 0)
+            {
+                _logger.LogInformation("Deleting items: {Processed}/{Total}", processed, items.Count);
+            }
+
+            processed++;
+
             try
             {
                 _libraryManager.DeleteItem(item, options);

--- a/tests/Jellyfin.Server.Implementations.Tests/EfMigrations/EfMigrationTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/EfMigrations/EfMigrationTests.cs
@@ -1,6 +1,15 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
 using Jellyfin.Database.Providers.Sqlite.Migrations;
 using Jellyfin.Server.Implementations.Migrations;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Jellyfin.Server.Implementations.Tests.EfMigrations;
@@ -13,5 +22,82 @@ public class EfMigrationTests
         var dbDesignContext = new SqliteDesignTimeJellyfinDbFactory();
         var context = dbDesignContext.CreateDbContext([]);
         Assert.False(context.Database.HasPendingModelChanges(), "There are unapplied changes to the EFCore model for SQLite. Please create a Migration.");
+    }
+
+    [Fact]
+    public async Task Migrate_AppliesAnOutOfOrderMigrationWithoutRevertingNewerOnes()
+    {
+        // Merging branches whose migration timestamps interleave leaves a pending migration that sorts before an applied
+        // one. IMigrator.MigrateAsync takes the state to end up in, so targeting that migration directly would revert
+        // everything newer - which drops data and, on SQLite, usually cannot even be generated. JellyfinMigrationService
+        // therefore caps the target at the newest applied migration; this pins that this applies the straggler and
+        // leaves the newer migrations alone.
+        const string BeforeStraggler = "20260728182152_AddPeopleItemMapCoveringIndex";
+        const string Straggler = "20260812050902_AddMediaStreamFilterIndex";
+        const string AfterStraggler = "20260815063607_RemoveOrphanedUserPermissionsAndPreferences";
+        const string StragglerIndex = "IX_MediaStreamInfos_StreamType_ItemId_Language_IsExternal";
+
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        var options = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(connection, f => f.MigrationsAssembly(typeof(SqliteDesignTimeJellyfinDbFactory).Assembly))
+            .Options;
+
+        using var context = new JellyfinDbContext(
+            options,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+
+        var migrator = context.GetService<IMigrator>();
+
+        // Recreate a database that only learned about the straggler after the newer migrations had been applied: apply
+        // everything before it, claim it is applied so its Up is skipped, move on, then forget it again.
+        await migrator.MigrateAsync(BeforeStraggler, TestContext.Current.CancellationToken);
+        SetApplied(connection, Straggler, true);
+        await migrator.MigrateAsync(AfterStraggler, TestContext.Current.CancellationToken);
+        SetApplied(connection, Straggler, false);
+        Assert.False(IndexExists(connection, StragglerIndex));
+
+        await migrator.MigrateAsync(AfterStraggler, TestContext.Current.CancellationToken);
+
+        Assert.True(IndexExists(connection, StragglerIndex));
+        Assert.True(IsApplied(connection, Straggler));
+        Assert.True(IsApplied(connection, AfterStraggler));
+    }
+
+    private static void SetApplied(SqliteConnection connection, string migrationId, bool applied)
+    {
+        using var command = connection.CreateCommand();
+        if (applied)
+        {
+            command.CommandText = "INSERT INTO \"__EFMigrationsHistory\" (\"MigrationId\", \"ProductVersion\") VALUES ($id, '0.0.0')";
+        }
+        else
+        {
+            command.CommandText = "DELETE FROM \"__EFMigrationsHistory\" WHERE \"MigrationId\" = $id";
+        }
+
+        command.Parameters.AddWithValue("$id", migrationId);
+        command.ExecuteNonQuery();
+    }
+
+    private static bool IsApplied(SqliteConnection connection, string migrationId)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT count(*) FROM \"__EFMigrationsHistory\" WHERE \"MigrationId\" = $id";
+        command.Parameters.AddWithValue("$id", migrationId);
+
+        return Convert.ToInt32(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture) == 1;
+    }
+
+    private static bool IndexExists(SqliteConnection connection, string name)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = $name";
+        command.Parameters.AddWithValue("$name", name);
+
+        return Convert.ToInt32(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture) == 1;
     }
 }


### PR DESCRIPTION
Migration order is not checked on merge, so we can merge a migration that was created before the latest migration already existing on master, triggering the latter to be rolled back on next boot which usually breaks data.

**Changes**
Safeguard against it. It is hacky, this will have a better solution in 13.x with .NET 11 apparently.

**Code assistance**
Cladue Opus 5

**Issues**
