### PR TITLE
fix: return fallback gracefully when requested fallback font is missing

### DIFF
--- a/Jellyfin.Api/Controllers/SubtitleController.cs
+++ b/Jellyfin.Api/Controllers/SubtitleController.cs
@@ -557,7 +557,7 @@ public class SubtitleController : BaseJellyfinApiController
         if (!string.IsNullOrEmpty(fallbackFontPath))
         {
             var fontFile = _fileSystem.GetFiles(fallbackFontPath)
-                .First(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
             var fileSize = fontFile?.Length;
 
             if (fontFile is not null && fileSize is not null && fileSize > 0)


### PR DESCRIPTION
**Changes**
`GetFallbackFont()` called `.First()` on the file sequence, which throws `System.InvalidOperationException: Sequence contains no matching element` when no font file matches the requested name. Changed to `.FirstOrDefault()` — a missing font now falls through to the existing null/size guard at line 563, which logs a warning and returns HTTP 200 OK (the empty-body response is intentional to avoid breaking SubtitlesOctopus, per the existing comment).

**Code assistance**
Fix identified with AI assistance (Claude Code, Anthropic); the root cause and one-line fix were reviewed and verified manually before submission.

**Issues**
Fixes #17683