### PR TITLE
Restore parental control error responses

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -303,3 +303,4 @@
  - [tikuf](https://github.com/tikuf/)
  - [Tim Hobbs](https://github.com/timhobbs)
  - [SvenVandenbrande](https://github.com/SvenVandenbrande)
+ - [pederbe](https://github.com/pederbe)

--- a/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
+++ b/Jellyfin.Api/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandler.cs
@@ -55,8 +55,9 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
                 return Task.CompletedTask;
             }
 
-            var isInLocalNetwork = _httpContextAccessor.HttpContext is not null
-                                   && _networkManager.IsInLocalNetwork(_httpContextAccessor.HttpContext.GetNormalizedRemoteIP());
+            var httpContext = _httpContextAccessor.HttpContext;
+            var isInLocalNetwork = httpContext is not null
+                                   && _networkManager.IsInLocalNetwork(httpContext.GetNormalizedRemoteIP());
             var user = _userManager.GetUserById(userId);
             if (user is null)
             {
@@ -80,6 +81,11 @@ namespace Jellyfin.Api.Auth.DefaultAuthorizationPolicy
             // It's not great to have this check, but parental schedule must usually be honored except in a few rare cases
             if (requirement.ValidateParentalSchedule && !user.IsParentalScheduleAllowed())
             {
+                if (httpContext is not null)
+                {
+                    httpContext.Response.Headers["X-Application-Error-Code"] = "ParentalControl";
+                }
+
                 context.Fail();
                 return Task.CompletedTask;
             }

--- a/Jellyfin.Api/Controllers/UserController.cs
+++ b/Jellyfin.Api/Controllers/UserController.cs
@@ -230,6 +230,11 @@ public class UserController : BaseJellyfinApiController
         }
         catch (SecurityException e)
         {
+            if (e is ParentalControlException)
+            {
+                Response.Headers["X-Application-Error-Code"] = "ParentalControl";
+            }
+
             // rethrow adding IP address to message
             throw new SecurityException($"[{HttpContext.GetNormalizedRemoteIP()}] {e.Message}", e);
         }

--- a/Jellyfin.Server.Implementations/Users/UserManager.cs
+++ b/Jellyfin.Server.Implementations/Users/UserManager.cs
@@ -646,7 +646,7 @@ namespace Jellyfin.Server.Implementations.Users
                         "Authentication request for {UserName} is not allowed at this time due parental restrictions (IP: {IP}).",
                         username,
                         remoteEndPoint);
-                    throw new SecurityException("User is not allowed access at this time.");
+                    throw new ParentalControlException("User is not allowed access at this time.");
                 }
 
                 // Update LastActivityDate and LastLoginDate, then save

--- a/MediaBrowser.Controller/Net/ParentalControlException.cs
+++ b/MediaBrowser.Controller/Net/ParentalControlException.cs
@@ -1,0 +1,16 @@
+namespace MediaBrowser.Controller.Net;
+
+/// <summary>
+/// The exception that is thrown when parental controls prevent a user from accessing the server.
+/// </summary>
+public sealed class ParentalControlException : SecurityException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParentalControlException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public ParentalControlException(string message)
+        : base(message)
+    {
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/DefaultAuthorizationPolicy/DefaultAuthorizationHandlerTests.cs
@@ -8,6 +8,7 @@ using AutoFixture.AutoMoq;
 using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
 using Jellyfin.Api.Constants;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Server.Implementations.Security;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
@@ -79,6 +80,28 @@ namespace Jellyfin.Api.Tests.Auth.DefaultAuthorizationPolicy
 
             await _sut.HandleAsync(context);
             Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task ShouldFailWithParentalControlErrorCodeWhenScheduleDisallowsAccess()
+        {
+            var accessSchedules = new[]
+            {
+                new AccessSchedule(DynamicDayOfWeek.Everyday, 24, 24, Guid.Empty)
+            };
+            var claims = TestHelpers.SetupUser(
+                _userManagerMock,
+                _httpContextAccessor,
+                UserRoles.User,
+                accessSchedules);
+            var httpContext = new DefaultHttpContext();
+            _httpContextAccessor.SetupGet(h => h.HttpContext).Returns(httpContext);
+            var context = new AuthorizationHandlerContext(_requirements, claims, null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasFailed);
+            Assert.Equal("ParentalControl", httpContext.Response.Headers["X-Application-Error-Code"]);
         }
 
         [Theory]

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/UserControllerTests.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Api.Models.UserDtos;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions.Json;
 using MediaBrowser.Model.Dto;
 using Xunit;
@@ -190,6 +193,48 @@ namespace Jellyfin.Server.Integration.Tests.Controllers
 
             // Sanity check, make sure we're testing something
             Assert.NotEqual(TestUsername, userDto.Name);
+        }
+
+        [Fact]
+        [Priority(3)]
+        public async Task AuthenticateByName_OutsideAccessSchedule_ReturnsParentalControlErrorCode()
+        {
+            var adminClient = _factory.CreateClient();
+            adminClient.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(adminClient));
+            var username = $"scheduleRestricted{Guid.NewGuid():N}";
+            using var createResponse = await CreateUserByName(
+                adminClient,
+                new CreateUserByName { Name = username });
+            Assert.Equal(HttpStatusCode.OK, createResponse.StatusCode);
+            var user = await createResponse.Content.ReadFromJsonAsync<UserDto>(_jsonOptions, TestContext.Current.CancellationToken);
+            Assert.NotNull(user);
+
+            user.Policy.AccessSchedules =
+            [
+                new AccessSchedule(DynamicDayOfWeek.Everyday, 24, 24, user.Id)
+            ];
+            using var policyResponse = await adminClient.PostAsJsonAsync(
+                $"Users/{user.Id:N}/Policy",
+                user.Policy,
+                _jsonOptions,
+                TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.NoContent, policyResponse.StatusCode);
+
+            var authenticationClient = _factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/Users/AuthenticateByName");
+            request.Headers.TryAddWithoutValidation(AuthHelper.AuthHeaderName, AuthHelper.DummyAuthHeader);
+            request.Content = JsonContent.Create(
+                new AuthenticateUserByName
+                {
+                    Username = username,
+                    Pw = string.Empty
+                },
+                options: _jsonOptions);
+
+            using var response = await authenticationClient.SendAsync(request, TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Equal("ParentalControl", response.Headers.GetValues("X-Application-Error-Code").Single());
         }
     }
 }


### PR DESCRIPTION
Hi guys. I love using Jellyfin so I wanted to contribute by fixing #17740 .

**Changes**
- Restored X-Application-Error-Code: ParentalControl for authenticated requests rejected by an access schedule.
- Added the same header to schedule-rejected login responses.
- Introduced a narrow exception type so unrelated authentication failures remain unchanged.
- Added unit and HTTP integration regression tests.
- The authorization handler sets the header directly. Login-time schedule failures use a dedicated exception so other forbidden responses are unaffected.

**Validation**
- Full dotnet test Jellyfin.sln --no-restore: 3,553 passed, 10 skipped, 0 failed
- dotnet format --verify-no-changes --verbosity minimal --no-restore: exit 0
- git diff --check: exit 0

**Code assistance**
I used Codex to help both with some of the coding and review. I manually ran the tests and then revised the code several times. Also used Codex for debugging guidance.

**Issues**
#17740 

As this is my first contribution here I hope you can let me know if my approach is fine. I'm happy to revise it, of course. Cheers.
