### PR TITLE
Skip tone mapping when BT709 has Dolby Vision

### DIFF
--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1421,6 +1421,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         private static DynamicHdrMetadataRemovalPlan ShouldRemoveDynamicHdrMetadata(EncodingJobInfo state)
         {
             var videoStream = state.VideoStream;
+
             if (videoStream.VideoRange is not VideoRange.HDR)
             {
                 return DynamicHdrMetadataRemovalPlan.None;
@@ -1443,7 +1444,9 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             // Case 2: Client supports DOVI, does not support broken DOVI config
             // Client does not report DOVI support should be allowed to copy bad data for remuxing as HDR10 players would not crash
-            shouldRemoveDovi = shouldRemoveDovi || (requestHasDOVI && videoStream.VideoRangeType == VideoRangeType.DOVIInvalid);
+            shouldRemoveDovi = shouldRemoveDovi || (requestHasDOVI
+                                                    && (videoStream.VideoRangeType == VideoRangeType.DOVIInvalid
+                                                    || videoStream.ColorSpace == "bt709"));
 
             // Special case: we have a video with both EL and HDR10+
             // If the client supports EL but not in the case of coexistence with HDR10+, remove HDR10+ for compatibility reasons.

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1421,7 +1421,6 @@ namespace MediaBrowser.Controller.MediaEncoding
         private static DynamicHdrMetadataRemovalPlan ShouldRemoveDynamicHdrMetadata(EncodingJobInfo state)
         {
             var videoStream = state.VideoStream;
-
             if (videoStream.VideoRange is not VideoRange.HDR)
             {
                 return DynamicHdrMetadataRemovalPlan.None;
@@ -1438,15 +1437,18 @@ namespace MediaBrowser.Controller.MediaEncoding
             var requestHasDOVIwithEL = requestedRangeTypes.Contains(VideoRangeType.DOVIWithEL.ToString(), StringComparison.OrdinalIgnoreCase);
             var requestHasDOVIwithELHDR10plus = requestedRangeTypes.Contains(VideoRangeType.DOVIWithELHDR10Plus.ToString(), StringComparison.OrdinalIgnoreCase);
 
+            if (videoStream.ColorSpace == "bt709" && requestHasDOVI)
+            {
+                return DynamicHdrMetadataRemovalPlan.RemoveDovi;
+            }
+
             var shouldRemoveHdr10Plus = false;
             // Case 1: Client supports HDR10, does not support DOVI with EL but EL presets
             var shouldRemoveDovi = (!requestHasDOVIwithEL && requestHasHDR10) && videoStream.VideoRangeType == VideoRangeType.DOVIWithEL;
 
             // Case 2: Client supports DOVI, does not support broken DOVI config
             // Client does not report DOVI support should be allowed to copy bad data for remuxing as HDR10 players would not crash
-            shouldRemoveDovi = shouldRemoveDovi || (requestHasDOVI
-                                                    && (videoStream.VideoRangeType == VideoRangeType.DOVIInvalid
-                                                    || videoStream.ColorSpace == "bt709"));
+            shouldRemoveDovi = shouldRemoveDovi || (requestHasDOVI && videoStream.VideoRangeType == VideoRangeType.DOVIInvalid);
 
             // Special case: we have a video with both EL and HDR10+
             // If the client supports EL but not in the case of coexistence with HDR10+, remove HDR10+ for compatibility reasons.

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -347,7 +347,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || GetVideoColorBitDepth(state) < 10
-                || !_mediaEncoder.SupportsFilter("tonemapx"))
+                || !_mediaEncoder.SupportsFilter("tonemapx")
+                || state.VideoStream.ColorSpace == "bt709")
             {
                 return false;
             }
@@ -359,7 +360,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || state.VideoStream.ColorSpace == "bt709")
             {
                 return false;
             }
@@ -392,7 +394,8 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
         {
-            if (state.VideoStream is null)
+            if (state.VideoStream is null
+                || state.VideoStream.ColorSpace == "bt709")
             {
                 return false;
             }
@@ -407,7 +410,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVppTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || state.VideoStream.ColorSpace == "bt709")
             {
                 return false;
             }
@@ -431,7 +435,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVideoToolboxTonemapping
-                || GetVideoColorBitDepth(state) < 10)
+                || GetVideoColorBitDepth(state) < 10
+                || state.VideoStream.ColorSpace == "bt709")
             {
                 return false;
             }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -347,8 +347,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || GetVideoColorBitDepth(state) < 10
-                || !_mediaEncoder.SupportsFilter("tonemapx")
-                || state.VideoStream.ColorSpace == "bt709")
+                || !_mediaEncoder.SupportsFilter("tonemapx"))
             {
                 return false;
             }
@@ -360,8 +359,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableTonemapping
-                || GetVideoColorBitDepth(state) < 10
-                || state.VideoStream.ColorSpace == "bt709")
+                || GetVideoColorBitDepth(state) < 10)
             {
                 return false;
             }
@@ -394,8 +392,7 @@ namespace MediaBrowser.Controller.MediaEncoding
 
         private bool IsVulkanHwTonemapAvailable(EncodingJobInfo state, EncodingOptions options)
         {
-            if (state.VideoStream is null
-                || state.VideoStream.ColorSpace == "bt709")
+            if (state.VideoStream is null)
             {
                 return false;
             }
@@ -410,8 +407,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVppTonemapping
-                || GetVideoColorBitDepth(state) < 10
-                || state.VideoStream.ColorSpace == "bt709")
+                || GetVideoColorBitDepth(state) < 10)
             {
                 return false;
             }
@@ -435,8 +431,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         {
             if (state.VideoStream is null
                 || !options.EnableVideoToolboxTonemapping
-                || GetVideoColorBitDepth(state) < 10
-                || state.VideoStream.ColorSpace == "bt709")
+                || GetVideoColorBitDepth(state) < 10)
             {
                 return false;
             }
@@ -1436,11 +1431,6 @@ namespace MediaBrowser.Controller.MediaEncoding
             var requestHasDOVI = requestedRangeTypes.Contains(VideoRangeType.DOVI.ToString(), StringComparison.OrdinalIgnoreCase);
             var requestHasDOVIwithEL = requestedRangeTypes.Contains(VideoRangeType.DOVIWithEL.ToString(), StringComparison.OrdinalIgnoreCase);
             var requestHasDOVIwithELHDR10plus = requestedRangeTypes.Contains(VideoRangeType.DOVIWithELHDR10Plus.ToString(), StringComparison.OrdinalIgnoreCase);
-
-            if (videoStream.ColorSpace == "bt709" && requestHasDOVI)
-            {
-                return DynamicHdrMetadataRemovalPlan.RemoveDovi;
-            }
 
             var shouldRemoveHdr10Plus = false;
             // Case 1: Client supports HDR10, does not support DOVI with EL but EL presets

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -816,11 +816,12 @@ namespace MediaBrowser.Model.Entities
             var blPresentFlag = BlPresentFlag == 1;
             var dvBlCompatId = DvBlSignalCompatibilityId;
 
+            var isSDRColorSpace = ColorSpace is "bt709";
             var isDoViProfile = dvProfile is 5 or 7 or 8 or 10;
             var isDoViELProfile = dvProfile is 7 or 8 or 10;
             var isDoViFlag = rpuPresentFlag && blPresentFlag && dvBlCompatId is 0 or 1 or 4 or 2 or 6;
 
-            if ((isDoViProfile && isDoViFlag)
+            if ((isDoViProfile && isDoViFlag && !isSDRColorSpace)
                 || string.Equals(codecTag, "dovi", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dvh1", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(codecTag, "dvhe", StringComparison.OrdinalIgnoreCase)
@@ -850,6 +851,11 @@ namespace MediaBrowser.Model.Entities
                     _ => (VideoRange.SDR, VideoRangeType.SDR)
                 };
 
+                if (!isSDRColorSpace && isDoViELProfile)
+                {
+                    return (VideoRange.SDR, VideoRangeType.DOVIInvalid);
+                }
+
                 if (Hdr10PlusPresentFlag == true)
                 {
                     return dvRangeSet.Item2 switch
@@ -864,7 +870,6 @@ namespace MediaBrowser.Model.Entities
             }
 
             var colorTransfer = ColorTransfer;
-            var colorSpace = ColorSpace;
 
             if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
             {
@@ -873,10 +878,6 @@ namespace MediaBrowser.Model.Entities
             else if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
             {
                 return (VideoRange.HDR, VideoRangeType.HLG);
-            }
-            else if (string.Equals(colorSpace, "bt709", StringComparison.OrdinalIgnoreCase) && isDoViELProfile)
-            {
-                return (VideoRange.SDR, VideoRangeType.DOVIInvalid);
             }
 
             return (VideoRange.SDR, VideoRangeType.SDR);

--- a/MediaBrowser.Model/Entities/MediaStream.cs
+++ b/MediaBrowser.Model/Entities/MediaStream.cs
@@ -817,6 +817,7 @@ namespace MediaBrowser.Model.Entities
             var dvBlCompatId = DvBlSignalCompatibilityId;
 
             var isDoViProfile = dvProfile is 5 or 7 or 8 or 10;
+            var isDoViELProfile = dvProfile is 7 or 8 or 10;
             var isDoViFlag = rpuPresentFlag && blPresentFlag && dvBlCompatId is 0 or 1 or 4 or 2 or 6;
 
             if ((isDoViProfile && isDoViFlag)
@@ -863,6 +864,7 @@ namespace MediaBrowser.Model.Entities
             }
 
             var colorTransfer = ColorTransfer;
+            var colorSpace = ColorSpace;
 
             if (string.Equals(colorTransfer, "smpte2084", StringComparison.OrdinalIgnoreCase))
             {
@@ -871,6 +873,10 @@ namespace MediaBrowser.Model.Entities
             else if (string.Equals(colorTransfer, "arib-std-b67", StringComparison.OrdinalIgnoreCase))
             {
                 return (VideoRange.HDR, VideoRangeType.HLG);
+            }
+            else if (string.Equals(colorSpace, "bt709", StringComparison.OrdinalIgnoreCase) && isDoViELProfile)
+            {
+                return (VideoRange.SDR, VideoRangeType.DOVIInvalid);
             }
 
             return (VideoRange.SDR, VideoRangeType.SDR);


### PR DESCRIPTION
**Changes**
Adds color space checks when determining whether to use tone mapping and whether to discard Dolby Vision metadata.  Currently there are no checks for color space.  A BT709 file with a Dolby Vision 7 EL should not be tone mapped.  The Dolby Vision data should simply be discard.

**Code assistance**
None

**Issues**
Fixes issue posted on the forum.

https://forum.jellyfin.org/t-dolby-vision-7-8-being-tone-mapped-incorrectly
