### PR TITLE
Send X-Application-Error-Code when parental control refuses a request

### DIFF
--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
@@ -80,6 +80,14 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
             // It's not great to have this check, but parental schedule must usually be honored except in a few rare cases
             if (requirement.ValidateParentalSchedule && !user.IsParentalScheduleAllowed())
             {
+                // Tell the client why it was refused. Without this the resulting 403 is
+                // indistinguishable from an ordinary permission denial, and clients render
+                // it as an empty library rather than an actionable message.
+                if (_httpContextAccessor.HttpContext is not null)
+                {
+                    _httpContextAccessor.HttpContext.Response.Headers[ApplicationErrorCodes.HeaderName] = ApplicationErrorCodes.ParentalControl;
+                }
+
                 context.Fail();
                 return Task.CompletedTask;
             }

--- a/Jellyfin.Api/Constants/ApplicationErrorCodes.cs
+++ b/Jellyfin.Api/Constants/ApplicationErrorCodes.cs
@@ -1,0 +1,23 @@
+namespace Jellyfin.Api.Constants
+{
+    /// <summary>
+    /// Values for the <c>X-Application-Error-Code</c> response header.
+    /// </summary>
+    /// <remarks>
+    /// Clients read this header to explain a failure to the user. jellyfin-web keys off
+    /// <see cref="ParentalControl"/> to show a message and return to the login screen
+    /// instead of rendering an empty library.
+    /// </remarks>
+    public static class ApplicationErrorCodes
+    {
+        /// <summary>
+        /// The name of the response header carrying the error code.
+        /// </summary>
+        public const string HeaderName = "X-Application-Error-Code";
+
+        /// <summary>
+        /// The request was refused by parental control, for example an access schedule.
+        /// </summary>
+        public const string ParentalControl = "ParentalControl";
+    }
+}

--- a/Jellyfin.Api/Middleware/ExceptionMiddleware.cs
+++ b/Jellyfin.Api/Middleware/ExceptionMiddleware.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Mime;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
@@ -92,6 +93,14 @@ public class ExceptionMiddleware
             context.Response.StatusCode = GetStatusCode(ex);
             context.Response.ContentType = MediaTypeNames.Text.Plain;
 
+            // Tell the client why it was refused. Without this a parental-control
+            // rejection is an indistinguishable 403 and clients render it as an
+            // empty library rather than an actionable message.
+            if (IsParentalControlRejection(ex))
+            {
+                context.Response.Headers[ApplicationErrorCodes.HeaderName] = ApplicationErrorCodes.ParentalControl;
+            }
+
             // Don't send exception unless the server is in a Development environment
             var errorContent = _hostEnvironment.IsDevelopment()
                     ? NormalizeExceptionMessage(ex.Message)
@@ -118,6 +127,29 @@ public class ExceptionMiddleware
         }
 
         return ex;
+    }
+
+    /// <summary>
+    /// Checks whether an exception, or anything it wraps, is a parental control rejection.
+    /// </summary>
+    /// <remarks>
+    /// The chain has to be walked because <c>UserController</c> catches
+    /// <see cref="SecurityException"/> and rethrows a plain one to prefix the remote IP to
+    /// the message, which erases the original type.
+    /// </remarks>
+    /// <param name="ex">The exception to inspect.</param>
+    /// <returns><c>true</c> if the exception or any inner exception is a <see cref="ParentalControlException"/>.</returns>
+    private static bool IsParentalControlRejection(Exception? ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is ParentalControlException)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static int GetStatusCode(Exception ex)

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -646,7 +646,7 @@ namespace Jellyfin.Server.Implementations.Users
                         "Authentication request for {UserName} is not allowed at this time due parental restrictions (IP: {IP}).",
                         username,
                         remoteEndPoint);
-                    throw new SecurityException("User is not allowed access at this time.");
+                    throw new ParentalControlException("User is not allowed access at this time.");
                 }
 
                 // Update LastActivityDate and LastLoginDate, then save

--- a/MediaBrowser.Controller/Net/ParentalControlException.cs
+++ b/MediaBrowser.Controller/Net/ParentalControlException.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace MediaBrowser.Controller.Net
+{
+    /// <summary>
+    /// The exception that is thrown when a user is refused because of parental control,
+    /// such as being outside their configured access schedule.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="SecurityException"/> so the API layer can tell clients
+    /// <em>why</em> the request was refused. A client that only sees a bare 403 cannot
+    /// distinguish this from an ordinary permission denial.
+    /// </remarks>
+    public class ParentalControlException : SecurityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        public ParentalControlException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ParentalControlException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public ParentalControlException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/ParentalControlErrorCodeTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/ParentalControlErrorCodeTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
+using Jellyfin.Api.Constants;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
+{
+    /// <summary>
+    /// A parental-schedule rejection must identify itself with the
+    /// <c>X-Application-Error-Code</c> header. Without it the resulting 403 is
+    /// indistinguishable from an ordinary permission denial, and clients render it
+    /// as an empty library instead of an actionable message.
+    /// </summary>
+    public class ParentalControlErrorCodeTests
+    {
+        private readonly Mock<IConfigurationManager> _configurationManagerMock;
+        private readonly List<IAuthorizationRequirement> _requirements;
+        private readonly DefaultAuthorizationHandler _sut;
+        private readonly Mock<IUserManager> _userManagerMock;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+
+        /// <summary>
+        /// Globally disallow access.
+        /// </summary>
+        private readonly AccessSchedule[] _disallowedSchedule = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };
+
+        /// <summary>
+        /// Allow access at any hour of any day.
+        /// </summary>
+        private readonly AccessSchedule[] _allowedSchedule = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 24, Guid.Empty) };
+
+        public ParentalControlErrorCodeTests()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
+            _requirements = new List<IAuthorizationRequirement> { new DefaultAuthorizationRequirement() };
+            _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
+            _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
+
+            _sut = fixture.Create<DefaultAuthorizationHandler>();
+        }
+
+        [Fact]
+        public async Task ShouldSetErrorCodeHeaderWhenOutsideAccessSchedule()
+        {
+            var (httpContext, claims) = SetupHandler(UserRoles.User, _disallowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.False(context.HasSucceeded);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                httpContext.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task ShouldNotSetErrorCodeHeaderWhenInsideAccessSchedule()
+        {
+            var (httpContext, claims) = SetupHandler(UserRoles.User, _allowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+            Assert.False(httpContext.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        [Fact]
+        public async Task ShouldNotSetErrorCodeHeaderForAdministrator()
+        {
+            // Administrators bypass the schedule, so nothing should be flagged.
+            var (httpContext, claims) = SetupHandler(UserRoles.Administrator, _disallowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+            Assert.False(httpContext.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        /// <summary>
+        /// Wires the handler up against a real <see cref="DefaultHttpContext"/> so the
+        /// response headers it writes can be asserted on.
+        /// </summary>
+        private (DefaultHttpContext HttpContext, ClaimsPrincipal Claims) SetupHandler(string role, AccessSchedule[] schedules)
+        {
+            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
+            var claims = TestHelpers.SetupUser(_userManagerMock, _httpContextAccessor, role, schedules);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = new IPAddress(0);
+            _httpContextAccessor.Setup(h => h.HttpContext).Returns(httpContext);
+
+            return (httpContext, claims);
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Middleware/ExceptionMiddlewareTests.cs
+++ b/tests/Jellyfin.Api.Tests/Middleware/ExceptionMiddlewareTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Middleware;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Middleware
+{
+    /// <summary>
+    /// The login path refuses out-of-schedule users by throwing, so the error code has
+    /// to be attached where the exception is turned into a response. Without it a client
+    /// cannot tell "outside your allowed hours" from a wrong password.
+    /// </summary>
+    public class ExceptionMiddlewareTests
+    {
+        [Fact]
+        public async Task ParentalControlExceptionSetsErrorCodeHeader()
+        {
+            var context = await InvokeWith(new ParentalControlException("User is not allowed access at this time."));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                context.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task WrappedParentalControlExceptionSetsErrorCodeHeader()
+        {
+            // UserController catches SecurityException and rethrows a plain one to prefix
+            // the remote IP to the message, which erases the original type. The error code
+            // must survive that.
+            var inner = new ParentalControlException("User is not allowed access at this time.");
+            var context = await InvokeWith(new SecurityException("[127.0.0.1] User is not allowed access at this time.", inner));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                context.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task PlainSecurityExceptionDoesNotSetErrorCodeHeader()
+        {
+            // Still a 403, but not a parental-control one -- it must not be mislabelled.
+            var context = await InvokeWith(new SecurityException("Forbidden."));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.False(context.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        [Fact]
+        public async Task UnrelatedExceptionDoesNotSetErrorCodeHeader()
+        {
+            var context = await InvokeWith(new ArgumentException("bad argument"));
+
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+            Assert.False(context.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        private static async Task<DefaultHttpContext> InvokeWith(Exception exception)
+        {
+            var configurationManager = new Mock<IServerConfigurationManager>();
+            configurationManager
+                .Setup(c => c.ApplicationPaths)
+                .Returns(Mock.Of<IServerApplicationPaths>());
+
+            var hostEnvironment = new Mock<IWebHostEnvironment>();
+            hostEnvironment.Setup(h => h.EnvironmentName).Returns("Production");
+
+            var sut = new ExceptionMiddleware(
+                _ => throw exception,
+                NullLogger<ExceptionMiddleware>.Instance,
+                configurationManager.Object,
+                hostEnvironment.Object);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            await sut.Invoke(context);
+
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

jellyfin-web already handles this case. `appRouter.onRequestFail` shows `AccessRestrictedTryAgainLater` and returns the user to the login screen, but only when a 403 carries `X-Application-Error-Code: ParentalControl`. The server never sends that header (it appears nowhere in the codebase), so the branch is dead and a parental-control refusal arrives as a bare 403 with an empty body, which clients render as an empty library. This sets the header on both paths that refuse these requests: `DefaultAuthorizationHandler` for an already-authenticated session whose access window has closed, and `ExceptionMiddleware` for a fresh login outside the window. 

No status codes or response bodies change.

Two supporting changes:

* 1. `UserManager` throws a new `ParentalControlException` (a `SecurityException` subclass) for the parental-schedule rejection, so the middleware can identify the cause instead of matching on a message string.
* 2. `ExceptionMiddleware` walks the inner-exception chain. `UserController` catches `SecurityException` and rethrows a plain one to prefix the remote IP to the message, which erases the original type.

**Verification**

Against a running server, with a user whose access schedule excludes the current time:

| Request | Before | After |
| --- | --- | --- |
| `GET /Users/Me` | 403, no header | 403, `ParentalControl` |
| `GET /UserViews` | 403, no header | 403, `ParentalControl` |
| `GET /Sessions` | 403, no header | 403, `ParentalControl` |
| `POST /Users/AuthenticateByName` | 403, no header | 403, `ParentalControl` |
| `POST /Users/AuthenticateByName`, wrong password | 401, no header | 401, no header (unchanged) |

Also reproduced the real sequence: sign in while allowed, apply a blocking schedule, reuse the token. The header appears from that point on.

Six unit tests cover both paths, the wrapped-exception case, and the negative cases (plain `SecurityException`, unrelated exception, in-schedule user, administrator). `Jellyfin.Api.Tests` passes at 146.

**Code assistance**

Used Claude Code for codebase navigation, drafting the patch and its tests, and running the verification. Worth noting that the first version passed its unit tests but did nothing on a live server, because it missed the type-erasing rethrow in `UserController`. The inner-exception walk and its test were created, the table was measured against a running server rather than taken from the model.

**Issues**

None fixed directly. Three related reports were closed as stale rather than resolved, all cases of an account-level block producing an unclear or misleading client-side result:

* #12808, connection error message unclear when the simultaneous session limit is reached
* #15033, access schedule not using client local time
* #7930, admin cannot change the password of a user with parental control

**Open question**

Left as a draft pending a maintainer view on the status code. These blocks are account-level and total, and the [documentation](https://jellyfin.org/docs/general/server/users/adding-managing-users/) describes an access-schedule window as effectively disabling the user, so 401 would be more accurate than 403 and would drive the sign-out path clients already implement. That is a larger behavioural change and is deliberately not in this PR. Happy to follow up with it if wanted.
