### PR TITLE
Fix: Parental control error code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -240,6 +240,7 @@
  - [Florin-Popescu](https://github.com/Florin-Popescu)
  - [m0g3r](https://github.com/m0g3r)
  - [martin-77](https://github.com/martin-77)
+ - [BGebken](https://github.com/BGebken)
 
 # Emby Contributors
 

--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Common.Net;
 using MediaBrowser.Controller.Library;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
 {
@@ -20,6 +21,7 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
         private readonly IUserManager _userManager;
         private readonly INetworkManager _networkManager;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILogger<DefaultAuthorizationHandler> _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultAuthorizationHandler"/> class.
@@ -27,14 +29,17 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
         /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
         /// <param name="networkManager">Instance of the <see cref="INetworkManager"/> interface.</param>
         /// <param name="httpContextAccessor">Instance of the <see cref="IHttpContextAccessor"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger{DefaultAuthorizationHandler}"/> interface.</param>
         public DefaultAuthorizationHandler(
             IUserManager userManager,
             INetworkManager networkManager,
-            IHttpContextAccessor httpContextAccessor)
+            IHttpContextAccessor httpContextAccessor,
+            ILogger<DefaultAuthorizationHandler> logger)
         {
             _userManager = userManager;
             _networkManager = networkManager;
             _httpContextAccessor = httpContextAccessor;
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -80,6 +85,18 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
             // It's not great to have this check, but parental schedule must usually be honored except in a few rare cases
             if (requirement.ValidateParentalSchedule && !user.IsParentalScheduleAllowed())
             {
+                // Let the client tell this apart from an ordinary permission denial
+                if (_httpContextAccessor.HttpContext is not null)
+                {
+                    _httpContextAccessor.HttpContext.Response.Headers[ApplicationErrorCodes.HeaderName] = ApplicationErrorCodes.ParentalControl;
+                }
+
+                // UserManager logs this for a login, but nothing did for a live session
+                _logger.LogInformation(
+                    "Request from {UserName} for {Path} is not allowed at this time due to parental restrictions",
+                    user.Username,
+                    _httpContextAccessor.HttpContext?.Request.Path.ToString() ?? "unknown");
+
                 context.Fail();
                 return Task.CompletedTask;
             }

--- a/Jellyfin.Api/Constants/ApplicationErrorCodes.cs
+++ b/Jellyfin.Api/Constants/ApplicationErrorCodes.cs
@@ -1,0 +1,18 @@
+namespace Jellyfin.Api.Constants
+{
+    /// <summary>
+    /// Values for the <c>X-Application-Error-Code</c> response header.
+    /// </summary>
+    public static class ApplicationErrorCodes
+    {
+        /// <summary>
+        /// The name of the response header carrying the error code.
+        /// </summary>
+        public const string HeaderName = "X-Application-Error-Code";
+
+        /// <summary>
+        /// The request was refused by parental control.
+        /// </summary>
+        public const string ParentalControl = "ParentalControl";
+    }
+}

--- a/Jellyfin.Api/Middleware/ExceptionMiddleware.cs
+++ b/Jellyfin.Api/Middleware/ExceptionMiddleware.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Mime;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
@@ -92,6 +93,12 @@ public class ExceptionMiddleware
             context.Response.StatusCode = GetStatusCode(ex);
             context.Response.ContentType = MediaTypeNames.Text.Plain;
 
+            // Let the client tell this apart from an ordinary permission denial
+            if (IsParentalControlRejection(ex))
+            {
+                context.Response.Headers[ApplicationErrorCodes.HeaderName] = ApplicationErrorCodes.ParentalControl;
+            }
+
             // Don't send exception unless the server is in a Development environment
             var errorContent = _hostEnvironment.IsDevelopment()
                     ? NormalizeExceptionMessage(ex.Message)
@@ -118,6 +125,20 @@ public class ExceptionMiddleware
         }
 
         return ex;
+    }
+
+    private static bool IsParentalControlRejection(Exception? ex)
+    {
+        // UserController rethrows a plain SecurityException to add the remote IP, losing the type
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is ParentalControlException)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static int GetStatusCode(Exception ex)

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -646,7 +646,7 @@ namespace Jellyfin.Server.Implementations.Users
                         "Authentication request for {UserName} is not allowed at this time due parental restrictions (IP: {IP}).",
                         username,
                         remoteEndPoint);
-                    throw new SecurityException("User is not allowed access at this time.");
+                    throw new ParentalControlException("User is not allowed access at this time.");
                 }
 
                 // Update LastActivityDate and LastLoginDate, then save

--- a/MediaBrowser.Controller/Net/ParentalControlException.cs
+++ b/MediaBrowser.Controller/Net/ParentalControlException.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace MediaBrowser.Controller.Net
+{
+    /// <summary>
+    /// The exception that is thrown when parental control refuses a request.
+    /// </summary>
+    public class ParentalControlException : SecurityException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        public ParentalControlException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public ParentalControlException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public ParentalControlException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/ParentalControlErrorCodeTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/ParentalControlErrorCodeTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
+using Jellyfin.Api.Constants;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
+{
+    public class ParentalControlErrorCodeTests
+    {
+        private readonly Mock<IConfigurationManager> _configurationManagerMock;
+        private readonly List<IAuthorizationRequirement> _requirements;
+        private readonly DefaultAuthorizationHandler _sut;
+        private readonly Mock<IUserManager> _userManagerMock;
+        private readonly Mock<IHttpContextAccessor> _httpContextAccessor;
+
+        private readonly AccessSchedule[] _disallowedSchedule = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 0, Guid.Empty) };
+
+        private readonly AccessSchedule[] _allowedSchedule = { new AccessSchedule(DynamicDayOfWeek.Everyday, 0, 24, Guid.Empty) };
+
+        public ParentalControlErrorCodeTests()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            _configurationManagerMock = fixture.Freeze<Mock<IConfigurationManager>>();
+            _requirements = new List<IAuthorizationRequirement> { new DefaultAuthorizationRequirement() };
+            _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
+            _httpContextAccessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
+
+            _sut = fixture.Create<DefaultAuthorizationHandler>();
+        }
+
+        [Fact]
+        public async Task ShouldSetErrorCodeHeaderWhenOutsideAccessSchedule()
+        {
+            var (httpContext, claims) = SetupHandler(UserRoles.User, _disallowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.False(context.HasSucceeded);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                httpContext.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task ShouldLogTheReasonWhenOutsideAccessSchedule()
+        {
+            var logger = new CollectingLogger();
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            fixture.Inject<ILogger<DefaultAuthorizationHandler>>(logger);
+            var configurationManager = fixture.Freeze<Mock<IConfigurationManager>>();
+            var userManager = fixture.Freeze<Mock<IUserManager>>();
+            var accessor = fixture.Freeze<Mock<IHttpContextAccessor>>();
+            var sut = fixture.Create<DefaultAuthorizationHandler>();
+
+            TestHelpers.SetupConfigurationManager(configurationManager, true);
+            var claims = TestHelpers.SetupUser(userManager, accessor, UserRoles.User, _disallowedSchedule);
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = new IPAddress(0);
+            httpContext.Request.Path = "/Sessions/Playing/Progress";
+            accessor.Setup(h => h.HttpContext).Returns(httpContext);
+
+            await sut.HandleAsync(new AuthorizationHandlerContext(_requirements, claims, null));
+
+            Assert.Contains(logger.Messages, m => m.Contains("parental restrictions", StringComparison.Ordinal));
+            Assert.Contains(logger.Messages, m => m.Contains("/Sessions/Playing/Progress", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task ShouldNotSetErrorCodeHeaderWhenInsideAccessSchedule()
+        {
+            var (httpContext, claims) = SetupHandler(UserRoles.User, _allowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+            Assert.False(httpContext.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        [Fact]
+        public async Task ShouldNotSetErrorCodeHeaderForAdministrator()
+        {
+            var (httpContext, claims) = SetupHandler(UserRoles.Administrator, _disallowedSchedule);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+            Assert.False(httpContext.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        private (DefaultHttpContext HttpContext, ClaimsPrincipal Claims) SetupHandler(string role, AccessSchedule[] schedules)
+        {
+            TestHelpers.SetupConfigurationManager(_configurationManagerMock, true);
+            var claims = TestHelpers.SetupUser(_userManagerMock, _httpContextAccessor, role, schedules);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.Connection.RemoteIpAddress = new IPAddress(0);
+            _httpContextAccessor.Setup(h => h.HttpContext).Returns(httpContext);
+
+            return (httpContext, claims);
+        }
+
+        private sealed class CollectingLogger : ILogger<DefaultAuthorizationHandler>
+        {
+            public List<string> Messages { get; } = new();
+
+            public IDisposable? BeginScope<TState>(TState state)
+                where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+                => Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Middleware/ExceptionMiddlewareTests.cs
+++ b/tests/Jellyfin.Api.Tests/Middleware/ExceptionMiddlewareTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Jellyfin.Api.Constants;
+using Jellyfin.Api.Middleware;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Middleware
+{
+    public class ExceptionMiddlewareTests
+    {
+        [Fact]
+        public async Task ParentalControlExceptionSetsErrorCodeHeader()
+        {
+            var context = await InvokeWith(new ParentalControlException("User is not allowed access at this time."));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                context.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task WrappedParentalControlExceptionSetsErrorCodeHeader()
+        {
+            // UserController rethrows a plain SecurityException to add the remote IP
+            var inner = new ParentalControlException("User is not allowed access at this time.");
+            var context = await InvokeWith(new SecurityException("[127.0.0.1] User is not allowed access at this time.", inner));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.Equal(
+                ApplicationErrorCodes.ParentalControl,
+                context.Response.Headers[ApplicationErrorCodes.HeaderName].ToString());
+        }
+
+        [Fact]
+        public async Task PlainSecurityExceptionDoesNotSetErrorCodeHeader()
+        {
+            var context = await InvokeWith(new SecurityException("Forbidden."));
+
+            Assert.Equal((int)HttpStatusCode.Forbidden, context.Response.StatusCode);
+            Assert.False(context.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        [Fact]
+        public async Task UnrelatedExceptionDoesNotSetErrorCodeHeader()
+        {
+            var context = await InvokeWith(new ArgumentException("bad argument"));
+
+            Assert.Equal((int)HttpStatusCode.BadRequest, context.Response.StatusCode);
+            Assert.False(context.Response.Headers.ContainsKey(ApplicationErrorCodes.HeaderName));
+        }
+
+        private static async Task<DefaultHttpContext> InvokeWith(Exception exception)
+        {
+            var configurationManager = new Mock<IServerConfigurationManager>();
+            configurationManager
+                .Setup(c => c.ApplicationPaths)
+                .Returns(Mock.Of<IServerApplicationPaths>());
+
+            var hostEnvironment = new Mock<IWebHostEnvironment>();
+            hostEnvironment.Setup(h => h.EnvironmentName).Returns("Production");
+
+            var sut = new ExceptionMiddleware(
+                _ => throw exception,
+                NullLogger<ExceptionMiddleware>.Instance,
+                configurationManager.Object,
+                hostEnvironment.Object);
+
+            var context = new DefaultHttpContext();
+            context.Response.Body = new MemoryStream();
+
+            await sut.Invoke(context);
+
+            return context;
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
@@ -6,8 +6,11 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Api.Models.UserDtos;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Users;
 using Xunit;
 using Xunit.v3.Priority;
 
@@ -33,6 +36,9 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
         private Task<HttpResponseMessage> UpdateUserPassword(HttpClient httpClient, Guid userId, UpdateUserPassword request)
             => httpClient.PostAsJsonAsync("Users/" + userId.ToString("N", CultureInfo.InvariantCulture) + "/Password", request, _jsonOptions);
+
+        private Task<HttpResponseMessage> UpdateUserPolicy(HttpClient httpClient, Guid userId, UserPolicy policy)
+            => httpClient.PostAsJsonAsync("Users/" + userId.ToString("N", CultureInfo.InvariantCulture) + "/Policy", policy, _jsonOptions);
 
         [Fact]
         [Priority(-1)]
@@ -190,6 +196,44 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
             // Sanity check, make sure we're testing something
             Assert.NotEqual(TestUsername, userDto.Name);
+        }
+
+        [Fact]
+        [Priority(3)]
+        public async Task AuthenticateUserByName_OutsideAccessSchedule_ReturnsParentalControlErrorCode()
+        {
+            var adminClient = _factory.CreateClient();
+            adminClient.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(adminClient));
+
+            const string Username = "parentalScheduleUser";
+            const string Password = "d0ntL3tM31n";
+
+            using var createResponse = await CreateUserByName(
+                adminClient,
+                new CreateUserByName { Name = Username, Password = Password });
+            Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+
+            var user = await createResponse.Content.ReadFromJsonAsync<UserDto>(_jsonOptions, TestContext.Current.CancellationToken);
+            Assert.NotNull(user);
+
+            // A schedule that only permits access tomorrow leaves the user blocked for the whole of today.
+            var tomorrow = (DynamicDayOfWeek)(((int)DateTime.Now.DayOfWeek + 1) % 7);
+            user.Policy.AccessSchedules = new[] { new AccessSchedule(tomorrow, 0, 24, user.Id) };
+
+            using var policyResponse = await UpdateUserPolicy(adminClient, user.Id, user.Policy);
+            Assert.Equal(HttpStatusCode.NoContent, policyResponse.StatusCode);
+
+            var client = _factory.CreateClient();
+            client.DefaultRequestHeaders.TryAddWithoutValidation(AuthHelper.AuthHeaderName, AuthHelper.DummyAuthHeader);
+
+            using var authResponse = await client.PostAsJsonAsync(
+                "Users/AuthenticateByName",
+                new AuthenticateUserByName { Username = Username, Pw = Password },
+                _jsonOptions,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Forbidden, authResponse.StatusCode);
+            Assert.Equal("ParentalControl", Assert.Single(authResponse.Headers.GetValues("X-Application-Error-Code")));
         }
     }
 }


### PR DESCRIPTION
## Changes

Trying to get the client to more clearly communicate when the parental controls prevent a user from continuing their session. This is existing header, just need it to pass clearly to the client side. `UserManager` throws a new `ParentalControlException` so the middleware can identify the cause rather than matching on a message string.

New log line:
```
[INF] DefaultAuthorizationHandler: Request from viewer for /Sessions/Playing/Progress is not allowed at this time due to parental restrictions
```

## Code assistance

I use Claude Opus and Sonnet to draft code and test coverage. Personally wrote this body and direct communication  to comply with LLM rules in repo.

## Issues

somewhat related to these:
#12808
#15033
#7930
They went stale and got closed.
