### PR TITLE
Omit -level for h264_videotoolbox

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2343,6 +2343,14 @@ namespace MediaBrowser.Controller.MediaEncoding
                     // level option may cause NVENC to fail.
                     // NVENC cannot adjust the given level, just throw an error.
                 }
+                else if (string.Equals(videoEncoder, "h264_videotoolbox", StringComparison.OrdinalIgnoreCase))
+                {
+                    // h264_videotoolbox cannot adjust the given level either. The client's level is a
+                    // decode maximum, not an encoder constraint; when the output does not fit in it
+                    // (e.g. level 4.1 with a 2560x1440 output, or above 62.5 Mbps at 1080p) VideoToolbox
+                    // refuses to create the session ("cannot prepare encoder: -12902", kVTParameterErr).
+                    // Omit the option and let the encoder pick the level that fits the output.
+                }
                 else if (string.Equals(videoEncoder, "h264_vaapi", StringComparison.OrdinalIgnoreCase)
                          || string.Equals(videoEncoder, "hevc_vaapi", StringComparison.OrdinalIgnoreCase)
                          || string.Equals(videoEncoder, "av1_vaapi", StringComparison.OrdinalIgnoreCase))

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperTests.cs
@@ -287,6 +287,32 @@ public class EncodingHelperTests
         };
     }
 
+    [Theory]
+    [InlineData("libx264", true)]
+    [InlineData("h264_videotoolbox", false)]
+    public void GetVideoQualityParam_RequestedH264Level_OmittedForVideoToolbox(string videoEncoder, bool expectLevel)
+    {
+        var state = BuildState(subtitle: null, deliveryMethod: null);
+        state.OutputVideoCodec = "h264";
+        state.BaseRequest.Level = "41";
+        var options = new EncodingOptions
+        {
+            HardwareAccelerationType = expectLevel ? HardwareAccelerationType.none : HardwareAccelerationType.videotoolbox
+        };
+
+        var param = CreateHelper().GetVideoQualityParam(state, videoEncoder, options, EncoderPreset.veryfast);
+
+        if (expectLevel)
+        {
+            Assert.Contains(" -level 41", param, StringComparison.Ordinal);
+        }
+        else
+        {
+            // VideoToolbox rejects a level that cannot hold the output (kVTParameterErr -12902).
+            Assert.DoesNotContain("-level", param, StringComparison.Ordinal);
+        }
+    }
+
     private static EncodingJobInfo BuildState(
         MediaStream? subtitle,
         SubtitleDeliveryMethod? deliveryMethod,


### PR DESCRIPTION
**Changes**

`GetVideoQualityParam` passes the H.264 level from the client's device profile to every encoder except NVENC (which "cannot adjust the given level"). VideoToolbox has the same limitation: when the requested level cannot hold the output, `h264_videotoolbox` refuses to create the session (`cannot prepare encoder: -12902`, `kVTParameterErr`) and the transcode dies before the first segment. Two ordinary requests produce such a command today:

- a 2160p source whose H.264 output is normalized to 2560×1440 (`ResolutionNormalizer`, 20 Mbps → max width 2560) while the client declares level 4.1 — 1440p needs level 5.1;
- a 1080p output whose bitrate resolves above 62.5 Mbps (the level 4.1 High limit), e.g. a ~67 Mbps source with an unlimited client bitrate.

This PR adds an `h264_videotoolbox` branch next to the NVENC one that omits `-level`, so the encoder picks the level that fits the output (verified: the same commands succeed without `-level`). `hevc_videotoolbox` is left as is; it accepts any requested level in testing (5.0 at 2160p60 and 80 Mbps included). A unit test covers the omission for `h264_videotoolbox` and the unchanged `libx264` behaviour.

Encoder-only reproduction with jellyfin-ffmpeg 7.1.4 on macOS 15.3.1 / Apple M4:

| Output | `-level` | `-b:v` | Result |
|---|---|---|---|
| 2560×1440 | 41 | 20M | `-12902` |
| 1920×1080 | 41 | 62 500 000 | OK |
| 1920×1080 | 41 | 63 000 000 | `-12902` |
| 2560×1440 / 3840×2160 | 51 or none | 20M | OK |

Related: the 2021 report #5670 shows the same error and was closed as stale.

**Code assistance**

Diagnosis, encoder-limit measurements, the patch and the test were prepared with an LLM assistant (Claude); the reproduction and the fix were verified by hand on real hardware (Jellyfin 10.11.11 native on an Apple M4, Jellyfin Android TV client) and the test suite (`Jellyfin.Controller.Tests`, 150 passed) was run locally.

**Issues**

Fixes #17803
Related: #5670 (same error, 2021, closed as stale).