### PR TITLE
Enforce reliable processing order in PeopleValidationTask

### DIFF
--- a/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
+++ b/Emby.Server.Implementations/ScheduledTasks/Tasks/PeopleValidationTask.cs
@@ -109,6 +109,8 @@ public class PeopleValidationTask : IScheduledTask, IConfigurableScheduledTask
             var dupQuery = context.Peoples
                     .GroupBy(e => new { e.Name, e.PersonType })
                     .Where(e => e.Count() > 1)
+                    .OrderBy(e => e.Key.Name)
+                    .ThenBy(e => e.Key.PersonType)
                     .Select(e => e.Select(f => f.Id).ToArray());
 
             var total = dupQuery.Count();


### PR DESCRIPTION
Without this, Efcore prints a warning every time the task is run

**Changes**
Enforce reliable processing order in PeopleValidationTask

**Code assistance**
None

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
