### PR TITLE
Support anime provider ids on season folders

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/TV/SeasonResolver.cs
@@ -129,6 +129,17 @@ namespace Emby.Server.Implementations.Library.Resolvers.TV
 
             var tmdbId = justName.GetAttributeValue("tmdbid");
             item.TrySetProviderId(MetadataProvider.Tmdb, tmdbId);
+
+            // Anime databases model a single cour as its own entry, so a multi-season
+            // series maps to one of these ids per season rather than one per series.
+            var anidbId = justName.GetAttributeValue("anidbid");
+            item.TrySetProviderId("AniDB", anidbId);
+
+            var aniListId = justName.GetAttributeValue("anilistid");
+            item.TrySetProviderId("AniList", aniListId);
+
+            var aniSearchId = justName.GetAttributeValue("anisearchid");
+            item.TrySetProviderId("AniSearch", aniSearchId);
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/SeasonResolverTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/SeasonResolverTests.cs
@@ -62,6 +62,36 @@ namespace Jellyfin.Server.Implementations.Tests.Library
             Assert.Equal(expectedId, actualId);
         }
 
+        [Theory]
+        [InlineData("/media/Show/Season 01 [anidbid=11111]", "AniDB", "11111")]
+        [InlineData("/media/Show/Season 01 [anidbid-11111]", "AniDB", "11111")]
+        [InlineData("/media/Show/Season 02 [anilistid=22222]", "AniList", "22222")]
+        [InlineData("/media/Show/Season 02 (anilistid=22222)", "AniList", "22222")]
+        [InlineData("/media/Show/Season 03 [anisearchid=33333]", "AniSearch", "33333")]
+        public void Resolve_SeasonFolderWithAniProviderId_SetsProviderId(string path, string providerKey, string expectedId)
+        {
+            var series = new Series { Path = "/media/Show" };
+
+            var args = new MediaBrowser.Controller.Library.ItemResolveArgs(
+                Mock.Of<IServerApplicationPaths>(),
+                null)
+            {
+                Parent = series,
+                LibraryOptions = new LibraryOptions(),
+                FileInfo = new FileSystemMetadata
+                {
+                    FullName = path,
+                    IsDirectory = true
+                }
+            };
+
+            var season = _resolver.Resolve(args);
+
+            Assert.NotNull(season);
+            Assert.True(season.TryGetProviderId(providerKey, out var actualId));
+            Assert.Equal(expectedId, actualId);
+        }
+
         [Fact]
         public void Resolve_SeasonFolderWithMultipleProviderIds_SetsAll()
         {
@@ -140,6 +170,9 @@ namespace Jellyfin.Server.Implementations.Tests.Library
             Assert.False(season.TryGetProviderId(MetadataProvider.Tvdb, out _));
             Assert.False(season.TryGetProviderId(MetadataProvider.TvMaze, out _));
             Assert.False(season.TryGetProviderId(MetadataProvider.Tmdb, out _));
+            Assert.False(season.TryGetProviderId("AniDB", out _));
+            Assert.False(season.TryGetProviderId("AniList", out _));
+            Assert.False(season.TryGetProviderId("AniSearch", out _));
         }
     }
 }


### PR DESCRIPTION
What the title says

**Changes**
Support `anidbid`, `anilistid` and `anisearchid` on a season level

**Code assistance**
None

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
