### PR TITLE
Require elevation for configuration access

### DIFF
--- a/Jellyfin.Api/Controllers/ConfigurationController.cs
+++ b/Jellyfin.Api/Controllers/ConfigurationController.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Api.Controllers;
 /// Configuration Controller.
 /// </summary>
 [Route("System")]
-[Authorize]
+[Authorize(Policy = Policies.RequiresElevation)]
 [Tags("System")]
 public class ConfigurationController : BaseJellyfinApiController
 {
@@ -60,7 +60,6 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <response code="204">Configuration updated.</response>
     /// <returns>Update status.</returns>
     [HttpPost("Configuration")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateConfiguration([FromBody, Required] ServerConfiguration configuration)
     {
@@ -90,7 +89,6 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <response code="204">Named configuration updated.</response>
     /// <returns>Update status.</returns>
     [HttpPost("Configuration/{key}")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateNamedConfiguration([FromRoute, Required] string key, [FromBody, Required] JsonDocument configuration)
     {
@@ -112,7 +110,6 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <response code="200">Metadata options returned.</response>
     /// <returns>Default MetadataOptions.</returns>
     [HttpGet("Configuration/MetadataOptions/Default")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<MetadataOptions> GetDefaultMetadataOptions()
     {
@@ -126,7 +123,6 @@ public class ConfigurationController : BaseJellyfinApiController
     /// <response code="204">Branding configuration updated.</response>
     /// <returns>Update status.</returns>
     [HttpPost("Configuration/Branding")]
-    [Authorize(Policy = Policies.RequiresElevation)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public ActionResult UpdateBrandingConfiguration([FromBody, Required] BrandingOptionsDto configuration)
     {

--- a/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
+++ b/Jellyfin.Server/Extensions/ApiServiceCollectionExtensions.cs
@@ -86,6 +86,7 @@ namespace Jellyfin.Server.Extensions
                 options.AddPolicy(
                     Policies.RequiresElevation,
                     policy => policy.AddAuthenticationSchemes(AuthenticationSchemes.CustomAuthentication)
+                        .AddRequirements(new DefaultAuthorizationRequirement())
                         .RequireClaim(ClaimTypes.Role, UserRoles.Administrator));
             });
         }

--- a/tests/Jellyfin.Api.Tests/Controllers/ConfigurationControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/ConfigurationControllerTests.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class ConfigurationControllerTests
+{
+    [Fact]
+    public void Controller_RequiresElevation()
+    {
+        Assert.Contains(
+            typeof(ConfigurationController).GetCustomAttributes<AuthorizeAttribute>(),
+            attribute => attribute.Policy == Policies.RequiresElevation);
+    }
+}

--- a/tests/Jellyfin.Server.Tests/Extensions/ApiServiceCollectionExtensionsTests.cs
+++ b/tests/Jellyfin.Server.Tests/Extensions/ApiServiceCollectionExtensionsTests.cs
@@ -1,0 +1,28 @@
+using Jellyfin.Api.Auth.DefaultAuthorizationPolicy;
+using Jellyfin.Server.Extensions;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Jellyfin.Server.Tests.Extensions;
+
+public class ApiServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void RequiresElevationPolicy_IncludesDefaultAuthorizationRequirement()
+    {
+        var services = new ServiceCollection();
+        services.AddJellyfinApiAuthorization();
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
+        var policy = options.GetPolicy(Policies.RequiresElevation);
+
+        Assert.NotNull(policy);
+        Assert.Contains(
+            policy.Requirements,
+            requirement => requirement is DefaultAuthorizationRequirement);
+    }
+}


### PR DESCRIPTION
**Changes**

`ConfigurationController` now requires `Policies.RequiresElevation` for every action. This prevents authenticated non-administrator users from reading `ServerConfiguration` and named configuration objects, which can contain certificate passwords, Live TV provider credentials, database connection strings, and plugin-defined settings.

`RequiresElevation` now includes `DefaultAuthorizationRequirement` before checking the administrator role. ASP.NET Core does not apply the default policy when an endpoint names a policy, so elevated endpoints now also enforce Jellyfin's normal remote-access check.

**Code assistance**

Codex audited the internet-facing authorization paths, identified the configuration disclosure and named-policy composition issue, implemented the fix, and added regression tests.

**Issues**

Related to #16682

**Validation**

- `git diff --check`
- `docker run --rm --network host --user 1000:1000 -e HOME=/tmp/dotnet-home -e DOTNET_CLI_HOME=/tmp/dotnet-home -e HTTPS_PROXY -e HTTP_PROXY -e NO_PROXY -e ALL_PROXY -v /home/dev-user/code/jellyfin:/src -w /src mcr.microsoft.com/dotnet/sdk:10.0 dotnet test tests/Jellyfin.Api.Tests/Jellyfin.Api.Tests.csproj --filter FullyQualifiedName~ConfigurationControllerTests` (blocked during restore: `NU1301` timed out while loading `https://api.nuget.org/v3/index.json` from this environment)
