### PR TITLE
fix(trickplay): resolve 10-bit HEVC extraction, progress tracking, an…

### DIFF
--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -136,7 +136,12 @@ public class TrickplayManager : ITrickplayManager
     }
 
     /// <inheritdoc />
-    public async Task RefreshTrickplayDataAsync(Video video, bool replace, LibraryOptions libraryOptions, CancellationToken cancellationToken)
+    public async Task RefreshTrickplayDataAsync(
+        Video video,
+        bool replace,
+        LibraryOptions libraryOptions,
+        CancellationToken cancellationToken,
+        IProgress<double>? progress = null)
     {
         var options = _config.Configuration.TrickplayOptions;
         if (!CanGenerateTrickplay(video, options.Interval) || libraryOptions is null)
@@ -192,7 +197,8 @@ public class TrickplayManager : ITrickplayManager
                     width,
                     options,
                     saveWithMedia,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken,
+                    progress).ConfigureAwait(false);
             }
 
             // Cleanup old trickplay files
@@ -228,7 +234,8 @@ public class TrickplayManager : ITrickplayManager
         int width,
         TrickplayOptions options,
         bool saveWithMedia,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IProgress<double>? progress = null)
     {
         var imgTempDir = string.Empty;
 
@@ -335,7 +342,8 @@ public class TrickplayManager : ITrickplayManager
                     options.ProcessPriority,
                     options.EnableKeyFrameOnlyExtraction,
                     _encodingHelper,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken,
+                    progress).ConfigureAwait(false);
 
                 if (string.IsNullOrEmpty(imgTempDir) || !Directory.Exists(imgTempDir))
                 {
@@ -382,7 +390,33 @@ public class TrickplayManager : ITrickplayManager
             {
                 if (!string.IsNullOrEmpty(imgTempDir))
                 {
-                    Directory.Delete(imgTempDir, true);
+                    try
+                    {
+                        if (Directory.Exists(imgTempDir))
+                        {
+                            Directory.Delete(imgTempDir, true);
+                        }
+                    }
+                    catch (IOException ex)
+                    {
+                        _logger.LogWarning(ex, "Temp trickplay directory {Path} locked by another process. Retrying after brief delay.", imgTempDir);
+                        try
+                        {
+                            await Task.Delay(500).ConfigureAwait(false);
+                            if (Directory.Exists(imgTempDir))
+                            {
+                                Directory.Delete(imgTempDir, true);
+                            }
+                        }
+                        catch (Exception retryEx)
+                        {
+                            _logger.LogWarning(retryEx, "Unable to delete temp trickplay directory {Path}. Will be cleaned up later.", imgTempDir);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Unable to delete temp trickplay directory {Path}.", imgTempDir);
+                    }
                 }
             }
         }

--- a/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
+++ b/Jellyfin.Server.Implementations/Trickplay/TrickplayManager.cs
@@ -204,26 +204,31 @@ public class TrickplayManager : ITrickplayManager
             // Cleanup old trickplay files
             if (Directory.Exists(trickplayDirectory))
             {
-                var existingFolders = Directory.GetDirectories(trickplayDirectory).ToList();
                 var trickplayInfos = await dbContext.TrickplayInfos
                         .AsNoTracking()
                         .Where(i => i.ItemId.Equals(video.Id))
                         .ToListAsync(cancellationToken)
                         .ConfigureAwait(false);
                 var expectedFolders = trickplayInfos.Select(i => GetTrickplayDirectory(video, i.TileWidth, i.TileHeight, i.Width, saveWithMedia)).ToList();
-                var foldersToRemove = existingFolders.Except(expectedFolders);
-                foreach (var folder in foldersToRemove)
-                {
-                    try
-                    {
-                        _logger.LogWarning("Pruning trickplay files for {Item}", video.Path);
-                        Directory.Delete(folder, true);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogWarning("Unable to remove trickplay directory: {Directory}: {Exception}", folder, ex);
-                    }
-                }
+                CleanupOldTrickplayFolders(trickplayDirectory, expectedFolders, video.Path);
+            }
+        }
+    }
+
+    private void CleanupOldTrickplayFolders(string trickplayDirectory, IEnumerable<string> expectedFolders, string videoPath)
+    {
+        var existingFolders = Directory.GetDirectories(trickplayDirectory).ToList();
+        var foldersToRemove = existingFolders.Except(expectedFolders);
+        foreach (var folder in foldersToRemove)
+        {
+            try
+            {
+                _logger.LogWarning("Pruning trickplay files for {Item}", videoPath);
+                Directory.Delete(folder, true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Unable to remove trickplay directory: {Directory}: {Exception}", folder, ex);
             }
         }
     }
@@ -402,7 +407,7 @@ public class TrickplayManager : ITrickplayManager
                         _logger.LogWarning(ex, "Temp trickplay directory {Path} locked by another process. Retrying after brief delay.", imgTempDir);
                         try
                         {
-                            await Task.Delay(500).ConfigureAwait(false);
+                            await Task.Delay(500, CancellationToken.None).ConfigureAwait(false);
                             if (Directory.Exists(imgTempDir))
                             {
                                 Directory.Delete(imgTempDir, true);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3997,7 +3997,19 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 var isRext = IsVideoStreamHevcRext(state);
-                var outFormat = doCuTonemap ? (isRext ? "p010" : string.Empty) : (isMjpegEncoder && GetVideoColorBitDepth(state) >= 10 ? "p010" : "yuv420p");
+                string outFormat;
+                if (doCuTonemap)
+                {
+                    outFormat = isRext ? "p010" : string.Empty;
+                }
+                else if (isMjpegEncoder && GetVideoColorBitDepth(state) >= 10)
+                {
+                    outFormat = "p010";
+                }
+                else
+                {
+                    outFormat = "yuv420p";
+                }
                 var hwScaleFilter = GetHwScaleFilter("scale", "cuda", outFormat, false, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
                 // hw scale
                 mainFilters.Add(hwScaleFilter);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -3997,7 +3997,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 }
 
                 var isRext = IsVideoStreamHevcRext(state);
-                var outFormat = doCuTonemap ? (isRext ? "p010" : string.Empty) : "yuv420p";
+                var outFormat = doCuTonemap ? (isRext ? "p010" : string.Empty) : (isMjpegEncoder && GetVideoColorBitDepth(state) >= 10 ? "p010" : "yuv420p");
                 var hwScaleFilter = GetHwScaleFilter("scale", "cuda", outFormat, false, swpInW, swpInH, reqW, reqH, reqMaxW, reqMaxH);
                 // hw scale
                 mainFilters.Add(hwScaleFilter);
@@ -4018,7 +4018,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
                 // OUTPUT yuv420p surface(memory)
                 mainFilters.Add("hwdownload");
-                mainFilters.Add("format=yuv420p");
+                mainFilters.Add(isMjpegEncoder && GetVideoColorBitDepth(state) >= 10 ? "format=p010" : "format=yuv420p");
             }
 
             // OUTPUT yuv420p surface(memory)

--- a/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
+++ b/MediaBrowser.Controller/MediaEncoding/IMediaEncoder.cs
@@ -175,6 +175,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <param name="enableKeyFrameOnlyExtraction">Whether to only extract key frames.</param>
         /// <param name="encodingHelper">EncodingHelper instance.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="progress">Progress reporter.</param>
         /// <returns>Directory where images where extracted. A given image made before another will always be named with a lower number.</returns>
         Task<string> ExtractVideoImagesOnIntervalAccelerated(
             string inputFile,
@@ -190,7 +191,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             ProcessPriorityClass? priority,
             bool enableKeyFrameOnlyExtraction,
             EncodingHelper encodingHelper,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken,
+            IProgress<double> progress = null);
 
         /// <summary>
         /// Gets the media info.

--- a/MediaBrowser.Controller/Trickplay/ITrickplayManager.cs
+++ b/MediaBrowser.Controller/Trickplay/ITrickplayManager.cs
@@ -20,8 +20,14 @@ public interface ITrickplayManager
     /// <param name="replace">Whether or not existing data should be replaced.</param>
     /// <param name="libraryOptions">The library options.</param>
     /// <param name="cancellationToken">CancellationToken to use for operation.</param>
+    /// <param name="progress">Progress reporter.</param>
     /// <returns>Task.</returns>
-    Task RefreshTrickplayDataAsync(Video video, bool replace, LibraryOptions libraryOptions, CancellationToken cancellationToken);
+    Task RefreshTrickplayDataAsync(
+        Video video,
+        bool replace,
+        LibraryOptions libraryOptions,
+        CancellationToken cancellationToken,
+        IProgress<double>? progress = null);
 
     /// <summary>
     /// Creates trickplay tiles out of individual thumbnails.

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -937,8 +937,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     cancellationToken,
                     mediaSource.RunTimeTicks,
                     interval,
-                    progress,
-                    inputFile).ConfigureAwait(false);
+                    progress).ConfigureAwait(false);
             }
             catch (FfmpegException ex)
             {
@@ -960,8 +959,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     cancellationToken,
                     mediaSource.RunTimeTicks,
                     interval,
-                    progress,
-                    inputFile).ConfigureAwait(false);
+                    progress).ConfigureAwait(false);
         }
 
         private async Task<string> ExtractVideoImagesOnIntervalInternal(
@@ -974,8 +972,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             CancellationToken cancellationToken,
             long? runtimeTicks = null,
             TimeSpan? interval = null,
-            IProgress<double> progress = null,
-            string inputFile = null)
+            IProgress<double> progress = null)
         {
             if (string.IsNullOrWhiteSpace(inputArg))
             {
@@ -1109,7 +1106,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                                         100d * finalJpegCount / expectedImageCount));
                             }
 
-                            _logger.LogInformation("Trickplay extraction completed: {FinalCount}/{ExpectedCount} frames for {MediaFile}", finalJpegCount, expectedImageCount, inputFile);
+                            _logger.LogInformation("Trickplay extraction completed: {FinalCount}/{ExpectedCount} frames", finalJpegCount, expectedImageCount);
 
                             break;
                         }
@@ -1136,7 +1133,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
                                 if (jpegCount - lastLoggedCount >= 50 || jpegCount >= expectedImageCount)
                                 {
                                     lastLoggedCount = jpegCount;
-                                    _logger.LogInformation("Trickplay extraction: {Percent:F1}% ({CurrentCount}/{ExpectedCount} frames) for {MediaFile}", pct, jpegCount, expectedImageCount, inputFile);
+                                    _logger.LogInformation("Trickplay extraction: {Percent:F1}% ({CurrentCount}/{ExpectedCount} frames)", pct, jpegCount, expectedImageCount);
                                 }
                             }
                         }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -841,7 +841,8 @@ namespace MediaBrowser.MediaEncoding.Encoder
             ProcessPriorityClass? priority,
             bool enableKeyFrameOnlyExtraction,
             EncodingHelper encodingHelper,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IProgress<double> progress = null)
         {
             var options = allowHwAccel ? _configurationManager.GetEncodingOptions() : new EncodingOptions();
             threads ??= _threads;
@@ -933,7 +934,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
                     threads,
                     qualityScale,
                     priority,
-                    cancellationToken).ConfigureAwait(false);
+                    cancellationToken,
+                    mediaSource.RunTimeTicks,
+                    interval,
+                    progress,
+                    inputFile).ConfigureAwait(false);
             }
             catch (FfmpegException ex)
             {
@@ -945,7 +950,18 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 _logger.LogWarning(ex, "I-frame trickplay extraction failed, will attempt standard way. Input: {InputFile}", inputFile);
             }
 
-            return await ExtractVideoImagesOnIntervalInternal(inputArg, filterParam, vidEncoder, threads, qualityScale, priority, cancellationToken).ConfigureAwait(false);
+            return await ExtractVideoImagesOnIntervalInternal(
+                    inputArg,
+                    filterParam,
+                    vidEncoder,
+                    threads,
+                    qualityScale,
+                    priority,
+                    cancellationToken,
+                    mediaSource.RunTimeTicks,
+                    interval,
+                    progress,
+                    inputFile).ConfigureAwait(false);
         }
 
         private async Task<string> ExtractVideoImagesOnIntervalInternal(
@@ -955,7 +971,11 @@ namespace MediaBrowser.MediaEncoding.Encoder
             int? outputThreads,
             int? qualityScale,
             ProcessPriorityClass? priority,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            long? runtimeTicks = null,
+            TimeSpan? interval = null,
+            IProgress<double> progress = null,
+            string inputFile = null)
         {
             if (string.IsNullOrWhiteSpace(inputArg))
             {
@@ -1052,27 +1072,78 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
                     bool isResponsive = true;
                     int lastCount = 0;
+                    int lastLoggedCount = 0;
                     var timeoutMs = _configurationManager.Configuration.ImageExtractionTimeoutMs;
                     timeoutMs = timeoutMs <= 0 ? DefaultHdrImageExtractionTimeout : timeoutMs;
+
+                    var expectedImageCount = 0L;
+
+                    if (runtimeTicks is > 0
+                        && interval is { } extractionInterval
+                        && extractionInterval > TimeSpan.Zero)
+                    {
+                        expectedImageCount = Math.Max(
+                            1,
+                            (long)Math.Floor(
+                                TimeSpan.FromTicks(runtimeTicks.Value).TotalSeconds
+                                / extractionInterval.TotalSeconds));
+                    }
+
+                    var lastImageTime = DateTime.UtcNow;
 
                     while (isResponsive && !cancellationToken.IsCancellationRequested)
                     {
                         try
                         {
-                            await process.WaitForExitAsync(TimeSpan.FromMilliseconds(timeoutMs)).ConfigureAwait(false);
+                            await process.WaitForExitAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
 
                             ranToCompletion = true;
+
+                            var finalJpegCount = _fileSystem.GetFilePaths(targetDirectory).Count();
+
+                            if (progress is not null && expectedImageCount > 0)
+                            {
+                                progress.Report(
+                                    Math.Min(
+                                        100d,
+                                        100d * finalJpegCount / expectedImageCount));
+                            }
+
+                            _logger.LogInformation("Trickplay extraction completed: {FinalCount}/{ExpectedCount} frames for {MediaFile}", finalJpegCount, expectedImageCount, inputFile);
+
                             break;
                         }
                         catch (OperationCanceledException)
                         {
-                            // We don't actually expect the process to be finished in one timeout span, just that one image has been generated.
+                            // Process is still running. Check generated JPEGs and report progress.
                         }
 
                         var jpegCount = _fileSystem.GetFilePaths(targetDirectory).Count();
 
-                        isResponsive = jpegCount > lastCount;
-                        lastCount = jpegCount;
+                        if (jpegCount > lastCount)
+                        {
+                            lastCount = jpegCount;
+                            lastImageTime = DateTime.UtcNow;
+
+                            if (expectedImageCount > 0)
+                            {
+                                var pct = Math.Min(100d, 100d * jpegCount / expectedImageCount);
+                                if (progress is not null)
+                                {
+                                    progress.Report(pct);
+                                }
+
+                                if (jpegCount - lastLoggedCount >= 50 || jpegCount >= expectedImageCount)
+                                {
+                                    lastLoggedCount = jpegCount;
+                                    _logger.LogInformation("Trickplay extraction: {Percent:F1}% ({CurrentCount}/{ExpectedCount} frames) for {MediaFile}", pct, jpegCount, expectedImageCount, inputFile);
+                                }
+                            }
+                        }
+                        else if ((DateTime.UtcNow - lastImageTime).TotalMilliseconds >= timeoutMs)
+                        {
+                            isResponsive = false;
+                        }
                     }
 
                     if (!ranToCompletion)

--- a/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
+++ b/MediaBrowser.Providers/Trickplay/TrickplayImagesTask.cs
@@ -44,11 +44,16 @@ public class TrickplayImagesTask : IScheduledTask
         _trickplayManager = trickplayManager;
     }
 
+    private string? _currentDescription;
+
     /// <inheritdoc />
     public string Name => _localization.GetLocalizedString("TaskRefreshTrickplayImages");
 
     /// <inheritdoc />
-    public string Description => _localization.GetLocalizedString("TaskRefreshTrickplayImagesDescription");
+    public string Description =>
+        string.IsNullOrEmpty(_currentDescription)
+            ? _localization.GetLocalizedString("TaskRefreshTrickplayImagesDescription")
+            : _currentDescription;
 
     /// <inheritdoc />
     public string Key => "RefreshTrickplayImages";
@@ -72,45 +77,90 @@ public class TrickplayImagesTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
-        var query = new InternalItemsQuery
+        var virtualFolders = _libraryManager.GetVirtualFolders();
+        var eligibleFolders = virtualFolders
+            .Where(vf => vf.LibraryOptions?.EnableTrickplayImageExtraction ?? false)
+            .ToList();
+
+        if (eligibleFolders.Count == 0)
         {
-            MediaTypes = [MediaType.Video],
-            SourceTypes = [SourceType.Library],
-            IsVirtualItem = false,
-            IsFolder = false,
-            Recursive = true,
-            Limit = QueryPageLimit
-        };
+            _logger.LogInformation("No libraries have trickplay extraction enabled.");
+            progress.Report(100);
+            return;
+        }
 
-        var numberOfVideos = _libraryManager.GetCount(query);
-
-        var startIndex = 0;
-        var numComplete = 0;
-
-        while (startIndex < numberOfVideos)
+        var allVideos = new List<Video>();
+        foreach (var folder in eligibleFolders)
         {
-            query.StartIndex = startIndex;
-            var videos = _libraryManager.GetItemList(query).OfType<Video>();
+            if (Guid.TryParse(folder.ItemId, out var folderId))
+            {
+                var query = new InternalItemsQuery
+                {
+                    MediaTypes = [MediaType.Video],
+                    IsVirtualItem = false,
+                    IsFolder = false,
+                    Recursive = true,
+                    ParentId = folderId
+                };
 
-            foreach (var video in videos)
+                allVideos.AddRange(_libraryManager.GetItemList(query).OfType<Video>());
+            }
+        }
+
+        var numberOfVideos = allVideos.Count;
+        _logger.LogInformation("Found {Count} videos in trickplay-enabled libraries.", numberOfVideos);
+
+        if (numberOfVideos == 0)
+        {
+            progress.Report(100);
+            return;
+        }
+
+        var completedCount = 0;
+
+        try
+        {
+            for (var i = 0; i < allVideos.Count; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                var video = allVideos[i];
+                var videoIndex = i + 1;
+
+                _currentDescription = $"Video #{videoIndex}/{numberOfVideos}: {video.Name} - 0%";
+                progress.Report(100d * completedCount / numberOfVideos);
 
                 try
                 {
                     var libraryOptions = _libraryManager.GetLibraryOptions(video);
-                    await _trickplayManager.RefreshTrickplayDataAsync(video, false, libraryOptions, cancellationToken).ConfigureAwait(false);
+                    var videoProgress = new Progress<double>(currentProgress =>
+                    {
+                        _currentDescription = $"Video #{videoIndex}/{numberOfVideos}: {video.Name} - {currentProgress:F0}%";
+                        var overall = 100d * (completedCount + (currentProgress / 100d)) / numberOfVideos;
+                        progress.Report(Math.Min(100d, overall));
+                    });
+
+                    _logger.LogInformation("Starting trickplay extraction for Video #{Index}/{Total}: \"{Name}\"", videoIndex, numberOfVideos, video.Name);
+
+                    await _trickplayManager.RefreshTrickplayDataAsync(
+                        video,
+                        false,
+                        libraryOptions,
+                        cancellationToken,
+                        videoProgress).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Error creating trickplay files for {ItemName}", video.Name);
                 }
 
-                numComplete++;
-                progress.Report(100d * numComplete / numberOfVideos);
+                completedCount++;
+                progress.Report(100d * completedCount / numberOfVideos);
             }
-
-            startIndex += QueryPageLimit;
+        }
+        finally
+        {
+            _currentDescription = null;
         }
 
         progress.Report(100);


### PR DESCRIPTION
### Summary of Changes

1. **Fix 10-bit HEVC CUDA Trickplay Extraction (`EncodingHelper.cs`)**:
   - For 10-bit HEVC/Dolby Vision video streams with NVIDIA CUDA acceleration when MJPEG encoder is used, ensures `scale_cuda` outputs `p010` and `hwdownload` outputs `format=p010` instead of forcing invalid `yuv420p` conversion. Tested on RTX 4070 Ti Super with 4K HDR/DV content.

2. **Active File Tracking & Real-Time Trickplay Progress (`MediaEncoder.cs`, `TrickplayImagesTask.cs`, interfaces)**:
   - **Active File & Progress Display**: Dynamically updates the task description on each frame progress tick to display the exact file currently being processed along with its individual percentage (e.g., `Video #1/2: Movie Title - 35%`), providing immediate visibility in the dashboard and server logs.
   - **Library Filtering**: Filtered candidate items in `TrickplayImagesTask` by libraries that actually have `EnableTrickplayImageExtraction == true`, preventing unrelated items (e.g. Live TV channels or disabled libraries) from diluting the scheduled task progress.
   - **Throttled Frame Logging**: Added periodic frame extraction logging every 50 frames so users and administrators can follow extraction speed and frame counts in real time.

3. **Windows Temp Directory Deletion Tolerance (`TrickplayManager.cs`)**:
   - Added retry and error handling around `Directory.Delete(imgTempDir, true)` in the `finally` block to prevent Windows file-locking `IOException` from aborting a successfully completed trickplay task.

### Testing
- Tested on Windows 11 with NVIDIA RTX 4070 Ti Super on 4K Dolby Vision Profile 8 HEVC Remux content (1 movie, 3 episodes).
- Verified hardware acceleration runs at 18x speed with accurate active-file progress and clean task completion.
