### PR TITLE
Fix ParentId for episodes in virtual seasons

### DIFF
--- a/MediaBrowser.Providers/TV/SeriesMetadataService.cs
+++ b/MediaBrowser.Providers/TV/SeriesMetadataService.cs
@@ -364,7 +364,7 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
         foreach (var episode in episodes)
         {
             var season = seasons.FirstOrDefault(i => i.IndexNumber == episode.ParentIndexNumber);
-            if (season is null || episode.SeasonId.Equals(season.Id))
+            if (season is null || (episode.SeasonId.Equals(season.Id) && episode.ParentId.Equals(season.Id)))
             {
                 continue;
             }
@@ -372,6 +372,11 @@ public class SeriesMetadataService : MetadataService<Series, SeriesInfo>
             // Assign the correct season id and name to episode.
             episode.SeasonId = season.Id;
             episode.SeasonName = season.Name;
+
+            // We need to set ParentId here for episodes in virtual seasons (e.g., flat structures), otherwise it retains the
+            // ParentId from the series.
+            episode.SetParent(season);
+
             await episode.UpdateToRepositoryAsync(ItemUpdateType.MetadataImport, cancellationToken).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
When a series with a virtual season (e.g., flat structure) is created, the episodes retained the `ParentId` from the series. This caused clients like ATV, which fetches the children for the season using `ParentId`, to return 0 results since the episode's `ParentId` still pointed to the series instead of the season.

**Changes**
Assign `ParentId` to episodes when we assign the name and SeasonId, and update the guard to also check for `ParentId`.

**Code assistance**
N/A

**Issues**
N/A
