### PR TITLE
Invalidate cached splashscreen derivatives when the collage is regenerated

### DIFF
--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1686,7 +1686,8 @@ public class ImageController : BaseJellyfinApiController
         {
             Image = new ItemImageInfo
             {
-                Path = splashscreenPath
+                Path = splashscreenPath,
+                DateModified = _fileSystem.GetLastWriteTimeUtc(splashscreenPath)
             },
             Height = null,
             MaxHeight = null,


### PR DESCRIPTION
When getting a splashscreen image the generated webp/ jpg file is cached. Which is only cleared every 30 days, even though the original png may have been updated.

**Changes**

Invalidates cached splashscreens when the collage is regenerated so a client pulls an updated image instead of having to wait up to 30 days for DeleteCacheFileTask.

**Code assistance**

Claude identified the cause and wrote the patch

**Issues**

N/A
