### PR TITLE
Fix SyncPlay active session counter leaking on rejoin

### DIFF
--- a/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
+++ b/Emby.Server.Implementations/SyncPlay/SyncPlayManager.cs
@@ -181,8 +181,8 @@ namespace Emby.Server.Implementations.SyncPlay
                     {
                         if (existingGroup.GroupId.Equals(request.GroupId))
                         {
-                            // Restore session.
-                            UpdateSessionsCounter(session.UserId, 1);
+                            // Restore session. The session is already in the group and has already
+                            // been counted, so the counter must not be incremented a second time.
                             group.SessionJoin(session, request, cancellationToken);
                             return;
                         }
@@ -400,7 +400,7 @@ namespace Emby.Server.Implementations.SyncPlay
             // Update sessions counter.
             var newSessionsCounter = _activeUsers.AddOrUpdate(
                 userId,
-                1,
+                toAdd,
                 (_, sessionsCounter) => sessionsCounter + toAdd);
 
             // Should never happen.

--- a/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/SyncPlayManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/SyncPlay/SyncPlayManagerTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Controller.SyncPlay.Requests;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using SyncPlayManager = Emby.Server.Implementations.SyncPlay.SyncPlayManager;
+
+namespace Jellyfin.Server.Implementations.Tests.SyncPlay;
+
+public class SyncPlayManagerTests
+{
+    [Fact]
+    public void LeaveGroup_AfterJoiningTheSameGroupTwice_ClearsTheActiveSessionCounter()
+    {
+        var harness = new ManagerHarness();
+
+        var info = harness.Manager.NewGroup(harness.Session, new NewGroupRequest("group"), CancellationToken.None);
+        Assert.True(harness.Manager.IsUserActive(harness.User.Id));
+
+        // A client that re-sends Join for the group it is already in must not be counted twice.
+        harness.Manager.JoinGroup(harness.Session, new JoinGroupRequest(info.GroupId), CancellationToken.None);
+        harness.Manager.LeaveGroup(harness.Session, new LeaveGroupRequest(), CancellationToken.None);
+
+        Assert.False(harness.Manager.IsUserActive(harness.User.Id));
+    }
+
+    [Fact]
+    public void LeaveGroup_AfterASingleJoin_ClearsTheActiveSessionCounter()
+    {
+        var harness = new ManagerHarness();
+
+        harness.Manager.NewGroup(harness.Session, new NewGroupRequest("group"), CancellationToken.None);
+        harness.Manager.LeaveGroup(harness.Session, new LeaveGroupRequest(), CancellationToken.None);
+
+        Assert.False(harness.Manager.IsUserActive(harness.User.Id));
+    }
+
+    [Fact]
+    public void IsUserActive_WithTwoSessionsOfTheSameUser_TracksBothSeparately()
+    {
+        var harness = new ManagerHarness();
+        var second = harness.CreateSession("session-2");
+
+        var info = harness.Manager.NewGroup(harness.Session, new NewGroupRequest("group"), CancellationToken.None);
+        harness.Manager.JoinGroup(second, new JoinGroupRequest(info.GroupId), CancellationToken.None);
+
+        harness.Manager.LeaveGroup(harness.Session, new LeaveGroupRequest(), CancellationToken.None);
+        Assert.True(harness.Manager.IsUserActive(harness.User.Id));
+
+        harness.Manager.LeaveGroup(second, new LeaveGroupRequest(), CancellationToken.None);
+        Assert.False(harness.Manager.IsUserActive(harness.User.Id));
+    }
+
+    private sealed class ManagerHarness
+    {
+        private readonly Mock<ISessionManager> _sessionManager = new();
+
+        public ManagerHarness()
+        {
+            var userManager = new Mock<IUserManager>();
+            var libraryManager = new Mock<ILibraryManager>();
+
+            User = new User("tester", "auth-provider", "pwdreset-provider");
+            userManager.Setup(m => m.GetUserById(It.IsAny<Guid>())).Returns(User);
+
+            Manager = new SyncPlayManager(
+                NullLoggerFactory.Instance,
+                userManager.Object,
+                _sessionManager.Object,
+                libraryManager.Object);
+
+            Session = CreateSession("session-1");
+        }
+
+        public SyncPlayManager Manager { get; }
+
+        public User User { get; }
+
+        public SessionInfo Session { get; }
+
+        public SessionInfo CreateSession(string id)
+        {
+            return new SessionInfo(_sessionManager.Object, NullLogger.Instance)
+            {
+                Id = id,
+                UserId = User.Id,
+                UserName = User.Username
+            };
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

The active session counter that backs `ISyncPlayManager.IsUserActive` could never return to zero once a client re-sent `Join` for the group it was already in.

Two things were wrong. `JoinGroup`'s restore branch called `UpdateSessionsCounter(session.UserId, 1)` for a session already present in `_sessionToGroupMap`, and therefore already counted, while `Group.AddSession` uses `TryAdd` and silently does nothing on re-add. The counter reached two with one participant, and a single leave brought it back to one rather than zero. Separately, `UpdateSessionsCounter` passed a hardcoded `1` as the add value to `AddOrUpdate` instead of `toAdd`, so a decrement on a missing key would have incremented.

`Policies.SyncPlayHasAccess` succeeds on `IsUserActive` alone, so a leaked counter kept SyncPlay access granted for a user whose access an administrator had since set to `None`, until the server restarted.

Three tests are added covering the rejoin case, the plain case, and two sessions of the same user. The first fails without the change.

**Code assistance**

Opus 5 was used to find the double count, confirm `TryAdd` masks it, and write the tests.

**Issues**

Related in symptom to #17352, though that report is mostly about group cleanup, which #17079 addressed. I am not tagging it as fixed.
