### PR TITLE
Fix UI stalls caused by large tag and genre sets

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.ByName.cs
@@ -121,20 +121,22 @@ public sealed partial class BaseItemRepository
     {
         using var context = _dbProvider.CreateDbContext();
 
-        var query = context.ItemValuesMap
-            .AsNoTracking()
-            .Where(e => itemValueTypes.Any(w => w == e.ItemValue.Type));
+        var maps = context.ItemValuesMap.AsNoTracking();
         if (withItemTypes.Count > 0)
         {
-            query = query.Where(e => withItemTypes.Contains(e.Item.Type));
+            maps = maps.Where(e => withItemTypes.Contains(e.Item.Type));
         }
 
         if (excludeItemTypes.Count > 0)
         {
-            query = query.Where(e => !excludeItemTypes.Contains(e.Item.Type));
+            maps = maps.Where(e => !excludeItemTypes.Contains(e.Item.Type));
         }
 
-        return query.Select(e => e.ItemValue)
+        return context.ItemValues
+            .AsNoTracking()
+            .WhereOneOrMany(itemValueTypes, e => e.Type)
+            .Where(e => maps.Any(m => m.ItemValueId == e.ItemValueId))
+            .Select(e => new { e.CleanValue, e.Value })
             .GroupBy(e => e.CleanValue)
             .Select(g => g.Min(v => v.Value)!)
             .ToArray();

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.Querying.cs
@@ -626,18 +626,26 @@ public sealed partial class BaseItemRepository
             .ToArray();
 
         var tags = context.ItemValuesMap
-            .Where(ivm => ivm.ItemValue.Type == ItemValueType.Tags)
-            .Where(ivm => matchingItemIds.Contains(ivm.ItemId))
-            .Select(ivm => ivm.ItemValue)
+            .Join(
+                context.ItemValues,
+                ivm => ivm.ItemValueId,
+                iv => iv.ItemValueId,
+                (ivm, iv) => new { ivm.ItemId, iv.Type, iv.CleanValue, iv.Value })
+            .Where(iv => iv.Type == ItemValueType.Tags)
+            .Where(iv => matchingItemIds.Contains(iv.ItemId))
             .GroupBy(iv => iv.CleanValue)
             .Select(g => g.Min(iv => iv.Value))
             .OrderBy(t => t)
             .ToArray();
 
         var genres = context.ItemValuesMap
-            .Where(ivm => ivm.ItemValue.Type == ItemValueType.Genre)
-            .Where(ivm => matchingItemIds.Contains(ivm.ItemId))
-            .Select(ivm => ivm.ItemValue)
+            .Join(
+                context.ItemValues,
+                ivm => ivm.ItemValueId,
+                iv => iv.ItemValueId,
+                (ivm, iv) => new { ivm.ItemId, iv.Type, iv.CleanValue, iv.Value })
+            .Where(iv => iv.Type == ItemValueType.Genre)
+            .Where(iv => matchingItemIds.Contains(iv.ItemId))
             .GroupBy(iv => iv.CleanValue)
             .Select(g => g.Min(iv => iv.Value))
             .OrderBy(g => g)

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryItemValueTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryItemValueTests.cs
@@ -8,13 +8,13 @@ using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
 
 namespace Jellyfin.Server.Implementations.Tests.Item;
 
-public sealed class BaseItemRepositoryLegacyFilterTests : SqliteDbTestFixture
+public sealed class BaseItemRepositoryItemValueTests : SqliteDbTestFixture
 {
     private readonly BaseItemRepository _repository;
     private readonly string _audioTypeName;
     private readonly string _movieTypeName;
 
-    public BaseItemRepositoryLegacyFilterTests()
+    public BaseItemRepositoryItemValueTests()
     {
         var itemTypeLookup = new ItemTypeLookup();
         _audioTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Audio];
@@ -103,6 +103,39 @@ public sealed class BaseItemRepositoryLegacyFilterTests : SqliteDbTestFixture
         Assert.Equal(["Genre Leak"], result.Genres);
     }
 
+    [Fact]
+    public void GetGenreNames_GroupsAndFiltersMappedItemValues()
+    {
+        var movie = CreateMovieEntity(Guid.NewGuid(), "Movie");
+        var audio = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = _audioTypeName,
+            Name = "Audio",
+            MediaType = "Audio",
+            IsFolder = false,
+            IsVirtualItem = false
+        };
+        var movieGenre = CreateItemValue(ItemValueType.Genre, "Movie Genre", "movie genre");
+        var duplicateMovieGenre = CreateItemValue(ItemValueType.Genre, "movie genre", "movie genre");
+        var musicGenre = CreateItemValue(ItemValueType.Genre, "Music Genre", "music genre");
+        var orphanedGenre = CreateItemValue(ItemValueType.Genre, "Orphaned Genre", "orphaned genre");
+
+        using (var context = CreateDbContext())
+        {
+            context.BaseItems.AddRange(movie, audio);
+            context.ItemValues.AddRange(movieGenre, duplicateMovieGenre, musicGenre, orphanedGenre);
+            context.ItemValuesMap.AddRange(
+                CreateMap(movie, movieGenre),
+                CreateMap(movie, duplicateMovieGenre),
+                CreateMap(audio, musicGenre));
+            context.SaveChanges();
+        }
+
+        Assert.Equal(["Movie Genre"], _repository.GetGenreNames());
+        Assert.Equal(["Music Genre"], _repository.GetMusicGenreNames());
+    }
+
     private BaseItemEntity CreateMovieEntity(Guid id, string name)
     {
         return new BaseItemEntity
@@ -125,6 +158,17 @@ public sealed class BaseItemRepositoryLegacyFilterTests : SqliteDbTestFixture
             ItemValueId = itemValue.ItemValueId,
             Item = item,
             ItemValue = itemValue
+        };
+    }
+
+    private static ItemValue CreateItemValue(ItemValueType type, string value, string cleanValue)
+    {
+        return new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = type,
+            Value = value,
+            CleanValue = cleanValue
         };
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class BaseItemRepositoryLegacyFilterTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
+    private readonly CommandRecordingInterceptor _interceptor = new();
+    private readonly BaseItemRepository _repository;
+    private readonly string _audioTypeName;
+    private readonly string _movieTypeName;
+
+    public BaseItemRepositoryLegacyFilterTests()
+    {
+        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(_interceptor)
+            .Options;
+
+        using (var context = CreateDbContext())
+        {
+            context.Database.EnsureCreated();
+        }
+
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
+
+        var itemTypeLookup = new ItemTypeLookup();
+        _audioTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Audio];
+        _movieTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Movie];
+
+        var serverConfigurationManager = new Mock<IServerConfigurationManager>();
+        serverConfigurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+
+        _repository = new BaseItemRepository(
+            factory.Object,
+            new Mock<IServerApplicationHost>().Object,
+            itemTypeLookup,
+            serverConfigurationManager.Object,
+            NullLogger<BaseItemRepository>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    // Verifies eligible tags and genres retain normalized result semantics with one direct ItemValues join.
+    [Fact]
+    public void GetQueryFiltersLegacy_ItemValues_GroupByCleanValueWithOneItemValuesJoin()
+    {
+        var firstItem = CreateMovieEntity(Guid.NewGuid(), "First");
+        var secondItem = CreateMovieEntity(Guid.NewGuid(), "Second");
+        var excludedItem = new BaseItemEntity
+        {
+            Id = Guid.NewGuid(),
+            Type = _audioTypeName,
+            Name = "Excluded Audio",
+            MediaType = "Audio",
+            IsMovie = false,
+            IsFolder = false,
+            IsVirtualItem = false
+        };
+        var firstTag = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Tags,
+            Value = "Alpha",
+            CleanValue = "alpha"
+        };
+        var duplicateTag = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Tags,
+            Value = "alpha",
+            CleanValue = "alpha"
+        };
+        var secondTag = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Tags,
+            Value = "Beta",
+            CleanValue = "beta"
+        };
+        var genre = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Genre,
+            Value = "Genre Leak",
+            CleanValue = "genre leak"
+        };
+        var excludedTag = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Tags,
+            Value = "Excluded Tag",
+            CleanValue = "excluded tag"
+        };
+        var excludedGenre = new ItemValue
+        {
+            ItemValueId = Guid.NewGuid(),
+            Type = ItemValueType.Genre,
+            Value = "Excluded Genre",
+            CleanValue = "excluded genre"
+        };
+
+        using (var context = CreateDbContext())
+        {
+            context.BaseItems.AddRange(firstItem, secondItem, excludedItem);
+            context.ItemValues.AddRange(firstTag, duplicateTag, secondTag, genre, excludedTag, excludedGenre);
+            context.ItemValuesMap.AddRange(
+                CreateMap(firstItem, firstTag),
+                CreateMap(firstItem, duplicateTag),
+                CreateMap(secondItem, secondTag),
+                CreateMap(firstItem, genre),
+                CreateMap(excludedItem, excludedTag),
+                CreateMap(excludedItem, excludedGenre));
+            context.SaveChanges();
+        }
+
+        var result = _repository.GetQueryFiltersLegacy(new InternalItemsQuery(new Database.Implementations.Entities.User("test", "auth", "reset"))
+        {
+            IncludeItemTypes = [BaseItemKind.Movie]
+        });
+
+        Assert.Equal(["Alpha", "Beta"], result.Tags);
+        Assert.Equal(["Genre Leak"], result.Genres);
+        var tagsCommand = Assert.Single(
+            _interceptor.Commands,
+            command => command.Contains("GROUP BY", StringComparison.Ordinal)
+                && command.Contains("\"Type\" = 4", StringComparison.Ordinal));
+        var genresCommand = Assert.Single(
+            _interceptor.Commands,
+            command => command.Contains("GROUP BY", StringComparison.Ordinal)
+                && command.Contains("\"Type\" = 2", StringComparison.Ordinal));
+        Assert.Equal(1, CountOccurrences(tagsCommand, "INNER JOIN \"ItemValues\""));
+        Assert.DoesNotContain("SELECT (", tagsCommand, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(genresCommand, "INNER JOIN \"ItemValues\""));
+        Assert.DoesNotContain("SELECT (", genresCommand, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string value, string pattern)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(pattern, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += pattern.Length;
+        }
+
+        return count;
+    }
+
+    private BaseItemEntity CreateMovieEntity(Guid id, string name)
+    {
+        return new BaseItemEntity
+        {
+            Id = id,
+            Type = _movieTypeName,
+            Name = name,
+            MediaType = "Video",
+            IsMovie = true,
+            IsFolder = false,
+            IsVirtualItem = false
+        };
+    }
+
+    private static ItemValueMap CreateMap(BaseItemEntity item, ItemValue itemValue)
+    {
+        return new ItemValueMap
+        {
+            ItemId = item.Id,
+            ItemValueId = itemValue.ItemValueId,
+            Item = item,
+            ItemValue = itemValue
+        };
+    }
+
+    private JellyfinDbContext CreateDbContext()
+    {
+        return new JellyfinDbContext(
+            _dbOptions,
+            NullLogger<JellyfinDbContext>.Instance,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
+            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+    }
+
+    private sealed class CommandRecordingInterceptor : DbCommandInterceptor
+    {
+        public List<string> Commands { get; } = [];
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Commands.Add(command.CommandText);
+            return result;
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
@@ -1,78 +1,29 @@
 using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
 using Emby.Server.Implementations.Data;
-using Jellyfin.Database.Implementations;
 using Jellyfin.Database.Implementations.Entities;
-using Jellyfin.Database.Implementations.Locking;
-using Jellyfin.Database.Providers.Sqlite;
 using Jellyfin.Server.Implementations.Item;
-using MediaBrowser.Controller;
-using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Model.Configuration;
-using MediaBrowser.Model.Entities;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Xunit;
 using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
 
 namespace Jellyfin.Server.Implementations.Tests.Item;
 
-public sealed class BaseItemRepositoryLegacyFilterTests : IDisposable
+public sealed class BaseItemRepositoryLegacyFilterTests : SqliteDbTestFixture
 {
-    private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
-    private readonly CommandRecordingInterceptor _interceptor = new();
     private readonly BaseItemRepository _repository;
     private readonly string _audioTypeName;
     private readonly string _movieTypeName;
 
     public BaseItemRepositoryLegacyFilterTests()
     {
-        _connection = new SqliteConnection("Data Source=:memory:");
-        _connection.Open();
-
-        _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
-            .UseSqlite(_connection)
-            .AddInterceptors(_interceptor)
-            .Options;
-
-        using (var context = CreateDbContext())
-        {
-            context.Database.EnsureCreated();
-        }
-
-        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
-        factory.Setup(f => f.CreateDbContext()).Returns(CreateDbContext);
-
         var itemTypeLookup = new ItemTypeLookup();
         _audioTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Audio];
         _movieTypeName = itemTypeLookup.BaseItemKindNames[BaseItemKind.Movie];
-
-        var serverConfigurationManager = new Mock<IServerConfigurationManager>();
-        serverConfigurationManager.Setup(c => c.Configuration).Returns(new ServerConfiguration());
-
-        _repository = new BaseItemRepository(
-            factory.Object,
-            new Mock<IServerApplicationHost>().Object,
-            itemTypeLookup,
-            serverConfigurationManager.Object,
-            NullLogger<BaseItemRepository>.Instance);
+        _repository = CreateBaseItemRepository(itemTypeLookup);
     }
 
-    public void Dispose()
-    {
-        _connection.Dispose();
-    }
-
-    // Verifies eligible tags and genres retain normalized result semantics with one direct ItemValues join.
     [Fact]
-    public void GetQueryFiltersLegacy_ItemValues_GroupByCleanValueWithOneItemValuesJoin()
+    public void GetQueryFiltersLegacy_GroupsAndFiltersItemValues()
     {
         var firstItem = CreateMovieEntity(Guid.NewGuid(), "First");
         var secondItem = CreateMovieEntity(Guid.NewGuid(), "Second");
@@ -150,31 +101,6 @@ public sealed class BaseItemRepositoryLegacyFilterTests : IDisposable
 
         Assert.Equal(["Alpha", "Beta"], result.Tags);
         Assert.Equal(["Genre Leak"], result.Genres);
-        var itemValueCommands = _interceptor.Commands
-            .Where(command => command.Contains("GROUP BY", StringComparison.Ordinal)
-                && command.Contains("INNER JOIN \"ItemValues\"", StringComparison.Ordinal))
-            .ToArray();
-
-        Assert.Equal(2, itemValueCommands.Length);
-
-        foreach (var command in itemValueCommands)
-        {
-            Assert.Equal(1, CountOccurrences(command, "INNER JOIN \"ItemValues\""));
-            Assert.DoesNotContain("SELECT (SELECT", command, StringComparison.Ordinal);
-        }
-    }
-
-    private static int CountOccurrences(string value, string pattern)
-    {
-        var count = 0;
-        var index = 0;
-        while ((index = value.IndexOf(pattern, index, StringComparison.Ordinal)) >= 0)
-        {
-            count++;
-            index += pattern.Length;
-        }
-
-        return count;
     }
 
     private BaseItemEntity CreateMovieEntity(Guid id, string name)
@@ -200,28 +126,5 @@ public sealed class BaseItemRepositoryLegacyFilterTests : IDisposable
             Item = item,
             ItemValue = itemValue
         };
-    }
-
-    private JellyfinDbContext CreateDbContext()
-    {
-        return new JellyfinDbContext(
-            _dbOptions,
-            NullLogger<JellyfinDbContext>.Instance,
-            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
-            new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
-    }
-
-    private sealed class CommandRecordingInterceptor : DbCommandInterceptor
-    {
-        public List<string> Commands { get; } = [];
-
-        public override InterceptionResult<DbDataReader> ReaderExecuting(
-            DbCommand command,
-            CommandEventData eventData,
-            InterceptionResult<DbDataReader> result)
-        {
-            Commands.Add(command.CommandText);
-            return result;
-        }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryLegacyFilterTests.cs
@@ -150,18 +150,18 @@ public sealed class BaseItemRepositoryLegacyFilterTests : IDisposable
 
         Assert.Equal(["Alpha", "Beta"], result.Tags);
         Assert.Equal(["Genre Leak"], result.Genres);
-        var tagsCommand = Assert.Single(
-            _interceptor.Commands,
-            command => command.Contains("GROUP BY", StringComparison.Ordinal)
-                && command.Contains("\"Type\" = 4", StringComparison.Ordinal));
-        var genresCommand = Assert.Single(
-            _interceptor.Commands,
-            command => command.Contains("GROUP BY", StringComparison.Ordinal)
-                && command.Contains("\"Type\" = 2", StringComparison.Ordinal));
-        Assert.Equal(1, CountOccurrences(tagsCommand, "INNER JOIN \"ItemValues\""));
-        Assert.DoesNotContain("SELECT (", tagsCommand, StringComparison.Ordinal);
-        Assert.Equal(1, CountOccurrences(genresCommand, "INNER JOIN \"ItemValues\""));
-        Assert.DoesNotContain("SELECT (", genresCommand, StringComparison.Ordinal);
+        var itemValueCommands = _interceptor.Commands
+            .Where(command => command.Contains("GROUP BY", StringComparison.Ordinal)
+                && command.Contains("INNER JOIN \"ItemValues\"", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Equal(2, itemValueCommands.Length);
+
+        foreach (var command in itemValueCommands)
+        {
+            Assert.Equal(1, CountOccurrences(command, "INNER JOIN \"ItemValues\""));
+            Assert.DoesNotContain("SELECT (SELECT", command, StringComparison.Ordinal);
+        }
     }
 
     private static int CountOccurrences(string value, string pattern)


### PR DESCRIPTION
**Context & Issue Description**
I use TubeArchivist to integrate YouTube subscriptions into Jellyfin. TubeArchivist automatically writes tags based on input videos, resulting in more than 60.000 tags values in my library. Opening the Shows or Episodes view for this library caused the UI to stall for 2 to 3 minutes. Investigating this showed that it stems from correct, but ineffcient SQL as a result from EF Core translation.

The legacy filter query projected the related `ItemValue` entity before grouping:

```csharp
.Select(ivm => ivm.ItemValue)
.GroupBy(iv => iv.CleanValue)
.Select(g => g.Min(iv => iv.Value))
.OrderBy(value => value)
```

EF Core translates this expression into a correlated scalar MIN subquery. The aggregate appeared once in the selected value and again in ORDER BY, causing SQLite to repeat the joined aggregate work for each normalized tag group.

The query for genres uses the same expression and produces the same SQL shape. The same fix applies.

**Changes**

Join ItemValuesMap directly to ItemValues before grouping tags/genres. This gives EF Core a scalar rowset containing only ItemId, Type, CleanValue, and Value, allowing it to produce one grouped aggregate query without correlated scalar subqueries. The filtering, normalization, minimum display-value selection, and ordering behavior remain unchanged.

**Code assistance**
- I used ChatGPT 5.6 Sol to identify and fix the issue.
- I used ChatGPT 5.6 Sol to guide me through the fix completely so I can understand the problem and write this PR.