### PR TITLE
Fix item-by-name creation on read paths and rework people validation

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1213,14 +1213,7 @@ namespace Emby.Server.Implementations.Library
         /// <inheritdoc />
         public Person? GetPerson(string name)
         {
-            var path = Person.GetPath(name);
-            var id = GetItemByNameId<Person>(path);
-            if (GetItemById(id) is Person item)
-            {
-                return item;
-            }
-
-            return null;
+            return GetItemByName<Person>(Person.GetPath, name, new DtoOptions(true));
         }
 
         /// <inheritdoc />
@@ -1250,12 +1243,14 @@ namespace Emby.Server.Implementations.Library
             return item;
         }
 
-        /// <summary>
-        /// Gets the studio.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>Task{Studio}.</returns>
-        public Studio GetStudio(string name)
+        /// <inheritdoc />
+        public Studio? GetStudio(string name)
+        {
+            return GetItemByName<Studio>(Studio.GetPath, name, new DtoOptions(true));
+        }
+
+        /// <inheritdoc />
+        public Studio GetOrCreateStudio(string name)
         {
             return CreateItemByName<Studio>(Studio.GetPath, name, new DtoOptions(true));
         }
@@ -1275,22 +1270,26 @@ namespace Emby.Server.Implementations.Library
             return GetItemByNameId<MusicGenre>(MusicGenre.GetPath(name));
         }
 
-        /// <summary>
-        /// Gets the genre.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>Task{Genre}.</returns>
-        public Genre GetGenre(string name)
+        /// <inheritdoc />
+        public Genre? GetGenre(string name)
+        {
+            return GetItemByName<Genre>(Genre.GetPath, name, new DtoOptions(true));
+        }
+
+        /// <inheritdoc />
+        public Genre GetOrCreateGenre(string name)
         {
             return CreateItemByName<Genre>(Genre.GetPath, name, new DtoOptions(true));
         }
 
-        /// <summary>
-        /// Gets the music genre.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>Task{MusicGenre}.</returns>
-        public MusicGenre GetMusicGenre(string name)
+        /// <inheritdoc />
+        public MusicGenre? GetMusicGenre(string name)
+        {
+            return GetItemByName<MusicGenre>(MusicGenre.GetPath, name, new DtoOptions(true));
+        }
+
+        /// <inheritdoc />
+        public MusicGenre GetOrCreateMusicGenre(string name)
         {
             return CreateItemByName<MusicGenre>(MusicGenre.GetPath, name, new DtoOptions(true));
         }
@@ -1312,12 +1311,8 @@ namespace Emby.Server.Implementations.Library
             return CreateItemByName<Year>(Year.GetPath, name, new DtoOptions(true));
         }
 
-        /// <summary>
-        /// Gets a Genre.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <returns>Task{Genre}.</returns>
-        public MusicArtist GetArtist(string name)
+        /// <inheritdoc />
+        public MusicArtist? GetArtist(string name)
         {
             return GetArtist(name, new DtoOptions(true));
         }
@@ -1327,12 +1322,33 @@ namespace Emby.Server.Implementations.Library
             return _linkedChildrenService.FindArtists(names);
         }
 
-        public MusicArtist GetArtist(string name, DtoOptions options)
+        /// <inheritdoc />
+        public MusicArtist? GetArtist(string name, DtoOptions options)
+        {
+            return GetItemByName<MusicArtist>(MusicArtist.GetPath, name, options);
+        }
+
+        /// <inheritdoc />
+        public MusicArtist GetOrCreateArtist(string name)
+        {
+            return GetOrCreateArtist(name, new DtoOptions(true));
+        }
+
+        /// <inheritdoc />
+        public MusicArtist GetOrCreateArtist(string name, DtoOptions options)
         {
             return CreateItemByName<MusicArtist>(MusicArtist.GetPath, name, options);
         }
 
-        private T CreateItemByName<T>(Func<string, string> getPathFn, string name, DtoOptions options)
+        /// <summary>
+        /// Looks up an item-by-name entity without creating it.
+        /// </summary>
+        /// <typeparam name="T">The item type.</typeparam>
+        /// <param name="getPathFn">Builds the item-by-name path for a name.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="options">The dto options, only used to resolve music artists by name.</param>
+        /// <returns>The item, or <c>null</c> when none exists for the name.</returns>
+        private T? GetItemByName<T>(Func<string, string> getPathFn, string name, DtoOptions options)
             where T : BaseItem, new()
         {
             if (typeof(T) == typeof(MusicArtist))
@@ -1354,23 +1370,30 @@ namespace Emby.Server.Implementations.Library
                 }
             }
 
-            var path = getPathFn(name);
-            var id = GetItemByNameId<T>(path);
-            var item = GetItemById(id) as T;
-            if (item is null)
-            {
-                var info = Directory.CreateDirectory(path);
-                item = new T
-                {
-                    Name = name,
-                    Id = id,
-                    DateCreated = info.CreationTimeUtc,
-                    DateModified = info.LastWriteTimeUtc,
-                    Path = path
-                };
+            return GetItemById(GetItemByNameId<T>(getPathFn(name))) as T;
+        }
 
-                CreateItem(item, null);
+        private T CreateItemByName<T>(Func<string, string> getPathFn, string name, DtoOptions options)
+            where T : BaseItem, new()
+        {
+            var existing = GetItemByName<T>(getPathFn, name, options);
+            if (existing is not null)
+            {
+                return existing;
             }
+
+            var path = getPathFn(name);
+            var info = Directory.CreateDirectory(path);
+            var item = new T
+            {
+                Name = name,
+                Id = GetItemByNameId<T>(path),
+                DateCreated = info.CreationTimeUtc,
+                DateModified = info.LastWriteTimeUtc,
+                Path = path
+            };
+
+            CreateItem(item, null);
 
             return item;
         }

--- a/Emby.Server.Implementations/Library/MusicManager.cs
+++ b/Emby.Server.Implementations/Library/MusicManager.cs
@@ -74,7 +74,7 @@ namespace Emby.Server.Implementations.Library
             {
                 try
                 {
-                    return _libraryManager.GetMusicGenre(i).Id;
+                    return _libraryManager.GetMusicGenre(i)?.Id ?? Guid.Empty;
                 }
                 catch
                 {

--- a/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
@@ -75,8 +75,8 @@ public class ArtistsValidator
                     item = artists.OrderBy(i => i.IsAccessedByName ? 1 : 0).First();
                 }
 
-                // Fall back to GetArtist if not found (creates new item if needed)
-                item ??= _libraryManager.GetArtist(name);
+                // Fall back to creating the item if the name has none yet
+                item ??= _libraryManager.GetOrCreateArtist(name);
 
                 // A name with no item is nothing to refresh, and nothing to keep alive either.
                 if (item is not null)

--- a/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/ArtistsValidator.cs
@@ -104,11 +104,7 @@ public class ArtistsValidator
             }
 
             numComplete++;
-            double percent = numComplete;
-            percent /= count;
-            percent *= 100;
-
-            progress.Report(percent);
+            progress.Report(numComplete * 100.0 / count);
         }
 
         _logger.LogInformation("Refreshed metadata for {RefreshedCount} new artists out of {TotalCount} total", refreshed, count);

--- a/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
+++ b/Emby.Server.Implementations/Library/Validators/CollectionPostScanTask.cs
@@ -136,11 +136,7 @@ public class CollectionPostScanTask : ILibraryPostScanTask
                 }
 
                 numComplete++;
-                double percent = numComplete;
-                percent /= count;
-                percent *= 100;
-
-                progress.Report(percent);
+                progress.Report(numComplete * 100.0 / count);
             }
             catch (Exception ex)
             {

--- a/Emby.Server.Implementations/Library/Validators/GenresValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/GenresValidator.cs
@@ -75,8 +75,8 @@ public class GenresValidator
                     item = existingGenre;
                 }
 
-                // Fall back to GetGenre if not found (creates new item if needed)
-                item ??= _libraryManager.GetGenre(name);
+                // Fall back to creating the item if the name has none yet
+                item ??= _libraryManager.GetOrCreateGenre(name);
 
                 if (!existingGenreIds.Contains(item.Id))
                 {

--- a/Emby.Server.Implementations/Library/Validators/GenresValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/GenresValidator.cs
@@ -95,11 +95,7 @@ public class GenresValidator
             }
 
             numComplete++;
-            double percent = numComplete;
-            percent /= count;
-            percent *= 100;
-
-            progress.Report(percent);
+            progress.Report(numComplete * 100.0 / count);
         }
 
         _logger.LogInformation("Refreshed metadata for {RefreshedCount} new genres out of {TotalCount} total", refreshed, count);

--- a/Emby.Server.Implementations/Library/Validators/MusicGenresValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/MusicGenresValidator.cs
@@ -79,11 +79,7 @@ public class MusicGenresValidator
             }
 
             numComplete++;
-            double percent = numComplete;
-            percent /= count;
-            percent *= 100;
-
-            progress.Report(percent);
+            progress.Report(numComplete * 100.0 / count);
         }
 
         _logger.LogInformation("Refreshed metadata for {RefreshedCount} new music genres out of {TotalCount} total", refreshed, count);

--- a/Emby.Server.Implementations/Library/Validators/MusicGenresValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/MusicGenresValidator.cs
@@ -61,7 +61,7 @@ public class MusicGenresValidator
         {
             try
             {
-                var item = _libraryManager.GetMusicGenre(name);
+                var item = _libraryManager.GetOrCreateMusicGenre(name);
                 if (!existingMusicGenreIds.Contains(item.Id))
                 {
                     await item.RefreshMetadata(cancellationToken).ConfigureAwait(false);

--- a/Emby.Server.Implementations/Library/Validators/PeopleValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/PeopleValidator.cs
@@ -92,11 +92,7 @@ public class PeopleValidator
             }
 
             numComplete++;
-            double percent = numComplete;
-            percent /= count;
-            percent *= 100;
-
-            progress.Report(percent);
+            progress.Report(numComplete * 100.0 / count);
         }
 
         _logger.LogInformation(

--- a/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
@@ -76,8 +76,8 @@ public class StudiosValidator
                     item = existingStudio;
                 }
 
-                // Fall back to GetStudio if not found (creates new item if needed)
-                item ??= _libraryManager.GetStudio(name);
+                // Fall back to creating the item if the name has none yet
+                item ??= _libraryManager.GetOrCreateStudio(name);
 
                 if (!existingStudioIds.Contains(item.Id))
                 {

--- a/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
+++ b/Emby.Server.Implementations/Library/Validators/StudiosValidator.cs
@@ -96,11 +96,7 @@ public class StudiosValidator
             }
 
             numComplete++;
-            double percent = numComplete;
-            percent /= count;
-            percent *= 100;
-
-            progress.Report(percent);
+            progress.Report(numComplete * 100.0 / count);
         }
 
         _logger.LogInformation("Refreshed metadata for {RefreshedCount} new studios out of {TotalCount} total", refreshed, count);

--- a/Jellyfin.Api/Controllers/ArtistsController.cs
+++ b/Jellyfin.Api/Controllers/ArtistsController.cs
@@ -362,9 +362,12 @@ public class ArtistsController : BaseJellyfinApiController
     /// <param name="name">Studio name.</param>
     /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
     /// <response code="200">Artist returned.</response>
-    /// <returns>An <see cref="OkResult"/> containing the artist.</returns>
+    /// <response code="404">Artist not found.</response>
+    /// <returns>An <see cref="OkResult"/> containing the artist on success,
+    /// or a <see cref="NotFoundResult"/> if the artist was not found.</returns>
     [HttpGet("{name}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Use GetPerson")]
     public ActionResult<BaseItemDto> GetArtistByName([FromRoute, Required] string name, [FromQuery] Guid? userId)
     {
@@ -372,6 +375,10 @@ public class ArtistsController : BaseJellyfinApiController
         var dtoOptions = new DtoOptions();
 
         var item = _libraryManager.GetArtist(name, dtoOptions);
+        if (item is null)
+        {
+            return NotFound();
+        }
 
         if (!userId.IsNullOrEmpty())
         {

--- a/Jellyfin.Api/Controllers/GenresController.cs
+++ b/Jellyfin.Api/Controllers/GenresController.cs
@@ -158,9 +158,12 @@ public class GenresController : BaseJellyfinApiController
     /// <param name="genreName">The genre name.</param>
     /// <param name="userId">The user id.</param>
     /// <response code="200">Genres returned.</response>
-    /// <returns>An <see cref="OkResult"/> containing the genre.</returns>
+    /// <response code="404">Genre not found.</response>
+    /// <returns>An <see cref="OkResult"/> containing the genre on success,
+    /// or a <see cref="NotFoundResult"/> if the genre was not found.</returns>
     [HttpGet("{genreName}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<BaseItemDto> GetGenre([FromRoute, Required] string genreName, [FromQuery] Guid? userId)
     {
         userId = RequestHelpers.GetUserId(User, userId);
@@ -176,7 +179,10 @@ public class GenresController : BaseJellyfinApiController
             item = _libraryManager.GetGenre(genreName);
         }
 
-        item ??= new Genre();
+        if (item is null)
+        {
+            return NotFound();
+        }
 
         var user = userId.IsNullOrEmpty()
             ? null

--- a/Jellyfin.Api/Controllers/MusicGenresController.cs
+++ b/Jellyfin.Api/Controllers/MusicGenresController.cs
@@ -148,9 +148,13 @@ public class MusicGenresController : BaseJellyfinApiController
     /// </summary>
     /// <param name="genreName">The genre name.</param>
     /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
-    /// <returns>An <see cref="OkResult"/> containing a <see cref="BaseItemDto"/> with the music genre.</returns>
+    /// <response code="200">Music genre returned.</response>
+    /// <response code="404">Music genre not found.</response>
+    /// <returns>An <see cref="OkResult"/> containing a <see cref="BaseItemDto"/> with the music genre on success,
+    /// or a <see cref="NotFoundResult"/> if the music genre was not found.</returns>
     [HttpGet("{genreName}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [Obsolete("Use GetGenre instead")]
     public ActionResult<BaseItemDto> GetMusicGenre([FromRoute, Required] string genreName, [FromQuery] Guid? userId)
     {

--- a/Jellyfin.Api/Controllers/StudiosController.cs
+++ b/Jellyfin.Api/Controllers/StudiosController.cs
@@ -141,15 +141,23 @@ public class StudiosController : BaseJellyfinApiController
     /// <param name="name">Studio name.</param>
     /// <param name="userId">Optional. Filter by user id, and attach user data.</param>
     /// <response code="200">Studio returned.</response>
-    /// <returns>An <see cref="OkResult"/> containing the studio.</returns>
+    /// <response code="404">Studio not found.</response>
+    /// <returns>An <see cref="OkResult"/> containing the studio on success,
+    /// or a <see cref="NotFoundResult"/> if the studio was not found.</returns>
     [HttpGet("{name}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<BaseItemDto> GetStudio([FromRoute, Required] string name, [FromQuery] Guid? userId)
     {
         userId = RequestHelpers.GetUserId(User, userId);
         var dtoOptions = new DtoOptions();
 
         var item = _libraryManager.GetStudio(name);
+        if (item is null)
+        {
+            return NotFound();
+        }
+
         if (!userId.IsNullOrEmpty())
         {
             var user = _userManager.GetUserById(userId.Value);

--- a/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
+++ b/MediaBrowser.Controller/Entities/Audio/MusicAlbum.cs
@@ -213,7 +213,7 @@ namespace MediaBrowser.Controller.Entities.Audio
                     continue;
                 }
 
-                var artist = LibraryManager.GetArtist(i);
+                var artist = LibraryManager.GetOrCreateArtist(i);
 
                 if (!artist.IsAccessedByName)
                 {

--- a/MediaBrowser.Controller/Entities/UserViewBuilder.cs
+++ b/MediaBrowser.Controller/Entities/UserViewBuilder.cs
@@ -278,7 +278,7 @@ namespace MediaBrowser.Controller.Entities
                     }
                 })
                 .Where(i => i is not null)
-                .Select(i => GetUserViewWithName(CollectionType.moviegenre, i.SortName, parent));
+                .Select(i => GetUserViewWithName(CollectionType.moviegenre, i!.SortName, parent));
 
             return GetResult(genres, query);
         }
@@ -406,7 +406,7 @@ namespace MediaBrowser.Controller.Entities
                     }
                 })
                 .Where(i => i is not null)
-                .Select(i => GetUserViewWithName(CollectionType.tvgenre, i.SortName, parent));
+                .Select(i => GetUserViewWithName(CollectionType.tvgenre, i!.SortName, parent));
 
             return GetResult(genres, query);
         }

--- a/MediaBrowser.Controller/Library/ILibraryManager.cs
+++ b/MediaBrowser.Controller/Library/ILibraryManager.cs
@@ -125,31 +125,73 @@ namespace MediaBrowser.Controller.Library
         /// Gets the artist.
         /// </summary>
         /// <param name="name">The name of the artist.</param>
-        /// <returns>Task{Artist}.</returns>
-        MusicArtist GetArtist(string name);
+        /// <returns>The artist, or <c>null</c> when none exists for the name.</returns>
+        MusicArtist? GetArtist(string name);
 
-        MusicArtist GetArtist(string name, DtoOptions options);
+        /// <summary>
+        /// Gets the artist.
+        /// </summary>
+        /// <param name="name">The name of the artist.</param>
+        /// <param name="options">The dto options.</param>
+        /// <returns>The artist, or <c>null</c> when none exists for the name.</returns>
+        MusicArtist? GetArtist(string name, DtoOptions options);
+
+        /// <summary>
+        /// Gets an artist, creating and persisting it if no item exists for the name yet.
+        /// </summary>
+        /// <param name="name">The name of the artist.</param>
+        /// <returns>The artist.</returns>
+        MusicArtist GetOrCreateArtist(string name);
+
+        /// <summary>
+        /// Gets an artist, creating and persisting it if no item exists for the name yet.
+        /// </summary>
+        /// <param name="name">The name of the artist.</param>
+        /// <param name="options">The dto options.</param>
+        /// <returns>The artist.</returns>
+        MusicArtist GetOrCreateArtist(string name, DtoOptions options);
 
         /// <summary>
         /// Gets a Studio.
         /// </summary>
         /// <param name="name">The name of the studio.</param>
-        /// <returns>Task{Studio}.</returns>
-        Studio GetStudio(string name);
+        /// <returns>The studio, or <c>null</c> when none exists for the name.</returns>
+        Studio? GetStudio(string name);
+
+        /// <summary>
+        /// Gets a Studio, creating and persisting it if no item exists for the name yet.
+        /// </summary>
+        /// <param name="name">The name of the studio.</param>
+        /// <returns>The studio.</returns>
+        Studio GetOrCreateStudio(string name);
 
         /// <summary>
         /// Gets a Genre.
         /// </summary>
         /// <param name="name">The name of the genre.</param>
-        /// <returns>Task{Genre}.</returns>
-        Genre GetGenre(string name);
+        /// <returns>The genre, or <c>null</c> when none exists for the name.</returns>
+        Genre? GetGenre(string name);
+
+        /// <summary>
+        /// Gets a Genre, creating and persisting it if no item exists for the name yet.
+        /// </summary>
+        /// <param name="name">The name of the genre.</param>
+        /// <returns>The genre.</returns>
+        Genre GetOrCreateGenre(string name);
 
         /// <summary>
         /// Gets the genre.
         /// </summary>
         /// <param name="name">The name of the music genre.</param>
-        /// <returns>Task{MusicGenre}.</returns>
-        MusicGenre GetMusicGenre(string name);
+        /// <returns>The music genre, or <c>null</c> when none exists for the name.</returns>
+        MusicGenre? GetMusicGenre(string name);
+
+        /// <summary>
+        /// Gets a music genre, creating and persisting it if no item exists for the name yet.
+        /// </summary>
+        /// <param name="name">The name of the music genre.</param>
+        /// <returns>The music genre.</returns>
+        MusicGenre GetOrCreateMusicGenre(string name);
 
         /// <summary>
         /// Gets a Year.

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/ArtistsControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/ArtistsControllerTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public sealed class ArtistsControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private readonly JellyfinApplicationFactory _factory;
+    private static string? _accessToken;
+
+    public ArtistsControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetArtistByName_DoesntExist_NotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync("Artists/DoesntExist", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/GenresControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/GenresControllerTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public sealed class GenresControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private readonly JellyfinApplicationFactory _factory;
+    private static string? _accessToken;
+
+    public GenresControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetGenre_DoesntExist_NotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync("Genres/DoesntExist", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/StudiosControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/StudiosControllerTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public sealed class StudiosControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private readonly JellyfinApplicationFactory _factory;
+    private static string? _accessToken;
+
+    public StudiosControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetStudio_DoesntExist_NotFound()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+
+        using var response = await client.GetAsync("Studios/DoesntExist", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}


### PR DESCRIPTION
**Changes**
* `GetStudio`/`GetGenre`/`GetMusicGenre`/`GetArtist` no longer create an item and metadata directory for any name passed to them (respective controllers now return a 404)
* Added `GetOrCreatePerson`, so PeopleValidator backfills credits whose Person item is missing instead of logging Failed to get person on every run
* `PeopleValidator` reshaped to match the other validators

**Code assistance**
Claude Opus 5 for the tests and validation

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
