### PR TITLE
Preserve manually edited images during library rescans.

### DIFF
--- a/MediaBrowser.Providers/Manager/ItemImageProvider.cs
+++ b/MediaBrowser.Providers/Manager/ItemImageProvider.cs
@@ -452,6 +452,12 @@ namespace MediaBrowser.Providers.Manager
                         foundImageTypes.Add(type);
                     }
 
+                    // Preserve user-edited images stored in internal metadata when local images exist in the media folder
+                    if (ShouldPreserveExistingImage(item, currentImage, image, refreshOptions, type))
+                    {
+                        continue;
+                    }
+
                     if (currentImage is null || !string.Equals(currentImage.Path, image.FileInfo.FullName, StringComparison.OrdinalIgnoreCase))
                     {
                         item.SetImagePath(type, image.FileInfo);
@@ -512,6 +518,25 @@ namespace MediaBrowser.Providers.Manager
             }
 
             return changed;
+        }
+
+        private static bool ShouldPreserveExistingImage(BaseItem item, ItemImageInfo currentImage, LocalImageInfo newImage, ImageRefreshOptions refreshOptions, ImageType type)
+        {
+            if (currentImage is null || refreshOptions?.IsReplacingImage(type) == true)
+            {
+                return false;
+            }
+
+            var internalMetadataPath = item.GetInternalMetadataPath();
+            if (string.IsNullOrEmpty(internalMetadataPath)
+                || !currentImage.Path.StartsWith(internalMetadataPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Only preserve when the new image comes from the media folder
+            return item.ContainingFolderPath is not null
+                && item.ContainingFolderPath.Contains(Path.GetDirectoryName(newImage.FileInfo.FullName), StringComparison.OrdinalIgnoreCase);
         }
 
         private static LocalImageInfo GetFirstLocalImageInfoByType(IReadOnlyList<LocalImageInfo> images, ImageType type)

--- a/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ItemImageProviderTests.cs
@@ -127,6 +127,92 @@ namespace Jellyfin.Providers.Tests.Manager
             }
         }
 
+        [Fact]
+        public void MergeImages_UserEditedImageInInternalMetadata_NotReplacedByLocalMediaImage()
+        {
+            const string mediaFolder = "/media/shows/Seinfeld";
+            const string internalMetadataPath = "/config/metadata/library/ab/cd1234567890";
+            const string userEditedImagePath = internalMetadataPath + "/poster.jpg";
+            const string localCoverPath = mediaFolder + "/cover.jpg";
+
+            var item = new Mock<Video>
+            {
+                CallBase = true
+            };
+            item.Setup(m => m.IsSaveLocalMetadataEnabled()).Returns(false);
+            item.Setup(m => m.GetInternalMetadataPath()).Returns(internalMetadataPath);
+            item.Setup(m => m.ContainingFolderPath).Returns(mediaFolder);
+
+            item.Object.SetImagePath(ImageType.Primary, 0, new FileSystemMetadata
+            {
+                FullName = userEditedImagePath,
+            });
+
+            var localImages = new[]
+            {
+                new LocalImageInfo
+                {
+                    Type = ImageType.Primary,
+                    FileInfo = new FileSystemMetadata
+                    {
+                        FullName = localCoverPath
+                    }
+                }
+            };
+
+            var itemImageProvider = GetItemImageProvider(null, null);
+            var changed = itemImageProvider.MergeImages(item.Object, localImages, new ImageRefreshOptions(Mock.Of<IDirectoryService>()));
+
+            Assert.False(changed);
+            Assert.Equal(userEditedImagePath, item.Object.GetImagePath(ImageType.Primary, 0));
+        }
+
+        [Fact]
+        public void MergeImages_UserEditedImageInInternalMetadata_ReplacedWhenForced()
+        {
+            const string mediaFolder = "/media/shows/Seinfeld";
+            const string internalMetadataPath = "/config/metadata/library/ab/cd1234567890";
+            const string userEditedImagePath = internalMetadataPath + "/poster.jpg";
+            const string localCoverPath = mediaFolder + "/cover.jpg";
+
+            var item = new Mock<Video>
+            {
+                CallBase = true
+            };
+            item.Setup(m => m.IsSaveLocalMetadataEnabled()).Returns(false);
+            item.Setup(m => m.GetInternalMetadataPath()).Returns(internalMetadataPath);
+            item.Setup(m => m.ContainingFolderPath).Returns(mediaFolder);
+
+            item.Object.SetImagePath(ImageType.Primary, 0, new FileSystemMetadata
+            {
+                FullName = userEditedImagePath,
+            });
+
+            var localImages = new[]
+            {
+                new LocalImageInfo
+                {
+                    Type = ImageType.Primary,
+                    FileInfo = new FileSystemMetadata
+                    {
+                        FullName = localCoverPath
+                    }
+                }
+            };
+
+            var refreshOptions = new ImageRefreshOptions(Mock.Of<IDirectoryService>())
+            {
+                ImageRefreshMode = MetadataRefreshMode.FullRefresh,
+                ReplaceAllImages = true
+            };
+
+            var itemImageProvider = GetItemImageProvider(null, null);
+            var changed = itemImageProvider.MergeImages(item.Object, localImages, refreshOptions);
+
+            Assert.True(changed);
+            Assert.Equal(localCoverPath, item.Object.GetImagePath(ImageType.Primary, 0));
+        }
+
         [Theory]
         [InlineData(ImageType.Primary, 1, false)]
         [InlineData(ImageType.Backdrop, 2, false)]


### PR DESCRIPTION
## Preserve manually edited images during library rescans

**Changes**

When a user sets an item’s image through Edit Images, Jellyfin stores it in internal metadata (unless “Save artwork into media folders” is enabled). During a normal library rescan, `MergeImages` was replacing those images with local files such as `cover.jpg` or `poster.jpg` found in the item’s media folder.

This change skips that replacement when the current image is stored in internal metadata and the scan is not an explicit image replace. Manually chosen artwork is kept across rescans. A full metadata refresh with “Replace all images” still replaces images as before.

**Code assistance**

Implementation and tests were written with AI assistance.

**Issues**

Fixes manually edited show/movie images being overwritten on library rescan when `cover.jpg` (or similar) exists in the item folder.

https://github.com/jellyfin/jellyfin/issues/17780
https://github.com/jellyfin/jellyfin/issues/16528
https://github.com/jellyfin/jellyfin/issues/6709