### PR TITLE
Add a per-collection option to hide items from the main library

### DIFF
--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -338,12 +338,16 @@ namespace Emby.Server.Implementations.Collections
                 throw new ArgumentException("No collection exists with the supplied collectionId " + collectionId);
             }
 
-            if (collection.HideItemsFromLibrary == hide)
+            collection.HideItemsFromLibrary = hide;
+
+            // Older collections often store path-based LinkedChildren only in memory.
+            // Library queries hide members using the LinkedChildren table, so resolve ItemIds and persist them.
+            var resolvedChildren = collection.GetLinkedChildren();
+            if (resolvedChildren.Count > 0)
             {
-                return;
+                collection.LinkedChildren = resolvedChildren.Select(LinkedChild.Create).ToArray();
             }
 
-            collection.HideItemsFromLibrary = hide;
             await collection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/Emby.Server.Implementations/Collections/CollectionManager.cs
+++ b/Emby.Server.Implementations/Collections/CollectionManager.cs
@@ -182,6 +182,7 @@ namespace Emby.Server.Implementations.Collections
                     Name = name,
                     Path = path,
                     IsLocked = options.IsLocked,
+                    HideItemsFromLibrary = options.HideItemsFromLibrary,
                     ProviderIds = options.ProviderIds,
                     DateCreated = info.CreationTimeUtc,
                     DateModified = info.LastWriteTimeUtc
@@ -327,6 +328,58 @@ namespace Emby.Server.Implementations.Collections
                 RefreshPriority.High);
 
             ItemsRemovedFromCollection?.Invoke(this, new CollectionModifiedEventArgs(collection, itemList));
+        }
+
+        /// <inheritdoc />
+        public async Task SetHideItemsFromLibraryAsync(Guid collectionId, bool hide)
+        {
+            if (_libraryManager.GetItemById(collectionId) is not BoxSet collection)
+            {
+                throw new ArgumentException("No collection exists with the supplied collectionId " + collectionId);
+            }
+
+            if (collection.HideItemsFromLibrary == hide)
+            {
+                return;
+            }
+
+            collection.HideItemsFromLibrary = hide;
+            await collection.UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<BaseItem> ExcludeItemsHiddenByCollections(IEnumerable<BaseItem> items)
+        {
+            var hidingCollections = GetHidingCollections();
+            if (hidingCollections.Count == 0)
+            {
+                return items;
+            }
+
+            return items.Where(item =>
+            {
+                var itemId = item.Id;
+                foreach (var collection in hidingCollections)
+                {
+                    if (collection.ContainsLinkedChildByItemId(itemId))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+        }
+
+        private IReadOnlyList<BoxSet> GetHidingCollections()
+        {
+            var folder = GetCollectionsFolder(false).GetAwaiter().GetResult();
+            if (folder is null)
+            {
+                return [];
+            }
+
+            return folder.Children.OfType<BoxSet>().Where(c => c.HideItemsFromLibrary).ToList();
         }
 
         /// <inheritdoc />

--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -26,6 +26,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.Extensions.Logging;
 using Book = MediaBrowser.Controller.Entities.Book;
+using BoxSet = MediaBrowser.Controller.Entities.Movies.BoxSet;
 using Episode = MediaBrowser.Controller.Entities.TV.Episode;
 using Movie = MediaBrowser.Controller.Entities.Movies.Movie;
 using MusicAlbum = MediaBrowser.Controller.Entities.Audio.MusicAlbum;
@@ -1103,6 +1104,11 @@ namespace Emby.Server.Implementations.Dto
             if (item is IHasDisplayOrder hasDisplayOrder)
             {
                 dto.DisplayOrder = hasDisplayOrder.DisplayOrder;
+            }
+
+            if (item is BoxSet boxSet)
+            {
+                dto.HideItemsFromLibrary = boxSet.HideItemsFromLibrary;
             }
 
             if (item is IHasCollectionType hasCollectionType)

--- a/Jellyfin.Api/Controllers/CollectionController.cs
+++ b/Jellyfin.Api/Controllers/CollectionController.cs
@@ -44,6 +44,7 @@ public class CollectionController : BaseJellyfinApiController
     /// <param name="ids">Item Ids to add to the collection.</param>
     /// <param name="parentId">Optional. Create the collection within a specific folder.</param>
     /// <param name="isLocked">Whether or not to lock the new collection.</param>
+    /// <param name="hideItemsFromLibrary">Whether items in the collection should be hidden from the main library.</param>
     /// <response code="200">Collection created.</response>
     /// <returns>A <see cref="CollectionCreationOptions"/> with information about the new collection.</returns>
     [HttpPost]
@@ -52,13 +53,15 @@ public class CollectionController : BaseJellyfinApiController
         [FromQuery] string? name,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] string[] ids,
         [FromQuery] Guid? parentId,
-        [FromQuery] bool isLocked = false)
+        [FromQuery] bool isLocked = false,
+        [FromQuery] bool hideItemsFromLibrary = false)
     {
         var userId = User.GetUserId();
 
         var item = await _collectionManager.CreateCollectionAsync(new CollectionCreationOptions
         {
             IsLocked = isLocked,
+            HideItemsFromLibrary = hideItemsFromLibrary,
             Name = name,
             ParentId = parentId,
             ItemIdList = ids,
@@ -106,6 +109,23 @@ public class CollectionController : BaseJellyfinApiController
         [FromQuery, Required, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] Guid[] ids)
     {
         await _collectionManager.RemoveFromCollectionAsync(collectionId, ids).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Sets whether items in a collection are hidden from the main library.
+    /// </summary>
+    /// <param name="collectionId">The collection id.</param>
+    /// <param name="hide">Whether to hide collection members from the main library.</param>
+    /// <response code="204">Setting updated.</response>
+    /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
+    [HttpPost("{collectionId}/HideItemsFromLibrary")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<ActionResult> SetHideItemsFromLibrary(
+        [FromRoute, Required] Guid collectionId,
+        [FromQuery] bool hide = true)
+    {
+        await _collectionManager.SetHideItemsFromLibraryAsync(collectionId, hide).ConfigureAwait(false);
         return NoContent();
     }
 }

--- a/Jellyfin.Api/Controllers/CollectionController.cs
+++ b/Jellyfin.Api/Controllers/CollectionController.cs
@@ -123,7 +123,7 @@ public class CollectionController : BaseJellyfinApiController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<ActionResult> SetHideItemsFromLibrary(
         [FromRoute, Required] Guid collectionId,
-        [FromQuery] bool hide = true)
+        [FromQuery, Required] bool hide)
     {
         await _collectionManager.SetHideItemsFromLibraryAsync(collectionId, hide).ConfigureAwait(false);
         return NoContent();

--- a/Jellyfin.Api/Controllers/ItemUpdateController.cs
+++ b/Jellyfin.Api/Controllers/ItemUpdateController.cs
@@ -12,6 +12,7 @@ using MediaBrowser.Common.Api;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
@@ -406,6 +407,11 @@ public class ItemUpdateController : BaseJellyfinApiController
         if (item is IHasDisplayOrder hasDisplayOrder)
         {
             hasDisplayOrder.DisplayOrder = request.DisplayOrder;
+        }
+
+        if (item is BoxSet boxSet && request.HideItemsFromLibrary.HasValue)
+        {
+            boxSet.HideItemsFromLibrary = request.HideItemsFromLibrary.Value;
         }
 
         if (item is IHasAspectRatio hasAspectRatio)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -17,6 +17,7 @@ using Jellyfin.Database.Implementations.MatchCriteria;
 using Jellyfin.Extensions;
 using Jellyfin.Server.Implementations.Extensions;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Model.Entities;
 using Microsoft.EntityFrameworkCore;
 using BaseItemEntity = Jellyfin.Database.Implementations.Entities.BaseItemEntity;
@@ -1279,6 +1280,26 @@ public sealed partial class BaseItemRepository
                         e.Data.Contains("\"AirsAfterSeasonNumber\":" + seasonStr)
                         || e.Data.Contains("\"AirsBeforeSeasonNumber\":" + seasonStr))));
             }
+        }
+
+        if (filter.ExcludeItemsHiddenByCollections
+            && filter.ParentType != BaseItemKind.BoxSet
+            && filter.ParentType != BaseItemKind.Playlist
+            && !filter.DescendantOfId.HasValue)
+        {
+            var boxSetTypeName = _itemTypeLookup.BaseItemKindNames[BaseItemKind.BoxSet];
+            var hidingCollectionIds = context.BaseItems
+                .Where(bs => bs.Type == boxSetTypeName
+                    && bs.Data != null
+                    && bs.Data.Contains(BoxSet.HideItemsFromLibraryDataMarker))
+                .Select(bs => bs.Id);
+
+            var hiddenChildIds = context.LinkedChildren
+                .Where(lc => lc.ChildType == Database.Implementations.Entities.LinkedChildType.Manual
+                    && hidingCollectionIds.Contains(lc.ParentId))
+                .Select(lc => lc.ChildId);
+
+            baseQuery = baseQuery.Where(e => !hiddenChildIds.Contains(e.Id));
         }
 
         return baseQuery;

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -1291,12 +1291,14 @@ public sealed partial class BaseItemRepository
             var hidingCollectionIds = context.BaseItems
                 .Where(bs => bs.Type == boxSetTypeName
                     && bs.Data != null
-                    && bs.Data.Contains(BoxSet.HideItemsFromLibraryDataMarker))
+                    && (bs.Data.Contains(BoxSet.HideItemsFromLibraryDataMarker)
+                        || bs.Data.Contains("\"HideItemsFromLibrary\": true")
+                        || bs.Data.Contains("\"hideItemsFromLibrary\":true")
+                        || bs.Data.Contains("\"hideItemsFromLibrary\": true")))
                 .Select(bs => bs.Id);
 
             var hiddenChildIds = context.LinkedChildren
-                .Where(lc => lc.ChildType == Database.Implementations.Entities.LinkedChildType.Manual
-                    && hidingCollectionIds.Contains(lc.ParentId))
+                .Where(lc => hidingCollectionIds.Contains(lc.ParentId))
                 .Select(lc => lc.ChildId);
 
             baseQuery = baseQuery.Where(e => !hiddenChildIds.Contains(e.Id));

--- a/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
+++ b/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
@@ -23,6 +23,8 @@ namespace MediaBrowser.Controller.Collections
 
         public bool IsLocked { get; set; }
 
+        public bool HideItemsFromLibrary { get; set; }
+
         public Dictionary<string, string> ProviderIds { get; set; }
 
         public IReadOnlyList<string> ItemIdList { get; set; }

--- a/MediaBrowser.Controller/Collections/ICollectionManager.cs
+++ b/MediaBrowser.Controller/Collections/ICollectionManager.cs
@@ -50,12 +50,27 @@ namespace MediaBrowser.Controller.Collections
         Task RemoveFromCollectionAsync(Guid collectionId, IEnumerable<Guid> itemIds);
 
         /// <summary>
+        /// Sets whether items in the collection are hidden from the main library.
+        /// </summary>
+        /// <param name="collectionId">The collection identifier.</param>
+        /// <param name="hide">Whether to hide collection members from the main library.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetHideItemsFromLibraryAsync(Guid collectionId, bool hide);
+
+        /// <summary>
         /// Collapses the items within box sets.
         /// </summary>
         /// <param name="items">The items.</param>
         /// <param name="user">The user.</param>
         /// <returns>IEnumerable{BaseItem}.</returns>
         IEnumerable<BaseItem> CollapseItemsWithinBoxSets(IEnumerable<BaseItem> items, User user);
+
+        /// <summary>
+        /// Excludes items that belong to a collection with hide-from-library enabled.
+        /// </summary>
+        /// <param name="items">The items.</param>
+        /// <returns>Items that are not hidden by a collection.</returns>
+        IEnumerable<BaseItem> ExcludeItemsHiddenByCollections(IEnumerable<BaseItem> items);
 
         /// <summary>
         /// Gets the collections accessible to the supplied user that contain the provided item.

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -931,6 +931,11 @@ namespace MediaBrowser.Controller.Entities
                 query.Parent = this;
             }
 
+            if (this is BoxSet || GetBaseItemKind() == BaseItemKind.Playlist)
+            {
+                query.ExcludeItemsHiddenByCollections = false;
+            }
+
             // BoxSets and Playlists can have per-user visibility (shares/open access) that is stored in the
             // serialized item data and cannot be evaluated by the database query, so filter them in memory.
             if (query.IncludeItemTypes.Length > 0
@@ -1099,6 +1104,14 @@ namespace MediaBrowser.Controller.Entities
                 // but the BoxSet's own name may not match. Re-apply name filtering so BoxSets
                 // appear under the correct letter (e.g. "Jump Street" under J, not under #).
                 items = ApplyNameFilter(items, query);
+            }
+
+            if (query.ExcludeItemsHiddenByCollections
+                && this is not BoxSet
+                && GetBaseItemKind() != BaseItemKind.Playlist
+                && CollectionManager is not null)
+            {
+                items = CollectionManager.ExcludeItemsHiddenByCollections(items);
             }
 
             return UserViewBuilder.SortAndPage(items, null, query, LibraryManager);

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -61,6 +61,7 @@ namespace MediaBrowser.Controller.Entities
             SkipDeserialization = false;
             AudioLanguages = [];
             SubtitleLanguages = [];
+            ExcludeItemsHiddenByCollections = true;
         }
 
         public InternalItemsQuery(User? user)
@@ -212,6 +213,13 @@ namespace MediaBrowser.Controller.Entities
         public bool? IsUnaired { get; set; }
 
         public bool? CollapseBoxSetItems { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether items that belong to a collection with
+        /// hide-from-library enabled should be excluded. Defaults to true. Disabled when
+        /// querying inside a collection or playlist so those items remain visible there.
+        /// </summary>
+        public bool ExcludeItemsHiddenByCollections { get; set; }
 
         /// <summary>
         /// Gets or sets the item types that should be collapsed into box sets.

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -21,6 +21,12 @@ namespace MediaBrowser.Controller.Entities.Movies
     /// </summary>
     public class BoxSet : Folder, IHasTrailers, IHasDisplayOrder, IHasLookupInfo<BoxSetInfo>
     {
+        /// <summary>
+        /// JSON fragment written into serialized item data when <see cref="HideItemsFromLibrary"/> is enabled.
+        /// Library queries use this marker to exclude collection members from the main library.
+        /// </summary>
+        public const string HideItemsFromLibraryDataMarker = "\"HideItemsFromLibrary\":true";
+
         public BoxSet()
         {
             DisplayOrder = "PremiereDate";
@@ -44,6 +50,12 @@ namespace MediaBrowser.Controller.Entities.Movies
         /// </summary>
         /// <value>The display order.</value>
         public string DisplayOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether items in this collection should be hidden from the main library.
+        /// Items remain visible when viewing the collection itself.
+        /// </summary>
+        public bool HideItemsFromLibrary { get; set; }
 
         [JsonIgnore]
         private bool IsLegacyBoxSet

--- a/MediaBrowser.LocalMetadata/Parsers/BoxSetXmlParser.cs
+++ b/MediaBrowser.LocalMetadata/Parsers/BoxSetXmlParser.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Xml;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Controller.Providers;
 using Microsoft.Extensions.Logging;
 
@@ -27,6 +29,10 @@ namespace MediaBrowser.LocalMetadata.Parsers
         {
             switch (reader.Name)
             {
+                case "HideItemsFromLibrary":
+                    itemResult.Item.HideItemsFromLibrary = string.Equals(reader.ReadNormalizedString(), "true", StringComparison.OrdinalIgnoreCase);
+                    break;
+
                 case "CollectionItems":
 
                     if (!reader.IsEmptyElement)

--- a/MediaBrowser.LocalMetadata/Savers/BoxSetXmlSaver.cs
+++ b/MediaBrowser.LocalMetadata/Savers/BoxSetXmlSaver.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
@@ -39,8 +40,17 @@ namespace MediaBrowser.LocalMetadata.Savers
         }
 
         /// <inheritdoc />
-        protected override Task WriteCustomElementsAsync(BaseItem item, XmlWriter writer)
-            => Task.CompletedTask;
+        protected override async Task WriteCustomElementsAsync(BaseItem item, XmlWriter writer)
+        {
+            if (item is BoxSet boxSet)
+            {
+                await writer.WriteElementStringAsync(
+                    null,
+                    "HideItemsFromLibrary",
+                    null,
+                    boxSet.HideItemsFromLibrary.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()).ConfigureAwait(false);
+            }
+        }
 
         /// <inheritdoc />
         protected override string GetLocalSavePath(BaseItem item)

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -425,6 +425,13 @@ namespace MediaBrowser.Model.Dto
         public string DisplayOrder { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether items in this collection should be hidden from the main library.
+        /// Only applies to collections (box sets). Items remain visible when viewing the collection itself.
+        /// </summary>
+        /// <value>Whether collection members are hidden from the main library.</value>
+        public bool? HideItemsFromLibrary { get; set; }
+
+        /// <summary>
         /// Gets or sets the album id.
         /// </summary>
         /// <value>The album id.</value>

--- a/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
+++ b/MediaBrowser.Providers/BoxSets/BoxSetMetadataService.cs
@@ -68,6 +68,11 @@ public class BoxSetMetadataService : MetadataService<BoxSet, BoxSetInfo>
         var sourceItem = source.Item;
         var targetItem = target.Item;
 
+        if (sourceItem.HideItemsFromLibrary)
+        {
+            targetItem.HideItemsFromLibrary = true;
+        }
+
         if (mergeMetadataSettings)
         {
             // Only merge LinkedChildren from metadata for external collections (not managed by Jellyfin).

--- a/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/ItemUpdateControllerTests.cs
@@ -70,6 +70,34 @@ public class ItemUpdateControllerTests
         Assert.Equal("tt1234567", movie.ProviderIds["Imdb"]);
     }
 
+    [Fact]
+    public async Task UpdateItem_WhenHideItemsFromLibrarySupplied_SetsBoxSetFlag()
+    {
+        var collection = new BoxSet();
+        var request = new BaseItemDto
+        {
+            HideItemsFromLibrary = true
+        };
+
+        await InvokeUpdateItem(request, collection);
+
+        Assert.True(collection.HideItemsFromLibrary);
+    }
+
+    [Fact]
+    public async Task UpdateItem_WhenHideItemsFromLibraryOmitted_LeavesExistingFlag()
+    {
+        var collection = new BoxSet
+        {
+            HideItemsFromLibrary = true
+        };
+        var request = new BaseItemDto();
+
+        await InvokeUpdateItem(request, collection);
+
+        Assert.True(collection.HideItemsFromLibrary);
+    }
+
     private Task InvokeUpdateItem(BaseItemDto request, BaseItem item)
     {
         return _subject.UpdateItem(request, item);

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryHideFromLibraryTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositoryHideFromLibraryTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using Xunit;
+using LinkedChildType = Jellyfin.Database.Implementations.Entities.LinkedChildType;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class BaseItemRepositoryHideFromLibraryTests : SqliteDbTestFixture
+{
+    private const string MovieType = "MediaBrowser.Controller.Entities.Movies.Movie";
+    private const string BoxSetType = "MediaBrowser.Controller.Entities.Movies.BoxSet";
+
+    private readonly BaseItemRepository _repository;
+    private readonly Guid _visibleMovie = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private readonly Guid _hiddenMovie = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private readonly Guid _groupedMovie = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private readonly Guid _hidingCollection = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private readonly Guid _normalCollection = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+    public BaseItemRepositoryHideFromLibraryTests()
+    {
+        _repository = CreateBaseItemRepository(new ItemTypeLookup());
+        Seed();
+    }
+
+    [Fact]
+    public void GetItemList_HidesMembersOfHidingCollection()
+    {
+        var ids = _repository.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Movie]
+        }).Select(i => i.Id).ToHashSet();
+
+        Assert.Contains(_visibleMovie, ids);
+        Assert.Contains(_groupedMovie, ids);
+        Assert.DoesNotContain(_hiddenMovie, ids);
+    }
+
+    [Fact]
+    public void GetItemList_ShowsHiddenMembersWhenViewingTheCollection()
+    {
+        var ids = _repository.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Movie],
+            DescendantOfId = _hidingCollection
+        }).Select(i => i.Id).ToHashSet();
+
+        Assert.Single(ids);
+        Assert.Contains(_hiddenMovie, ids);
+    }
+
+    [Fact]
+    public void GetItemList_CanDisableHideFilter()
+    {
+        var ids = _repository.GetItemList(new InternalItemsQuery
+        {
+            IncludeItemTypes = [BaseItemKind.Movie],
+            ExcludeItemsHiddenByCollections = false
+        }).Select(i => i.Id).ToHashSet();
+
+        Assert.Contains(_hiddenMovie, ids);
+        Assert.Contains(_visibleMovie, ids);
+        Assert.Contains(_groupedMovie, ids);
+    }
+
+    private void Seed()
+    {
+        using var context = CreateDbContext();
+
+        context.BaseItems.Add(CreateMovie(_visibleMovie, "Visible movie"));
+        context.BaseItems.Add(CreateMovie(_hiddenMovie, "Hidden movie"));
+        context.BaseItems.Add(CreateMovie(_groupedMovie, "Grouped movie"));
+        context.BaseItems.Add(new BaseItemEntity
+        {
+            Id = _hidingCollection,
+            Type = BoxSetType,
+            Name = "Private",
+            IsFolder = true,
+            Data = "{" + BoxSet.HideItemsFromLibraryDataMarker + "}"
+        });
+        context.BaseItems.Add(new BaseItemEntity
+        {
+            Id = _normalCollection,
+            Type = BoxSetType,
+            Name = "MCU",
+            IsFolder = true,
+            Data = "{\"HideItemsFromLibrary\":false}"
+        });
+
+        context.LinkedChildren.Add(new LinkedChildEntity
+        {
+            ParentId = _hidingCollection,
+            ChildId = _hiddenMovie,
+            ChildType = LinkedChildType.Manual,
+            SortOrder = 0
+        });
+        context.LinkedChildren.Add(new LinkedChildEntity
+        {
+            ParentId = _normalCollection,
+            ChildId = _groupedMovie,
+            ChildType = LinkedChildType.Manual,
+            SortOrder = 0
+        });
+
+        context.SaveChanges();
+    }
+
+    private static BaseItemEntity CreateMovie(Guid id, string name)
+    {
+        return new BaseItemEntity
+        {
+            Id = id,
+            Type = MovieType,
+            Name = name,
+            MediaType = "Video",
+            IsMovie = true,
+            IsFolder = false,
+            IsVirtualItem = false
+        };
+    }
+}


### PR DESCRIPTION
**Changes**
Lets you hide a collection’s items from the main library so Movies, home, and search stay cleaner. The videos stay inside that collection. Each collection has its own toggle; this is not the global “group movies into collections” option.

**Code assistance**
I used Cursor while implementing this: it helped me find the query/DTO paths, draft the filter and tests, and iterate on StyleCop. I ran the server locally, checked the behavior myself, and edited the result until it matched what I wanted.

**Issues**
No GitHub issue. This is a new feature, so I did not file a bug ticket. I can add a Fider request if you want it tracked there.