### PR TITLE
Fix crash when SyncPlay shuffle mode is set to sorted twice

### DIFF
--- a/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
+++ b/MediaBrowser.Controller/SyncPlay/Queue/PlayQueueManager.cs
@@ -157,7 +157,10 @@ namespace MediaBrowser.Controller.SyncPlay.Queue
         /// </summary>
         public void RestoreSortedPlaylist()
         {
-            if (PlayingItemIndex != NoPlayingItemIndex)
+            // The shuffled playlist is only populated while the shuffle mode is active, so there is
+            // nothing to map back when the playlist is already sorted. Guarding on its contents keeps
+            // a redundant request for the sorted mode from indexing an empty list.
+            if (PlayingItemIndex != NoPlayingItemIndex && _shuffledPlaylist.Count > 0)
             {
                 var playingItem = _shuffledPlaylist[PlayingItemIndex];
                 PlayingItemIndex = _sortedPlaylist.IndexOf(playingItem);

--- a/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/PlayQueueManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/PlayQueueManagerTests.cs
@@ -143,6 +143,36 @@ public class PlayQueueManagerTests
     }
 
     [Fact]
+    public void SetShuffleMode_SortedWhileAlreadySorted_KeepsPlayingItem()
+    {
+        var queue = CreateQueue(3);
+        queue.SetPlayingItemByIndex(1);
+        var expectedItemId = queue.GetPlayingItemId();
+
+        queue.SetShuffleMode(GroupShuffleMode.Sorted);
+
+        Assert.Equal(GroupShuffleMode.Sorted, queue.ShuffleMode);
+        Assert.Equal(1, queue.PlayingItemIndex);
+        Assert.Equal(expectedItemId, queue.GetPlayingItemId());
+    }
+
+    [Fact]
+    public void SetShuffleMode_SortedTwiceAfterShuffle_KeepsPlayingItem()
+    {
+        var queue = CreateQueue(5);
+        queue.SetPlayingItemByIndex(2);
+        var expectedItemId = queue.GetPlayingItemId();
+
+        queue.SetShuffleMode(GroupShuffleMode.Shuffle);
+        queue.SetShuffleMode(GroupShuffleMode.Sorted);
+        queue.SetShuffleMode(GroupShuffleMode.Sorted);
+
+        Assert.Equal(GroupShuffleMode.Sorted, queue.ShuffleMode);
+        Assert.Equal(5, queue.GetPlaylist().Count);
+        Assert.Equal(expectedItemId, queue.GetPlayingItemId());
+    }
+
+    [Fact]
     public void SetPlayingItemByIndex_InBounds_SetsPlayingItem()
     {
         var queue = CreateQueue(2);


### PR DESCRIPTION
**Changes**

`PlayQueueManager.RestoreSortedPlaylist` indexed `_shuffledPlaylist` whenever an item was playing, but that list is only populated while the shuffle mode is active. Setting the sorted mode on a queue that is already sorted therefore threw `ArgumentOutOfRangeException`, which reached the client as an HTTP 500 from `POST /SyncPlay/SetShuffleMode` and left its shuffle control out of sync with the group. Any group member can trigger it with a single request.

The remap is now guarded on the shuffled playlist actually having contents, so a redundant request for the current mode is a no-op instead of a throw. Two regression tests are added; both fail without the change.

**Code assistance**

Opus 5 was used to locate the defect, write the regression tests and check that the fix did not change behaviour on the shuffle and round-trip paths.

**Issues**

None filed for this.
