### PR TITLE
Fix external subtitles being dropped on strm playback refresh

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -179,14 +179,18 @@ namespace Emby.Server.Implementations.Library
             var mediaSources = GetStaticMediaSources(item, enablePathSubstitution, user);
             ResolveSymlinkPaths(mediaSources, enablePathSubstitution);
 
+            var isStrm = item.Path?.EndsWith(".strm", StringComparison.OrdinalIgnoreCase) == true;
+
             // If file is strm or main media stream is missing, force a metadata refresh with remote probing
             if (allowMediaProbe && mediaSources[0].Type != MediaSourceType.Placeholder
-                && (item.Path.EndsWith(".strm", StringComparison.OrdinalIgnoreCase)
+                && (isStrm
                     || (item.MediaType == MediaType.Video && mediaSources[0].MediaStreams.All(i => i.Type != MediaStreamType.Video))
                     || (item.MediaType == MediaType.Audio && mediaSources[0].MediaStreams.All(i => i.Type != MediaStreamType.Audio))))
             {
+                // Use a current folder snapshot so remote probing cannot overwrite sidecars with stale cache data.
+                var directoryService = isStrm ? new DirectoryService(_fileSystem) : _directoryService;
                 await item.RefreshMetadata(
-                    new MetadataRefreshOptions(_directoryService)
+                    new MetadataRefreshOptions(directoryService)
                     {
                         EnableRemoteContentProbe = true,
                         MetadataRefreshMode = MetadataRefreshMode.FullRefresh

--- a/tests/Jellyfin.Providers.Tests/BaseItemServiceLocatorCollection.cs
+++ b/tests/Jellyfin.Providers.Tests/BaseItemServiceLocatorCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Jellyfin.Providers.Tests;
+
+[CollectionDefinition("BaseItemServiceLocators", DisableParallelization = true)]
+public sealed class BaseItemServiceLocatorCollection
+{
+}

--- a/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
+++ b/tests/Jellyfin.Providers.Tests/MediaInfo/FFProbeVideoInfoTests.cs
@@ -1,17 +1,33 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
+using Emby.Naming.Common;
+using MediaBrowser.Controller.Chapters;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Persistence;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.IO;
+using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Providers.MediaInfo;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
 namespace Jellyfin.Providers.Tests.MediaInfo;
 
+[Collection("BaseItemServiceLocators")]
 public class FFProbeVideoInfoTests
 {
     private readonly FFProbeVideoInfo _fFProbeVideoInfo;
@@ -121,6 +137,125 @@ public class FFProbeVideoInfoTests
 
         Assert.Null(video.ProductionYear);
         Assert.Null(video.PremiereDate);
+    }
+
+    [Fact]
+    public async Task ProbeVideo_ExternalSubtitle_SavesResolvedStream()
+    {
+        const string videoPath = MediaInfoResolverTests.VideoDirectoryPath + "/Movie.strm";
+        const string subtitlePath = MediaInfoResolverTests.VideoDirectoryPath + "/Movie.eng.srt";
+
+        var mediaSourceManager = new Mock<IMediaSourceManager>();
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsAny<string>())).Returns(MediaProtocol.File);
+        mediaSourceManager.Setup(x => x.GetPathProtocol(It.IsRegex("^https://"))).Returns(MediaProtocol.Http);
+
+        var mediaEncoder = new Mock<IMediaEncoder>();
+        mediaEncoder
+            .Setup(x => x.GetMediaInfo(It.Is<MediaInfoRequest>(r => r.MediaType == DlnaProfileType.Video), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new MediaBrowser.Model.MediaInfo.MediaInfo
+                {
+                    MediaStreams = [new MediaStream { Type = MediaStreamType.Video }]
+                });
+        mediaEncoder
+            .Setup(x => x.GetMediaInfo(It.Is<MediaInfoRequest>(r => r.MediaType == DlnaProfileType.Subtitle), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new MediaBrowser.Model.MediaInfo.MediaInfo
+                {
+                    MediaStreams = [new MediaStream { Type = MediaStreamType.Subtitle, Codec = "subrip" }]
+                });
+
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
+        fileSystem.Setup(x => x.DirectoryExists(MediaInfoResolverTests.VideoDirectoryPath)).Returns(true);
+
+        var localizationManager = Mock.Of<ILocalizationManager>();
+        var audioResolver = new AudioResolver(
+            Mock.Of<ILogger<AudioResolver>>(),
+            localizationManager,
+            mediaEncoder.Object,
+            fileSystem.Object,
+            new NamingOptions());
+        var subtitleResolver = new SubtitleResolver(
+            Mock.Of<ILogger<SubtitleResolver>>(),
+            localizationManager,
+            mediaEncoder.Object,
+            fileSystem.Object,
+            new NamingOptions());
+
+        IReadOnlyList<MediaStream>? savedStreams = null;
+        var streamRepository = new Mock<IMediaStreamRepository>();
+        streamRepository
+            .Setup(x => x.SaveMediaStreams(It.IsAny<Guid>(), It.IsAny<IReadOnlyList<MediaStream>>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, IReadOnlyList<MediaStream>, CancellationToken>((_, streams, _) => savedStreams = streams.ToArray());
+
+        var libraryManager = new Mock<ILibraryManager>();
+        libraryManager.Setup(x => x.GetLibraryOptions(It.IsAny<BaseItem>())).Returns(new LibraryOptions());
+
+        var chapterManager = new Mock<IChapterManager>();
+        chapterManager
+            .Setup(x => x.RefreshChapterImages(
+                It.IsAny<Video>(),
+                It.IsAny<IDirectoryService>(),
+                It.IsAny<IReadOnlyList<ChapterInfo>>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var serverConfig = new Mock<IServerConfigurationManager>();
+        serverConfig.Setup(x => x.Configuration).Returns(new ServerConfiguration());
+
+        var probe = new FFProbeVideoInfo(
+            Mock.Of<ILogger<FFProbeVideoInfo>>(),
+            mediaSourceManager.Object,
+            mediaEncoder.Object,
+            Mock.Of<IBlurayExaminer>(),
+            localizationManager,
+            chapterManager.Object,
+            serverConfig.Object,
+            Mock.Of<MediaBrowser.Controller.Subtitles.ISubtitleManager>(),
+            libraryManager.Object,
+            audioResolver,
+            subtitleResolver,
+            Mock.Of<IMediaAttachmentRepository>(),
+            streamRepository.Object);
+
+        var video = new Mock<Video> { CallBase = true };
+        video.Setup(x => x.ContainingFolderPath).Returns(MediaInfoResolverTests.VideoDirectoryPath);
+        video.Setup(x => x.GetInternalMetadataPath()).Returns(MediaInfoResolverTests.MetadataDirectoryPath);
+        video.Object.Id = Guid.NewGuid();
+        video.Object.ParentId = Guid.Empty;
+        video.Object.Path = videoPath;
+        video.Object.IsShortcut = true;
+        video.Object.ShortcutPath = "https://example.com/Movie.mp4";
+
+        var directoryService = new Mock<IDirectoryService>();
+        directoryService.Setup(x => x.GetFilePaths(MediaInfoResolverTests.VideoDirectoryPath, false)).Returns([videoPath, subtitlePath]);
+
+        var previousMediaSourceManager = BaseItem.MediaSourceManager;
+        BaseItem.MediaSourceManager = mediaSourceManager.Object;
+        try
+        {
+            await probe.ProbeVideo(
+                video.Object,
+                new MetadataRefreshOptions(directoryService.Object)
+                {
+                    EnableRemoteContentProbe = true,
+                    MetadataRefreshMode = MetadataRefreshMode.FullRefresh
+                },
+                CancellationToken.None);
+        }
+        finally
+        {
+            BaseItem.MediaSourceManager = previousMediaSourceManager;
+        }
+
+        Assert.NotNull(savedStreams);
+        var subtitle = Assert.Single(savedStreams, x => x.Type == MediaStreamType.Subtitle);
+        Assert.True(subtitle.IsExternal);
+        Assert.Equal(subtitlePath, subtitle.Path);
+        Assert.Equal([subtitlePath], video.Object.SubtitleFiles);
     }
 
     private static MediaBrowser.Model.MediaInfo.MediaInfo CreateMediaInfoWithDates()

--- a/tests/Jellyfin.Server.Implementations.Tests/BaseItemServiceLocatorCollection.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/BaseItemServiceLocatorCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests;
+
+[CollectionDefinition("BaseItemServiceLocators", DisableParallelization = true)]
+public sealed class BaseItemServiceLocatorCollection
+{
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoFixture;
 using AutoFixture.AutoMoq;
 using Castle.Components.DictionaryAdapter;
@@ -11,6 +13,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
@@ -21,6 +24,7 @@ using Xunit;
 
 namespace Jellyfin.Server.Implementations.Tests.Library
 {
+    [Collection("BaseItemServiceLocators")]
     public class MediaSourceManagerTests
     {
         private readonly MediaSourceManager _mediaSourceManager;
@@ -57,6 +61,81 @@ namespace Jellyfin.Server.Implementations.Tests.Library
         [InlineData("rtsp://media.example.com:554/twister/audiotrack", MediaProtocol.Rtsp)]
         public void GetPathProtocol_ValidArg_Correct(string path, MediaProtocol expected)
             => Assert.Equal(expected, _mediaSourceManager.GetPathProtocol(path));
+
+        [Theory]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public async Task GetPlaybackMediaSources_StrmRefreshUsesCurrentDirectoryContents(
+            bool subtitleInitiallyExists,
+            bool subtitleCurrentlyExists)
+        {
+            const string directoryPath = @"C:\media";
+            const string streamPath = @"C:\media\Movie.strm";
+            const string subtitlePath = @"C:\media\Movie.eng.srt";
+
+            IReadOnlyList<string> currentDirectoryContents = subtitleInitiallyExists
+                ? [streamPath, subtitlePath]
+                : [streamPath];
+
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .Setup(x => x.GetFilePaths(directoryPath, false))
+                .Returns(() => currentDirectoryContents);
+
+            var cachedDirectoryService = new DirectoryService(fileSystem.Object);
+            _ = cachedDirectoryService.GetFilePaths(directoryPath);
+
+            currentDirectoryContents = subtitleCurrentlyExists
+                ? [streamPath, subtitlePath]
+                : [streamPath];
+
+            IFixture fixture = new Fixture().Customize(new AutoMoqCustomization { ConfigureMembers = true });
+            fixture.Inject(fileSystem.Object);
+            fixture.Inject<IDirectoryService>(cachedDirectoryService);
+
+            var mediaSourceManager = fixture.Create<MediaSourceManager>();
+            mediaSourceManager.AddParts([]);
+
+            var item = new Mock<Video> { CallBase = true };
+            item
+                .Setup(x => x.GetMediaSources(It.IsAny<bool>()))
+                .Returns(
+                    [
+                        new MediaSourceInfo
+                        {
+                            Id = Guid.NewGuid().ToString("N"),
+                            Path = "https://example.com/Movie.mp4",
+                            Protocol = MediaProtocol.Http,
+                            MediaStreams = [new MediaStream { Type = MediaStreamType.Video }]
+                        }
+                    ]);
+            item.Object.Id = Guid.NewGuid();
+            item.Object.ParentId = Guid.Empty;
+            item.Object.Path = streamPath;
+
+            MetadataRefreshOptions? refreshOptions = null;
+            var providerManager = new Mock<IProviderManager>();
+            providerManager
+                .Setup(x => x.RefreshSingleItem(It.IsAny<BaseItem>(), It.IsAny<MetadataRefreshOptions>(), It.IsAny<CancellationToken>()))
+                .Callback<BaseItem, MetadataRefreshOptions, CancellationToken>((_, options, _) => refreshOptions = options)
+                .ReturnsAsync(ItemUpdateType.None);
+
+            var previousProviderManager = BaseItem.ProviderManager;
+            BaseItem.ProviderManager = providerManager.Object;
+            try
+            {
+                _ = await mediaSourceManager.GetPlaybackMediaSources(item.Object, null, true, false, CancellationToken.None);
+            }
+            finally
+            {
+                BaseItem.ProviderManager = previousProviderManager;
+            }
+
+            Assert.NotNull(refreshOptions);
+            Assert.Equal(
+                subtitleCurrentlyExists,
+                refreshOptions.DirectoryService.GetFilePaths(directoryPath).Contains(subtitlePath, StringComparer.Ordinal));
+        }
 
         [Theory]
         [InlineData(5, "eng", "eng", false, true)]


### PR DESCRIPTION
**Changes**

`MediaSourceManager.GetPlaybackMediaSources` forces a `FullRefresh` with `EnableRemoteContentProbe` for every `.strm` item on every `PlaybackInfo` call. That refresh currently receives the injected `IDirectoryService`, which is registered as a singleton (`ApplicationHost.cs`) and caches each folder listing for the life of the process. `MediaInfoResolver.GetExternalFiles` therefore sees a stale listing of the item's folder and of its internal metadata folder, so any external subtitle added after the folder was first listed (an OpenSubtitles download, a new sidecar) is not rediscovered, and `SaveMediaStreams` then rewrites the stream list without it. The scanner and the subtitle download endpoint use a fresh `DirectoryService`, which is why the subtitle shows in the UI, disappears on the next playback, and returns after a server restart.

This change gives the `.strm` playback-time refresh a fresh `DirectoryService` so remote probing works from the current folder contents. Two tests cover it: `FFProbeVideoInfoTests.ProbeVideo_ExternalSubtitle_SavesResolvedStream` (an external subtitle next to a remote `.strm` is kept when probing with `EnableRemoteContentProbe`) and `MediaSourceManagerTests.GetPlaybackMediaSources_StrmRefreshUsesCurrentDirectoryContents` (the refresh sees the current directory contents rather than the cached ones).

Verified on a live 10.11.11 server with this one-file change backported: before, `POST /Items/{id}/Refresh` re-added two downloaded `.srt` streams and a single `GET /Items/{id}/PlaybackInfo` removed them again; after, they persist across repeated `PlaybackInfo` calls and are delivered to the client as `DeliveryMethod=External`.

Related: #16869 (snapshot and restore of external streams around the refresh) and #17050 (skip the re-probe when streams are persisted) address the same symptom from the other side; this PR removes the stale cache that causes the loss while keeping the probe behaviour unchanged.

**Code assistance**

The analysis, patch and tests were prepared with AI assistance (Anthropic Claude) by tracing the v10.11.11 and master sources; the fix was then reproduced and validated on a live 10.11.11 deployment as described above.

**Issues**

Fixes #15882
Fixes #10338
