### PR TITLE
Drop SyncPlay requests from sessions that left the group

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
+++ b/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
@@ -332,8 +332,11 @@ namespace Emby.Server.Implementations.SyncPlay
                 // Group lock required as Group is not thread-safe.
                 lock (group)
                 {
-                    // Make sure that session still belongs to this group.
-                    if (_sessionToGroupMap.TryGetValue(session.Id, out var checkGroup) && !checkGroup.GroupId.Equals(group.GroupId))
+                    // Make sure that session still belongs to this group. The lookup can fail
+                    // outright when the session left while this request was waiting on the group
+                    // lock, which is exactly the case this re-check exists to catch.
+                    if (!_sessionToGroupMap.TryGetValue(session.Id, out var checkGroup)
+                        || !checkGroup.GroupId.Equals(group.GroupId))
                     {
                         // Drop request.
                         return;


### PR DESCRIPTION
**Changes**

`SyncPlayManager.HandleRequest` re-checks that the session still belongs to the group after taking the group lock, because the session can leave while the request waits on that lock. The check was written as:

```csharp
if (_sessionToGroupMap.TryGetValue(session.Id, out var checkGroup) && !checkGroup.GroupId.Equals(group.GroupId))
```

which drops the request only when the session has moved to a different group. When the lookup fails outright, which is exactly the case where the session left, the `&&` short-circuits, the guard passes and the request is applied anyway. `LeaveGroup` takes the same group lock, so an in-flight request blocks on it and then proceeds against a group it is no longer a member of, letting a departed session seek, pause, replace the queue or skip items for everyone still there.

The guard now fails closed. The equivalent check added in #15159 for `GetQueue` is already written in the positive form, which is the intended behaviour.

No test: the interleaving is a lock-ordering race with no seam to drive it deterministically, and I would rather not add a timing-dependent test. The change is strictly narrowing, so any request the old guard accepted correctly is still accepted.

**Code assistance**

Opus 5 was used to find the short-circuit and confirm the mutation paths for `_sessionToGroupMap` are all under `_groupsLock` while `HandleRequest` is not.

**Issues**

None filed for this.
