### PR TITLE
Filter search candidates by user access in a single query

### DIFF
--- a/Emby.Server.Implementations/Library/Search/SearchManager.cs
+++ b/Emby.Server.Implementations/Library/Search/SearchManager.cs
@@ -112,13 +112,12 @@ public class SearchManager : ISearchManager
             return externalResults;
         }
 
-        var internalResults = await internalTask.ConfigureAwait(false);
         if (_internalProviders.Length > 0)
         {
             _logger.LogDebug("No results from external providers, using internal provider results");
         }
 
-        return internalResults;
+        return await internalTask.ConfigureAwait(false);
     }
 
     private async Task<IReadOnlyList<SearchResult>> FilterByUserAccessAsync(
@@ -144,16 +143,15 @@ public class SearchManager : ISearchManager
 
             baseQuery = _queryHelpers.ApplyAccessFiltering(dbContext, baseQuery, accessFilter);
 
-            var allowedCount = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
-            if (allowedCount == candidates.Count)
-            {
-                return candidates;
-            }
-
             var allowedIds = await baseQuery
                 .Select(e => e.Id)
                 .ToHashSetAsync(cancellationToken)
                 .ConfigureAwait(false);
+
+            if (allowedIds.Count == candidates.Count)
+            {
+                return candidates;
+            }
 
             var filtered = candidates.Where(c => allowedIds.Contains(c.ItemId)).ToList();
             if (filtered.Count < candidates.Count)


### PR DESCRIPTION
We don't need to execute this twice.

**Changes**
Filter search candidates by user access in a single query

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
