### PR TITLE
Add plugin hooks for session audio filters and edit graphs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -241,6 +241,7 @@
  - [m0g3r](https://github.com/m0g3r)
  - [martin-77](https://github.com/martin-77)
  - [Oggeb1](https://github.com/Oggeb1)
+ - [mcorrigan](https://github.com/mcorrigan)
 
 # Emby Contributors
 

--- a/Emby.Server.Implementations/ApplicationHost.cs
+++ b/Emby.Server.Implementations/ApplicationHost.cs
@@ -565,6 +565,8 @@ namespace Emby.Server.Implementations
             serviceCollection.AddSingleton<IItemTypeLookup, ItemTypeLookup>();
 
             serviceCollection.AddSingleton<IMediaEncoder, MediaBrowser.MediaEncoding.Encoder.MediaEncoder>();
+            serviceCollection.AddSingleton<ISessionAudioFilterProvider, NoOpSessionAudioFilterProvider>();
+            serviceCollection.AddSingleton<ISessionMediaEditGraphProvider, NoOpSessionMediaEditGraphProvider>();
             serviceCollection.AddSingleton<EncodingHelper>();
             serviceCollection.AddSingleton<IPathManager, PathManager>();
             serviceCollection.AddSingleton<IExternalDataManager, ExternalDataManager>();

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1600,18 +1600,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         var threads = EncodingHelper.GetNumberOfThreads(state, _encodingOptions, videoCodec);
 
         var mapArgs = state.IsOutputVideo ? _encodingHelper.GetMapArgs(state) : string.Empty;
-        var editGraphPrefix = string.Empty;
-        long? savedEditSeek = null;
-        if (state.IsOutputVideo
-            && _encodingHelper.TryGetSessionEditGraphMapArgs(state, out var filterComplexArg, out var editMapArgs))
-        {
-            editGraphPrefix = filterComplexArg + " ";
-            mapArgs = editMapArgs;
-            savedEditSeek = state.BaseRequest.StartTimeTicks;
-            state.BaseRequest.StartTimeTicks = 0;
-            state.BaseRequest.AllowVideoStreamCopy = false;
-            state.BaseRequest.AllowAudioStreamCopy = false;
-        }
+        var editGraphPrefix = TryStartSessionEditGraph(state, ref mapArgs, out var savedEditSeek);
 
         var directory = Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath));
         var outputFileNameWithoutExtension = Path.GetFileNameWithoutExtension(outputPath);
@@ -1623,10 +1612,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         var segmentContainer = outputExtension.TrimStart('.');
         var inputModifier = _encodingHelper.GetInputModifier(state, _encodingOptions, segmentContainer);
         var inputArgument = _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer);
-        if (savedEditSeek.HasValue)
-        {
-            state.BaseRequest.StartTimeTicks = savedEditSeek;
-        }
+        RestoreSessionEditGraphSeek(state, savedEditSeek);
 
         var hlsArguments = $"-hls_playlist_type {(isEventPlaylist ? "event" : "vod")} -hls_list_size 0";
 
@@ -1674,15 +1660,12 @@ public class DynamicHlsController : BaseJellyfinApiController
                 Path.GetFileNameWithoutExtension(outputPath));
         }
 
-        var videoArgs = GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer);
-        var audioArgs = GetAudioArguments(state);
-        var timestampArgs = "-copyts -avoid_negative_ts disabled";
-        if (!string.IsNullOrEmpty(editGraphPrefix))
-        {
-            videoArgs = GetVideoArgumentsForEditGraph(state, startNumber, isEventPlaylist);
-            audioArgs = GetAudioArgumentsForEditGraph(state);
-            timestampArgs = "-avoid_negative_ts make_zero";
-        }
+        var (videoArgs, audioArgs, timestampArgs) = GetHlsCodecAndTimestampArgs(
+            state,
+            startNumber,
+            isEventPlaylist,
+            segmentContainer,
+            editGraphPrefix);
 
         return string.Format(
             CultureInfo.InvariantCulture,
@@ -1703,6 +1686,52 @@ public class DynamicHlsController : BaseJellyfinApiController
             outputTsArg.EscapeProcessArgument(),
             hlsArguments,
             outputPath.EscapeProcessArgument()).Trim();
+    }
+
+    private string TryStartSessionEditGraph(StreamState state, ref string mapArgs, out long? savedEditSeek)
+    {
+        savedEditSeek = null;
+        if (!state.IsOutputVideo
+            || !_encodingHelper.TryGetSessionEditGraphMapArgs(state, out var filterComplexArg, out var editMapArgs))
+        {
+            return string.Empty;
+        }
+
+        mapArgs = editMapArgs;
+        savedEditSeek = state.BaseRequest.StartTimeTicks;
+        state.BaseRequest.StartTimeTicks = 0;
+        state.BaseRequest.AllowVideoStreamCopy = false;
+        state.BaseRequest.AllowAudioStreamCopy = false;
+        return filterComplexArg + " ";
+    }
+
+    private static void RestoreSessionEditGraphSeek(StreamState state, long? savedEditSeek)
+    {
+        if (savedEditSeek.HasValue)
+        {
+            state.BaseRequest.StartTimeTicks = savedEditSeek;
+        }
+    }
+
+    private (string VideoArgs, string AudioArgs, string TimestampArgs) GetHlsCodecAndTimestampArgs(
+        StreamState state,
+        int startNumber,
+        bool isEventPlaylist,
+        string segmentContainer,
+        string editGraphPrefix)
+    {
+        if (string.IsNullOrEmpty(editGraphPrefix))
+        {
+            return (
+                GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer),
+                GetAudioArguments(state),
+                "-copyts -avoid_negative_ts disabled");
+        }
+
+        return (
+            GetVideoArgumentsForEditGraph(state, startNumber, isEventPlaylist),
+            GetAudioArgumentsForEditGraph(state),
+            "-avoid_negative_ts make_zero");
     }
 
     private string GetVideoArgumentsForEditGraph(StreamState state, int startNumber, bool isEventPlaylist)

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -60,6 +60,7 @@ public class DynamicHlsController : BaseJellyfinApiController
     private readonly IDynamicHlsPlaylistGenerator _dynamicHlsPlaylistGenerator;
     private readonly DynamicHlsHelper _dynamicHlsHelper;
     private readonly EncodingOptions _encodingOptions;
+    private readonly IEnumerable<ISessionPlaybackPlanLoader> _playbackPlanLoaders;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DynamicHlsController"/> class.
@@ -75,6 +76,7 @@ public class DynamicHlsController : BaseJellyfinApiController
     /// <param name="dynamicHlsHelper">Instance of <see cref="DynamicHlsHelper"/>.</param>
     /// <param name="encodingHelper">Instance of <see cref="EncodingHelper"/>.</param>
     /// <param name="dynamicHlsPlaylistGenerator">Instance of <see cref="IDynamicHlsPlaylistGenerator"/>.</param>
+    /// <param name="playbackPlanLoaders">Optional plugin loaders run before the first FFmpeg request.</param>
     public DynamicHlsController(
         ILibraryManager libraryManager,
         IUserManager userManager,
@@ -86,7 +88,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         ILogger<DynamicHlsController> logger,
         DynamicHlsHelper dynamicHlsHelper,
         EncodingHelper encodingHelper,
-        IDynamicHlsPlaylistGenerator dynamicHlsPlaylistGenerator)
+        IDynamicHlsPlaylistGenerator dynamicHlsPlaylistGenerator,
+        IEnumerable<ISessionPlaybackPlanLoader>? playbackPlanLoaders = null)
     {
         _libraryManager = libraryManager;
         _userManager = userManager;
@@ -99,6 +102,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         _dynamicHlsHelper = dynamicHlsHelper;
         _encodingHelper = encodingHelper;
         _dynamicHlsPlaylistGenerator = dynamicHlsPlaylistGenerator;
+        _playbackPlanLoaders = playbackPlanLoaders ?? Array.Empty<ISessionPlaybackPlanLoader>();
 
         _encodingOptions = serverConfigurationManager.GetEncodingOptions();
     }
@@ -280,6 +284,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         // Due to CTS.Token calling ThrowIfDisposed (https://github.com/dotnet/runtime/issues/29970) we have to "cache" the token
         // since it gets disposed when ffmpeg exits
         var cancellationToken = cancellationTokenSource.Token;
+        await ApplyPlaybackPlanTranscodeFlagsAsync(streamingRequest, itemId.ToString("N", CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
         var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
                 HttpContext,
@@ -515,6 +520,11 @@ public class DynamicHlsController : BaseJellyfinApiController
             EnableAudioVbrEncoding = enableAudioVbrEncoding,
             AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding
         };
+
+        await ApplyPlaybackPlanTranscodeFlagsAsync(
+            streamingRequest,
+            itemId.ToString("N", CultureInfo.InvariantCulture),
+            HttpContext.RequestAborted).ConfigureAwait(false);
 
         return await _dynamicHlsHelper.GetMasterHlsPlaylist(TranscodingJobType, streamingRequest, enableAdaptiveBitrateStreaming).ConfigureAwait(false);
     }
@@ -1386,6 +1396,10 @@ public class DynamicHlsController : BaseJellyfinApiController
 
     private async Task<ActionResult> GetVariantPlaylistInternal(StreamingRequestDto streamingRequest, CancellationTokenSource cancellationTokenSource)
     {
+        await ApplyPlaybackPlanTranscodeFlagsAsync(
+            streamingRequest,
+            streamingRequest.Id.ToString("N", CultureInfo.InvariantCulture),
+            cancellationTokenSource.Token).ConfigureAwait(false);
         using var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
                 HttpContext,
@@ -1434,6 +1448,11 @@ public class DynamicHlsController : BaseJellyfinApiController
         // CTS lifecycle is managed internally.
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
+
+        await ApplyPlaybackPlanTranscodeFlagsAsync(
+            streamingRequest,
+            streamingRequest.Id.ToString("N", CultureInfo.InvariantCulture),
+            cancellationToken).ConfigureAwait(false);
 
         var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
@@ -1581,6 +1600,18 @@ public class DynamicHlsController : BaseJellyfinApiController
         var threads = EncodingHelper.GetNumberOfThreads(state, _encodingOptions, videoCodec);
 
         var mapArgs = state.IsOutputVideo ? _encodingHelper.GetMapArgs(state) : string.Empty;
+        var editGraphPrefix = string.Empty;
+        long? savedEditSeek = null;
+        if (state.IsOutputVideo
+            && _encodingHelper.TryGetSessionEditGraphMapArgs(state, out var filterComplexArg, out var editMapArgs))
+        {
+            editGraphPrefix = filterComplexArg + " ";
+            mapArgs = editMapArgs;
+            savedEditSeek = state.BaseRequest.StartTimeTicks;
+            state.BaseRequest.StartTimeTicks = 0;
+            state.BaseRequest.AllowVideoStreamCopy = false;
+            state.BaseRequest.AllowAudioStreamCopy = false;
+        }
 
         var directory = Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath));
         var outputFileNameWithoutExtension = Path.GetFileNameWithoutExtension(outputPath);
@@ -1591,6 +1622,12 @@ public class DynamicHlsController : BaseJellyfinApiController
         var segmentFormat = string.Empty;
         var segmentContainer = outputExtension.TrimStart('.');
         var inputModifier = _encodingHelper.GetInputModifier(state, _encodingOptions, segmentContainer);
+        var inputArgument = _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer);
+        if (savedEditSeek.HasValue)
+        {
+            state.BaseRequest.StartTimeTicks = savedEditSeek;
+        }
+
         var hlsArguments = $"-hls_playlist_type {(isEventPlaylist ? "event" : "vod")} -hls_list_size 0";
 
         if (string.Equals(segmentContainer, "ts", StringComparison.OrdinalIgnoreCase))
@@ -1637,15 +1674,27 @@ public class DynamicHlsController : BaseJellyfinApiController
                 Path.GetFileNameWithoutExtension(outputPath));
         }
 
+        var videoArgs = GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer);
+        var audioArgs = GetAudioArguments(state);
+        var timestampArgs = "-copyts -avoid_negative_ts disabled";
+        if (!string.IsNullOrEmpty(editGraphPrefix))
+        {
+            videoArgs = GetVideoArgumentsForEditGraph(state, startNumber, isEventPlaylist);
+            audioArgs = GetAudioArgumentsForEditGraph(state);
+            timestampArgs = "-avoid_negative_ts make_zero";
+        }
+
         return string.Format(
             CultureInfo.InvariantCulture,
-            "{0} {1} -map_metadata -1 -map_chapters -1 -threads {2} {3} {4} {5} -copyts -avoid_negative_ts disabled -max_muxing_queue_size {6} -f hls -max_delay 5000000 -hls_time {7} -hls_segment_type {8} -start_number {9}{10} -hls_segment_filename \"{11}\" {12} -y \"{13}\"",
+            "{0} {1} {2}-map_metadata -1 -map_chapters -1 -threads {3} {4} {5} {6} {7} -max_muxing_queue_size {8} -f hls -max_delay 5000000 -hls_time {9} -hls_segment_type {10} -start_number {11}{12} -hls_segment_filename \"{13}\" {14} -y \"{15}\"",
             inputModifier,
-            _encodingHelper.GetInputArgument(state, _encodingOptions, segmentContainer),
+            inputArgument,
+            editGraphPrefix,
             threads,
             mapArgs,
-            GetVideoArguments(state, startNumber, isEventPlaylist, segmentContainer),
-            GetAudioArguments(state),
+            videoArgs,
+            audioArgs,
+            timestampArgs,
             maxMuxingQueueSize,
             state.SegmentLength.ToString(CultureInfo.InvariantCulture),
             segmentFormat,
@@ -1654,6 +1703,70 @@ public class DynamicHlsController : BaseJellyfinApiController
             outputTsArg.EscapeProcessArgument(),
             hlsArguments,
             outputPath.EscapeProcessArgument()).Trim();
+    }
+
+    private string GetVideoArgumentsForEditGraph(StreamState state, int startNumber, bool isEventPlaylist)
+    {
+        var videoCodec = _encodingHelper.GetVideoEncoder(state, _encodingOptions);
+        if (EncodingHelper.IsCopyCodec(videoCodec))
+        {
+            videoCodec = "libx264";
+        }
+
+        return "-codec:v:0 " + videoCodec
+            + _encodingHelper.GetHlsVideoKeyFrameArguments(state, videoCodec, state.SegmentLength, isEventPlaylist, startNumber);
+    }
+
+    private string GetAudioArgumentsForEditGraph(StreamState state)
+    {
+        if (state.AudioStream is null)
+        {
+            return string.Empty;
+        }
+
+        var audioCodec = _encodingHelper.GetAudioEncoder(state);
+        if (EncodingHelper.IsCopyCodec(audioCodec))
+        {
+            audioCodec = "aac";
+        }
+
+        var args = "-codec:a:0 " + audioCodec;
+        if (state.OutputAudioBitrate.HasValue)
+        {
+            args += " -ab " + state.OutputAudioBitrate.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        return args;
+    }
+
+    /// <summary>
+    /// Loads any plugin playback plan, then forces stream copy off when a session filter or edit graph applies.
+    /// </summary>
+    private async Task ApplyPlaybackPlanTranscodeFlagsAsync(StreamingRequestDto streamingRequest, string? itemId, CancellationToken cancellationToken)
+    {
+        foreach (var loader in _playbackPlanLoaders)
+        {
+            await loader.EnsurePlanLoadedAsync(
+                streamingRequest.PlaySessionId,
+                streamingRequest.DeviceId,
+                itemId,
+                streamingRequest.MediaSourceId,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var playSessionId = streamingRequest.PlaySessionId ?? string.Empty;
+        var deviceId = streamingRequest.DeviceId ?? string.Empty;
+        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(playSessionId, deviceId);
+        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(playSessionId, deviceId);
+        if (hasAudioFilter || hasEditGraph)
+        {
+            streamingRequest.AllowAudioStreamCopy = false;
+        }
+
+        if (hasEditGraph)
+        {
+            streamingRequest.AllowVideoStreamCopy = false;
+        }
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -284,7 +284,11 @@ public class DynamicHlsController : BaseJellyfinApiController
         // Due to CTS.Token calling ThrowIfDisposed (https://github.com/dotnet/runtime/issues/29970) we have to "cache" the token
         // since it gets disposed when ffmpeg exits
         var cancellationToken = cancellationTokenSource.Token;
-        await ApplyPlaybackPlanTranscodeFlagsAsync(streamingRequest, itemId.ToString("N", CultureInfo.InvariantCulture), cancellationToken).ConfigureAwait(false);
+        await _encodingHelper.ApplyPlaybackPlanTranscodeFlagsAsync(
+            _playbackPlanLoaders,
+            streamingRequest,
+            itemId.ToString("N", CultureInfo.InvariantCulture),
+            cancellationToken).ConfigureAwait(false);
         var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
                 HttpContext,
@@ -521,7 +525,8 @@ public class DynamicHlsController : BaseJellyfinApiController
             AlwaysBurnInSubtitleWhenTranscoding = alwaysBurnInSubtitleWhenTranscoding
         };
 
-        await ApplyPlaybackPlanTranscodeFlagsAsync(
+        await _encodingHelper.ApplyPlaybackPlanTranscodeFlagsAsync(
+            _playbackPlanLoaders,
             streamingRequest,
             itemId.ToString("N", CultureInfo.InvariantCulture),
             HttpContext.RequestAborted).ConfigureAwait(false);
@@ -1396,7 +1401,8 @@ public class DynamicHlsController : BaseJellyfinApiController
 
     private async Task<ActionResult> GetVariantPlaylistInternal(StreamingRequestDto streamingRequest, CancellationTokenSource cancellationTokenSource)
     {
-        await ApplyPlaybackPlanTranscodeFlagsAsync(
+        await _encodingHelper.ApplyPlaybackPlanTranscodeFlagsAsync(
+            _playbackPlanLoaders,
             streamingRequest,
             streamingRequest.Id.ToString("N", CultureInfo.InvariantCulture),
             cancellationTokenSource.Token).ConfigureAwait(false);
@@ -1449,7 +1455,8 @@ public class DynamicHlsController : BaseJellyfinApiController
         var cancellationTokenSource = new CancellationTokenSource();
         var cancellationToken = cancellationTokenSource.Token;
 
-        await ApplyPlaybackPlanTranscodeFlagsAsync(
+        await _encodingHelper.ApplyPlaybackPlanTranscodeFlagsAsync(
+            _playbackPlanLoaders,
             streamingRequest,
             streamingRequest.Id.ToString("N", CultureInfo.InvariantCulture),
             cancellationToken).ConfigureAwait(false);
@@ -1766,36 +1773,6 @@ public class DynamicHlsController : BaseJellyfinApiController
         }
 
         return args;
-    }
-
-    /// <summary>
-    /// Loads any plugin playback plan, then forces stream copy off when a session filter or edit graph applies.
-    /// </summary>
-    private async Task ApplyPlaybackPlanTranscodeFlagsAsync(StreamingRequestDto streamingRequest, string? itemId, CancellationToken cancellationToken)
-    {
-        foreach (var loader in _playbackPlanLoaders)
-        {
-            await loader.EnsurePlanLoadedAsync(
-                streamingRequest.PlaySessionId,
-                streamingRequest.DeviceId,
-                itemId,
-                streamingRequest.MediaSourceId,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var playSessionId = streamingRequest.PlaySessionId ?? string.Empty;
-        var deviceId = streamingRequest.DeviceId ?? string.Empty;
-        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(playSessionId, deviceId);
-        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(playSessionId, deviceId);
-        if (hasAudioFilter || hasEditGraph)
-        {
-            streamingRequest.AllowAudioStreamCopy = false;
-        }
-
-        if (hasEditGraph)
-        {
-            streamingRequest.AllowVideoStreamCopy = false;
-        }
     }
 
     /// <summary>

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -430,7 +430,8 @@ public class VideosController : BaseJellyfinApiController
         };
 
         var itemIdStr = streamingRequest.Id.IsEmpty() ? null : streamingRequest.Id.ToString("N");
-        var (hasEditGraph, hasAudioFilter) = await ApplyPlaybackPlanTranscodeFlagsAsync(
+        var (hasEditGraph, hasAudioFilter) = await _encodingHelper.ApplyPlaybackPlanTranscodeFlagsAsync(
+            _playbackPlanLoaders,
             streamingRequest,
             itemIdStr,
             cancellationTokenSource.Token)
@@ -671,37 +672,5 @@ public class VideosController : BaseJellyfinApiController
             context,
             streamOptions,
             enableAudioVbrEncoding);
-    }
-
-    private async Task<(bool HasEditGraph, bool HasAudioFilter)> ApplyPlaybackPlanTranscodeFlagsAsync(
-        StreamingRequestDto streamingRequest,
-        string? itemId,
-        CancellationToken cancellationToken)
-    {
-        foreach (var loader in _playbackPlanLoaders)
-        {
-            await loader.EnsurePlanLoadedAsync(
-                streamingRequest.PlaySessionId,
-                streamingRequest.DeviceId,
-                itemId,
-                streamingRequest.MediaSourceId,
-                cancellationToken).ConfigureAwait(false);
-        }
-
-        var playSessionId = streamingRequest.PlaySessionId ?? string.Empty;
-        var deviceId = streamingRequest.DeviceId ?? string.Empty;
-        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(playSessionId, deviceId);
-        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(playSessionId, deviceId);
-        if (hasAudioFilter || hasEditGraph)
-        {
-            streamingRequest.AllowAudioStreamCopy = false;
-        }
-
-        if (hasEditGraph)
-        {
-            streamingRequest.AllowVideoStreamCopy = false;
-        }
-
-        return (hasEditGraph, hasAudioFilter);
     }
 }

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -47,6 +47,7 @@ public class VideosController : BaseJellyfinApiController
     private readonly ITranscodeManager _transcodeManager;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly EncodingHelper _encodingHelper;
+    private readonly IEnumerable<ISessionPlaybackPlanLoader> _playbackPlanLoaders;
 
     private readonly TranscodingJobType _transcodingJobType = TranscodingJobType.Progressive;
 
@@ -62,6 +63,7 @@ public class VideosController : BaseJellyfinApiController
     /// <param name="transcodeManager">Instance of the <see cref="ITranscodeManager"/> interface.</param>
     /// <param name="httpClientFactory">Instance of the <see cref="IHttpClientFactory"/> interface.</param>
     /// <param name="encodingHelper">Instance of <see cref="EncodingHelper"/>.</param>
+    /// <param name="playbackPlanLoaders">Optional plugin loaders run before the first FFmpeg request.</param>
     public VideosController(
         ILibraryManager libraryManager,
         IUserManager userManager,
@@ -71,7 +73,8 @@ public class VideosController : BaseJellyfinApiController
         IMediaEncoder mediaEncoder,
         ITranscodeManager transcodeManager,
         IHttpClientFactory httpClientFactory,
-        EncodingHelper encodingHelper)
+        EncodingHelper encodingHelper,
+        IEnumerable<ISessionPlaybackPlanLoader>? playbackPlanLoaders = null)
     {
         _libraryManager = libraryManager;
         _userManager = userManager;
@@ -82,6 +85,7 @@ public class VideosController : BaseJellyfinApiController
         _transcodeManager = transcodeManager;
         _httpClientFactory = httpClientFactory;
         _encodingHelper = encodingHelper;
+        _playbackPlanLoaders = playbackPlanLoaders ?? Array.Empty<ISessionPlaybackPlanLoader>();
     }
 
     /// <summary>
@@ -425,6 +429,29 @@ public class VideosController : BaseJellyfinApiController
             EnableAudioVbrEncoding = enableAudioVbrEncoding
         };
 
+        var itemIdStr = streamingRequest.Id.IsEmpty() ? null : streamingRequest.Id.ToString("N");
+        foreach (var loader in _playbackPlanLoaders)
+        {
+            await loader.EnsurePlanLoadedAsync(
+                streamingRequest.PlaySessionId,
+                streamingRequest.DeviceId,
+                itemIdStr,
+                streamingRequest.MediaSourceId,
+                cancellationTokenSource.Token).ConfigureAwait(false);
+        }
+
+        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(streamingRequest.PlaySessionId ?? string.Empty, streamingRequest.DeviceId ?? string.Empty);
+        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(streamingRequest.PlaySessionId ?? string.Empty, streamingRequest.DeviceId ?? string.Empty);
+        if (hasEditGraph || hasAudioFilter)
+        {
+            streamingRequest.AllowAudioStreamCopy = false;
+        }
+
+        if (hasEditGraph)
+        {
+            streamingRequest.AllowVideoStreamCopy = false;
+        }
+
         var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
                 HttpContext,
@@ -465,7 +492,9 @@ public class VideosController : BaseJellyfinApiController
         }
 
         // Static stream
-        if (@static.HasValue && @static.Value && !(state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd))
+        if (@static.HasValue && @static.Value && !(state.MediaSource.VideoType == VideoType.BluRay || state.MediaSource.VideoType == VideoType.Dvd)
+            && !hasEditGraph
+            && !hasAudioFilter)
         {
             var contentType = state.GetMimeType("." + state.OutputContainer, false) ?? state.GetMimeType(state.MediaPath);
 

--- a/Jellyfin.Api/Controllers/VideosController.cs
+++ b/Jellyfin.Api/Controllers/VideosController.cs
@@ -430,27 +430,11 @@ public class VideosController : BaseJellyfinApiController
         };
 
         var itemIdStr = streamingRequest.Id.IsEmpty() ? null : streamingRequest.Id.ToString("N");
-        foreach (var loader in _playbackPlanLoaders)
-        {
-            await loader.EnsurePlanLoadedAsync(
-                streamingRequest.PlaySessionId,
-                streamingRequest.DeviceId,
-                itemIdStr,
-                streamingRequest.MediaSourceId,
-                cancellationTokenSource.Token).ConfigureAwait(false);
-        }
-
-        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(streamingRequest.PlaySessionId ?? string.Empty, streamingRequest.DeviceId ?? string.Empty);
-        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(streamingRequest.PlaySessionId ?? string.Empty, streamingRequest.DeviceId ?? string.Empty);
-        if (hasEditGraph || hasAudioFilter)
-        {
-            streamingRequest.AllowAudioStreamCopy = false;
-        }
-
-        if (hasEditGraph)
-        {
-            streamingRequest.AllowVideoStreamCopy = false;
-        }
+        var (hasEditGraph, hasAudioFilter) = await ApplyPlaybackPlanTranscodeFlagsAsync(
+            streamingRequest,
+            itemIdStr,
+            cancellationTokenSource.Token)
+            .ConfigureAwait(false);
 
         var state = await StreamingHelpers.GetStreamingState(
                 streamingRequest,
@@ -687,5 +671,37 @@ public class VideosController : BaseJellyfinApiController
             context,
             streamOptions,
             enableAudioVbrEncoding);
+    }
+
+    private async Task<(bool HasEditGraph, bool HasAudioFilter)> ApplyPlaybackPlanTranscodeFlagsAsync(
+        StreamingRequestDto streamingRequest,
+        string? itemId,
+        CancellationToken cancellationToken)
+    {
+        foreach (var loader in _playbackPlanLoaders)
+        {
+            await loader.EnsurePlanLoadedAsync(
+                streamingRequest.PlaySessionId,
+                streamingRequest.DeviceId,
+                itemId,
+                streamingRequest.MediaSourceId,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var playSessionId = streamingRequest.PlaySessionId ?? string.Empty;
+        var deviceId = streamingRequest.DeviceId ?? string.Empty;
+        var hasEditGraph = _encodingHelper.HasSessionEditGraphForRequest(playSessionId, deviceId);
+        var hasAudioFilter = _encodingHelper.HasSessionAudioFilterForRequest(playSessionId, deviceId);
+        if (hasAudioFilter || hasEditGraph)
+        {
+            streamingRequest.AllowAudioStreamCopy = false;
+        }
+
+        if (hasEditGraph)
+        {
+            streamingRequest.AllowVideoStreamCopy = false;
+        }
+
+        return (hasEditGraph, hasAudioFilter);
     }
 }

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -20,6 +20,7 @@ using Jellyfin.Extensions;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Extensions;
 using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dlna;
 using MediaBrowser.Model.Dto;
@@ -64,6 +65,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         private readonly IConfiguration _config;
         private readonly IConfigurationManager _configurationManager;
         private readonly IPathManager _pathManager;
+        private readonly IEnumerable<ISessionAudioFilterProvider> _sessionAudioFilterProviders;
+        private readonly IEnumerable<ISessionMediaEditGraphProvider> _sessionMediaEditGraphProviders;
 
         // i915 hang was fixed by linux 6.2 (3f882f2)
         private readonly Version _minKerneli915Hang = new Version(5, 18);
@@ -164,7 +167,9 @@ namespace MediaBrowser.Controller.MediaEncoding
             ISubtitleEncoder subtitleEncoder,
             IConfiguration config,
             IConfigurationManager configurationManager,
-            IPathManager pathManager)
+            IPathManager pathManager,
+            IEnumerable<ISessionAudioFilterProvider> sessionAudioFilterProviders = null,
+            IEnumerable<ISessionMediaEditGraphProvider> sessionMediaEditGraphProviders = null)
         {
             _appPaths = appPaths;
             _mediaEncoder = mediaEncoder;
@@ -172,6 +177,8 @@ namespace MediaBrowser.Controller.MediaEncoding
             _config = config;
             _configurationManager = configurationManager;
             _pathManager = pathManager;
+            _sessionAudioFilterProviders = sessionAudioFilterProviders ?? Array.Empty<ISessionAudioFilterProvider>();
+            _sessionMediaEditGraphProviders = sessionMediaEditGraphProviders ?? Array.Empty<ISessionMediaEditGraphProvider>();
         }
 
         private enum DynamicHdrMetadataRemovalPlan
@@ -2944,12 +2951,75 @@ namespace MediaBrowser.Controller.MediaEncoding
                         Math.Round(seconds)));
             }
 
+            if (_sessionAudioFilterProviders.Any())
+            {
+                GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
+                var startSeconds = TimeSpan.FromTicks(state.StartTimeTicks ?? 0).TotalSeconds;
+                foreach (var provider in _sessionAudioFilterProviders)
+                {
+                    var extra = provider.GetAdditionalAudioFilter(playSessionId, deviceId, startSeconds);
+                    if (!string.IsNullOrWhiteSpace(extra))
+                    {
+                        filters.Add(extra.Trim());
+                        break;
+                    }
+                }
+            }
+
             if (filters.Count > 0)
             {
                 return " -af \"" + string.Join(',', filters) + "\"";
             }
 
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Returns true if any session audio filter provider has a filter for the given play session/device.
+        /// Used by the API layer to force audio transcoding so the filter is applied.
+        /// </summary>
+        public bool HasSessionAudioFilterForRequest(string playSessionId, string deviceId)
+        {
+            foreach (var provider in _sessionAudioFilterProviders)
+            {
+                var extra = provider.GetAdditionalAudioFilter(playSessionId, deviceId, 0);
+                if (!string.IsNullOrWhiteSpace(extra))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if any session audio filter provider has a filter for this encoding job.
+        /// </summary>
+        public bool HasSessionAudioFilter(EncodingJobInfo state)
+        {
+            GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
+            var startSeconds = TimeSpan.FromTicks(state.StartTimeTicks ?? 0).TotalSeconds;
+            foreach (var provider in _sessionAudioFilterProviders)
+            {
+                var extra = provider.GetAdditionalAudioFilter(playSessionId, deviceId, startSeconds);
+                if (!string.IsNullOrWhiteSpace(extra))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void GetPlaySessionAndDeviceId(EncodingJobInfo state, out string playSessionId, out string deviceId)
+        {
+            playSessionId = null;
+            deviceId = null;
+            if (state is StreamState streamState)
+            {
+                playSessionId = streamState.Request?.PlaySessionId;
+                deviceId = streamState.Request?.DeviceId;
+            }
         }
 
         /// <summary>
@@ -7665,7 +7735,35 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             var threads = GetNumberOfThreads(state, encodingOptions, videoCodec);
 
-            var inputModifier = GetInputModifier(state, encodingOptions, null);
+            var editGraph = TryGetSessionEditGraph(state);
+            string inputModifier;
+            if (editGraph is not null)
+            {
+                var savedStart = state.BaseRequest?.StartTimeTicks;
+                if (state.BaseRequest is not null)
+                {
+                    state.BaseRequest.StartTimeTicks = 0;
+                }
+
+                inputModifier = GetInputModifier(state, encodingOptions, null);
+                var inputArgument = GetInputArgument(state, encodingOptions, null);
+                if (state.BaseRequest is not null)
+                {
+                    state.BaseRequest.StartTimeTicks = savedStart;
+                }
+
+                return GetProgressiveVideoFullCommandLineWithEditGraph(
+                    state,
+                    encodingOptions,
+                    defaultPreset,
+                    inputModifier,
+                    inputArgument,
+                    editGraph,
+                    format,
+                    outputPath);
+            }
+
+            inputModifier = GetInputModifier(state, encodingOptions, null);
 
             return string.Format(
                 CultureInfo.InvariantCulture,
@@ -7680,6 +7778,279 @@ namespace MediaBrowser.Controller.MediaEncoding
                 GetSubtitleEmbedArguments(state),
                 format,
                 outputPath).Trim();
+        }
+
+        private string GetProgressiveVideoFullCommandLineWithEditGraph(
+            EncodingJobInfo state,
+            EncodingOptions encodingOptions,
+            EncoderPreset defaultPreset,
+            string inputModifier,
+            string inputArgument,
+            SessionMediaEditGraph editGraph,
+            string format,
+            string outputPath)
+        {
+            var videoCodec = GetVideoEncoder(state, encodingOptions);
+            if (IsCopyCodec(videoCodec))
+            {
+                videoCodec = "libx264";
+            }
+
+            var audioCodec = GetAudioEncoder(state);
+            if (IsCopyCodec(audioCodec))
+            {
+                audioCodec = "aac";
+            }
+
+            var threads = GetNumberOfThreads(state, encodingOptions, videoCodec);
+            var mapArgs = string.Format(
+                CultureInfo.InvariantCulture,
+                "-map \"[{0}]\"",
+                editGraph.VideoMapLabel);
+            if (!string.IsNullOrEmpty(editGraph.AudioMapLabel))
+            {
+                mapArgs += string.Format(
+                    CultureInfo.InvariantCulture,
+                    " -map \"[{0}]\"",
+                    editGraph.AudioMapLabel);
+            }
+
+            var videoArgs = "-codec:v:0 " + videoCodec
+                + string.Format(CultureInfo.InvariantCulture, " -force_key_frames \"expr:gte(t,n_forced*{0})\"", 5)
+                + GetOutputFFlags(state);
+            var audioArgs = "-codec:a:0 " + audioCodec;
+            var bitrate = state.OutputAudioBitrate;
+            if (bitrate.HasValue)
+            {
+                audioArgs += " -ab " + bitrate.Value.ToString(CultureInfo.InvariantCulture);
+            }
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} {1} -filter_complex \"{2}\" {3} -map_metadata -1 -map_chapters -1 -threads {4} {5} {6}{7}{8} -y \"{9}\"",
+                inputModifier,
+                inputArgument,
+                editGraph.FilterComplex,
+                mapArgs,
+                threads,
+                videoArgs,
+                audioArgs,
+                GetSubtitleEmbedArguments(state),
+                format,
+                outputPath).Trim();
+        }
+
+        /// <summary>
+        /// Returns true if any edit-graph provider needs a filter graph for this request.
+        /// </summary>
+        public bool HasSessionEditGraphForRequest(string playSessionId, string deviceId)
+        {
+            foreach (var provider in _sessionMediaEditGraphProviders)
+            {
+                if (provider.HasEditGraph(playSessionId, deviceId))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to get a session edit graph for the encoding job.
+        /// </summary>
+        public SessionMediaEditGraph TryGetSessionEditGraph(EncodingJobInfo state)
+        {
+            if (!_sessionMediaEditGraphProviders.Any())
+            {
+                return null;
+            }
+
+            GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
+            var duration = state.RunTimeTicks.HasValue
+                ? TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds
+                : 0;
+            var startSeconds = state.BaseRequest?.StartTimeTicks is long ticks && ticks > 0
+                ? TimeSpan.FromTicks(ticks).TotalSeconds
+                : 0;
+
+            var inputLayout = string.Empty;
+            var inputChannels = 0;
+            string stereoDownmix = null;
+            if (state.AudioStream is not null)
+            {
+                inputLayout = DownMixAlgorithmsHelper.InferChannelLayout(state.AudioStream) ?? string.Empty;
+                inputChannels = state.AudioStream.Channels ?? 0;
+                if (state.OutputAudioChannels == 2 && inputChannels > 2)
+                {
+                    foreach (var algo in new[]
+                             {
+                                 DownMixStereoAlgorithms.Rfc7845,
+                                 DownMixStereoAlgorithms.Ac4,
+                                 DownMixStereoAlgorithms.Dave750,
+                                 DownMixStereoAlgorithms.NightmodeDialogue
+                             })
+                    {
+                        if (DownMixAlgorithmsHelper.AlgorithmFilterStrings.TryGetValue((algo, inputLayout), out stereoDownmix)
+                            && !string.IsNullOrWhiteSpace(stereoDownmix))
+                        {
+                            break;
+                        }
+                    }
+
+                    if (string.IsNullOrWhiteSpace(stereoDownmix))
+                    {
+                        stereoDownmix = "aformat=channel_layouts=stereo";
+                    }
+                }
+            }
+
+            TryFillSubtitleBurnIn(
+                state,
+                out var burnInSubInput,
+                out var burnInSubIndex,
+                out var burnInSubFilters,
+                out var burnInTextFilter);
+
+            var context = new SessionMediaEditGraphContext
+            {
+                DurationSeconds = duration,
+                StartTimeSeconds = startSeconds,
+                InputChannelLayout = inputLayout,
+                InputChannelCount = inputChannels,
+                OutputAudioChannels = state.OutputAudioChannels ?? 0,
+                StereoDownmixFilter = stereoDownmix,
+                BurnInGraphicalSubtitleInputIndex = burnInSubInput,
+                BurnInGraphicalSubtitleStreamIndex = burnInSubIndex,
+                BurnInGraphicalSubtitleFilters = burnInSubFilters,
+                BurnInTextSubtitleFilter = burnInTextFilter
+            };
+
+            foreach (var provider in _sessionMediaEditGraphProviders)
+            {
+                var graph = provider.GetEditGraph(playSessionId, deviceId, context);
+                if (graph is not null && !string.IsNullOrWhiteSpace(graph.FilterComplex))
+                {
+                    return graph;
+                }
+            }
+
+            return null;
+        }
+
+        private void TryFillSubtitleBurnIn(
+            EncodingJobInfo state,
+            out int? graphicalInputIndex,
+            out int? graphicalStreamIndex,
+            out string graphicalFilters,
+            out string textFilter)
+        {
+            graphicalInputIndex = null;
+            graphicalStreamIndex = null;
+            graphicalFilters = null;
+            textFilter = null;
+
+            if (state.SubtitleStream is null || !ShouldEncodeSubtitle(state))
+            {
+                return;
+            }
+
+            if (state.SubtitleStream.IsTextSubtitleStream)
+            {
+                textFilter = TryGetOriginalTimelineTextSubtitlesFilter(state);
+                return;
+            }
+
+            if (state.MediaSource?.MediaStreams is null)
+            {
+                return;
+            }
+
+            var idx = FindIndex(state.MediaSource.MediaStreams, state.SubtitleStream);
+            if (idx < 0)
+            {
+                return;
+            }
+
+            graphicalInputIndex = state.SubtitleStream.IsExternal ? 1 : 0;
+            graphicalStreamIndex = idx;
+            var videoW = state.VideoStream?.Width;
+            var videoH = state.VideoStream?.Height;
+            var pre = GetGraphicalSubPreProcessFilters(
+                videoW,
+                videoH,
+                state.SubtitleStream.Width,
+                state.SubtitleStream.Height,
+                state.BaseRequest?.Width,
+                state.BaseRequest?.Height,
+                state.BaseRequest?.MaxWidth,
+                state.BaseRequest?.MaxHeight);
+            graphicalFilters = string.IsNullOrEmpty(pre)
+                ? "format=yuva420p"
+                : pre + ",format=yuva420p";
+        }
+
+        private string TryGetOriginalTimelineTextSubtitlesFilter(EncodingJobInfo state)
+        {
+            if (state.BaseRequest is null)
+            {
+                return null;
+            }
+
+            var savedStart = state.BaseRequest.StartTimeTicks;
+            var savedCopy = state.BaseRequest.CopyTimestamps;
+            try
+            {
+                state.BaseRequest.StartTimeTicks = 0;
+                state.BaseRequest.CopyTimestamps = true;
+                var filter = GetTextSubtitlesFilter(state, false, false);
+                if (string.IsNullOrWhiteSpace(filter)
+                    || !filter.StartsWith("subtitles=", StringComparison.Ordinal)
+                    || filter.Contains('[', StringComparison.Ordinal)
+                    || filter.Contains(']', StringComparison.Ordinal)
+                    || filter.Contains(';', StringComparison.Ordinal)
+                    || filter.Contains('\n', StringComparison.Ordinal)
+                    || filter.Contains('\r', StringComparison.Ordinal))
+                {
+                    return null;
+                }
+
+                return filter;
+            }
+#pragma warning disable CA1031 // Subtitle extract can fail; skip burn-in rather than abort the encode.
+            catch (Exception)
+            {
+                return null;
+            }
+#pragma warning restore CA1031
+            finally
+            {
+                state.BaseRequest.StartTimeTicks = savedStart;
+                state.BaseRequest.CopyTimestamps = savedCopy;
+            }
+        }
+
+        /// <summary>
+        /// Map args and optional <c>-filter_complex</c> prefix for HLS when an edit graph is present.
+        /// </summary>
+        public bool TryGetSessionEditGraphMapArgs(EncodingJobInfo state, out string filterComplexArg, out string mapArgs)
+        {
+            filterComplexArg = string.Empty;
+            mapArgs = string.Empty;
+            var graph = TryGetSessionEditGraph(state);
+            if (graph is null)
+            {
+                return false;
+            }
+
+            filterComplexArg = "-filter_complex \"" + graph.FilterComplex + "\"";
+            mapArgs = string.Format(CultureInfo.InvariantCulture, "-map \"[{0}]\"", graph.VideoMapLabel);
+            if (!string.IsNullOrEmpty(graph.AudioMapLabel))
+            {
+                mapArgs += string.Format(CultureInfo.InvariantCulture, " -map \"[{0}]\"", graph.AudioMapLabel);
+            }
+
+            return true;
         }
 
         public string GetOutputFFlags(EncodingJobInfo state)
@@ -7800,7 +8171,13 @@ namespace MediaBrowser.Controller.MediaEncoding
 
             if (IsCopyCodec(codec))
             {
-                return args;
+                if (!HasSessionAudioFilter(state))
+                {
+                    return args;
+                }
+
+                codec = "aac";
+                args = "-codec:a:0 " + codec;
             }
 
             var channels = state.OutputAudioChannels;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
@@ -2965,6 +2966,9 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// Returns true if any session audio filter provider has a filter for the given play session/device.
         /// Used by the API layer to force audio transcoding so the filter is applied.
         /// </summary>
+        /// <param name="playSessionId">The play session ID.</param>
+        /// <param name="deviceId">The device ID.</param>
+        /// <returns>Whether a session audio filter applies.</returns>
         public bool HasSessionAudioFilterForRequest(string playSessionId, string deviceId)
         {
             foreach (var provider in _sessionAudioFilterProviders)
@@ -2982,6 +2986,8 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Returns true if any session audio filter provider has a filter for this encoding job.
         /// </summary>
+        /// <param name="state">The encoding job.</param>
+        /// <returns>Whether a session audio filter applies.</returns>
         public bool HasSessionAudioFilter(EncodingJobInfo state)
         {
             GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
@@ -7843,12 +7849,58 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Returns true if any edit-graph provider needs a filter graph for this request.
         /// </summary>
+        /// <param name="playSessionId">The play session ID.</param>
+        /// <param name="deviceId">The device ID.</param>
+        /// <returns>Whether a session edit graph applies.</returns>
         public bool HasSessionEditGraphForRequest(string playSessionId, string deviceId)
             => _sessionMediaEditGraphProviders.Any(provider => provider.HasEditGraph(playSessionId, deviceId));
 
         /// <summary>
+        /// Loads any plugin playback plan, then forces stream copy off when a session filter or edit graph applies.
+        /// </summary>
+        /// <param name="loaders">Optional playback plan loaders to run first.</param>
+        /// <param name="streamingRequest">The streaming request whose copy flags may be updated.</param>
+        /// <param name="itemId">The item ID from the stream request.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>Whether an edit graph and/or audio filter apply for this request.</returns>
+        public async Task<(bool HasEditGraph, bool HasAudioFilter)> ApplyPlaybackPlanTranscodeFlagsAsync(
+            IEnumerable<ISessionPlaybackPlanLoader> loaders,
+            StreamingRequestDto streamingRequest,
+            string itemId,
+            CancellationToken cancellationToken)
+        {
+            foreach (var loader in loaders ?? Array.Empty<ISessionPlaybackPlanLoader>())
+            {
+                await loader.EnsurePlanLoadedAsync(
+                    streamingRequest.PlaySessionId,
+                    streamingRequest.DeviceId,
+                    itemId,
+                    streamingRequest.MediaSourceId,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            var playSessionId = streamingRequest.PlaySessionId ?? string.Empty;
+            var deviceId = streamingRequest.DeviceId ?? string.Empty;
+            var hasEditGraph = HasSessionEditGraphForRequest(playSessionId, deviceId);
+            var hasAudioFilter = HasSessionAudioFilterForRequest(playSessionId, deviceId);
+            if (hasAudioFilter || hasEditGraph)
+            {
+                streamingRequest.AllowAudioStreamCopy = false;
+            }
+
+            if (hasEditGraph)
+            {
+                streamingRequest.AllowVideoStreamCopy = false;
+            }
+
+            return (hasEditGraph, hasAudioFilter);
+        }
+
+        /// <summary>
         /// Tries to get a session edit graph for the encoding job.
         /// </summary>
+        /// <param name="state">The encoding job.</param>
+        /// <returns>The session edit graph, or <c>null</c> if none applies.</returns>
         public SessionMediaEditGraph TryGetSessionEditGraph(EncodingJobInfo state)
         {
             if (!_sessionMediaEditGraphProviders.Any())
@@ -8033,6 +8085,10 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// <summary>
         /// Map args and optional <c>-filter_complex</c> prefix for HLS when an edit graph is present.
         /// </summary>
+        /// <param name="state">The encoding job.</param>
+        /// <param name="filterComplexArg">The <c>-filter_complex</c> argument, or empty when unused.</param>
+        /// <param name="mapArgs">The <c>-map</c> arguments for graph outputs.</param>
+        /// <returns>Whether an edit graph supplied map arguments.</returns>
         public bool TryGetSessionEditGraphMapArgs(EncodingJobInfo state, out string filterComplexArg, out string mapArgs)
         {
             filterComplexArg = string.Empty;

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -2951,20 +2951,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                         Math.Round(seconds)));
             }
 
-            if (_sessionAudioFilterProviders.Any())
-            {
-                GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
-                var startSeconds = TimeSpan.FromTicks(state.StartTimeTicks ?? 0).TotalSeconds;
-                foreach (var provider in _sessionAudioFilterProviders)
-                {
-                    var extra = provider.GetAdditionalAudioFilter(playSessionId, deviceId, startSeconds);
-                    if (!string.IsNullOrWhiteSpace(extra))
-                    {
-                        filters.Add(extra.Trim());
-                        break;
-                    }
-                }
-            }
+            AppendSessionAudioFilters(state, filters);
 
             if (filters.Count > 0)
             {
@@ -3009,6 +2996,21 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             return false;
+        }
+
+        private void AppendSessionAudioFilters(EncodingJobInfo state, List<string> filters)
+        {
+            GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
+            var startSeconds = TimeSpan.FromTicks(state.StartTimeTicks ?? 0).TotalSeconds;
+            foreach (var provider in _sessionAudioFilterProviders)
+            {
+                var extra = provider.GetAdditionalAudioFilter(playSessionId, deviceId, startSeconds);
+                if (!string.IsNullOrWhiteSpace(extra))
+                {
+                    filters.Add(extra.Trim());
+                    break;
+                }
+            }
         }
 
         private static void GetPlaySessionAndDeviceId(EncodingJobInfo state, out string playSessionId, out string deviceId)
@@ -7755,7 +7757,6 @@ namespace MediaBrowser.Controller.MediaEncoding
                 return GetProgressiveVideoFullCommandLineWithEditGraph(
                     state,
                     encodingOptions,
-                    defaultPreset,
                     inputModifier,
                     inputArgument,
                     editGraph,
@@ -7783,7 +7784,6 @@ namespace MediaBrowser.Controller.MediaEncoding
         private string GetProgressiveVideoFullCommandLineWithEditGraph(
             EncodingJobInfo state,
             EncodingOptions encodingOptions,
-            EncoderPreset defaultPreset,
             string inputModifier,
             string inputArgument,
             SessionMediaEditGraph editGraph,
@@ -7844,17 +7844,7 @@ namespace MediaBrowser.Controller.MediaEncoding
         /// Returns true if any edit-graph provider needs a filter graph for this request.
         /// </summary>
         public bool HasSessionEditGraphForRequest(string playSessionId, string deviceId)
-        {
-            foreach (var provider in _sessionMediaEditGraphProviders)
-            {
-                if (provider.HasEditGraph(playSessionId, deviceId))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
+            => _sessionMediaEditGraphProviders.Any(provider => provider.HasEditGraph(playSessionId, deviceId));
 
         /// <summary>
         /// Tries to get a session edit graph for the encoding job.
@@ -7867,65 +7857,7 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             GetPlaySessionAndDeviceId(state, out var playSessionId, out var deviceId);
-            var duration = state.RunTimeTicks.HasValue
-                ? TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds
-                : 0;
-            var startSeconds = state.BaseRequest?.StartTimeTicks is long ticks && ticks > 0
-                ? TimeSpan.FromTicks(ticks).TotalSeconds
-                : 0;
-
-            var inputLayout = string.Empty;
-            var inputChannels = 0;
-            string stereoDownmix = null;
-            if (state.AudioStream is not null)
-            {
-                inputLayout = DownMixAlgorithmsHelper.InferChannelLayout(state.AudioStream) ?? string.Empty;
-                inputChannels = state.AudioStream.Channels ?? 0;
-                if (state.OutputAudioChannels == 2 && inputChannels > 2)
-                {
-                    foreach (var algo in new[]
-                             {
-                                 DownMixStereoAlgorithms.Rfc7845,
-                                 DownMixStereoAlgorithms.Ac4,
-                                 DownMixStereoAlgorithms.Dave750,
-                                 DownMixStereoAlgorithms.NightmodeDialogue
-                             })
-                    {
-                        if (DownMixAlgorithmsHelper.AlgorithmFilterStrings.TryGetValue((algo, inputLayout), out stereoDownmix)
-                            && !string.IsNullOrWhiteSpace(stereoDownmix))
-                        {
-                            break;
-                        }
-                    }
-
-                    if (string.IsNullOrWhiteSpace(stereoDownmix))
-                    {
-                        stereoDownmix = "aformat=channel_layouts=stereo";
-                    }
-                }
-            }
-
-            TryFillSubtitleBurnIn(
-                state,
-                out var burnInSubInput,
-                out var burnInSubIndex,
-                out var burnInSubFilters,
-                out var burnInTextFilter);
-
-            var context = new SessionMediaEditGraphContext
-            {
-                DurationSeconds = duration,
-                StartTimeSeconds = startSeconds,
-                InputChannelLayout = inputLayout,
-                InputChannelCount = inputChannels,
-                OutputAudioChannels = state.OutputAudioChannels ?? 0,
-                StereoDownmixFilter = stereoDownmix,
-                BurnInGraphicalSubtitleInputIndex = burnInSubInput,
-                BurnInGraphicalSubtitleStreamIndex = burnInSubIndex,
-                BurnInGraphicalSubtitleFilters = burnInSubFilters,
-                BurnInTextSubtitleFilter = burnInTextFilter
-            };
-
+            var context = CreateSessionEditGraphContext(state);
             foreach (var provider in _sessionMediaEditGraphProviders)
             {
                 var graph = provider.GetEditGraph(playSessionId, deviceId, context);
@@ -7936,6 +7868,74 @@ namespace MediaBrowser.Controller.MediaEncoding
             }
 
             return null;
+        }
+
+        private SessionMediaEditGraphContext CreateSessionEditGraphContext(EncodingJobInfo state)
+        {
+            GetSessionAudioLayout(state, out var inputLayout, out var inputChannels, out var stereoDownmix);
+            TryFillSubtitleBurnIn(
+                state,
+                out var burnInSubInput,
+                out var burnInSubIndex,
+                out var burnInSubFilters,
+                out var burnInTextFilter);
+
+            return new SessionMediaEditGraphContext
+            {
+                DurationSeconds = state.RunTimeTicks.HasValue
+                    ? TimeSpan.FromTicks(state.RunTimeTicks.Value).TotalSeconds
+                    : 0,
+                StartTimeSeconds = state.BaseRequest?.StartTimeTicks is long ticks && ticks > 0
+                    ? TimeSpan.FromTicks(ticks).TotalSeconds
+                    : 0,
+                InputChannelLayout = inputLayout,
+                InputChannelCount = inputChannels,
+                OutputAudioChannels = state.OutputAudioChannels ?? 0,
+                StereoDownmixFilter = stereoDownmix,
+                BurnInGraphicalSubtitleInputIndex = burnInSubInput,
+                BurnInGraphicalSubtitleStreamIndex = burnInSubIndex,
+                BurnInGraphicalSubtitleFilters = burnInSubFilters,
+                BurnInTextSubtitleFilter = burnInTextFilter
+            };
+        }
+
+        private static void GetSessionAudioLayout(
+            EncodingJobInfo state,
+            out string inputLayout,
+            out int inputChannels,
+            out string stereoDownmix)
+        {
+            inputLayout = string.Empty;
+            inputChannels = 0;
+            stereoDownmix = null;
+            if (state.AudioStream is null)
+            {
+                return;
+            }
+
+            inputLayout = DownMixAlgorithmsHelper.InferChannelLayout(state.AudioStream) ?? string.Empty;
+            inputChannels = state.AudioStream.Channels ?? 0;
+            if (state.OutputAudioChannels != 2 || inputChannels <= 2)
+            {
+                return;
+            }
+
+            foreach (var algo in new[]
+                     {
+                         DownMixStereoAlgorithms.Rfc7845,
+                         DownMixStereoAlgorithms.Ac4,
+                         DownMixStereoAlgorithms.Dave750,
+                         DownMixStereoAlgorithms.NightmodeDialogue
+                     })
+            {
+                if (DownMixAlgorithmsHelper.AlgorithmFilterStrings.TryGetValue((algo, inputLayout), out stereoDownmix)
+                    && !string.IsNullOrWhiteSpace(stereoDownmix))
+                {
+                    return;
+                }
+            }
+
+            stereoDownmix = "aformat=channel_layouts=stereo";
         }
 
         private void TryFillSubtitleBurnIn(

--- a/MediaBrowser.Controller/MediaEncoding/ISessionAudioFilterProvider.cs
+++ b/MediaBrowser.Controller/MediaEncoding/ISessionAudioFilterProvider.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// Provides session-scoped additional audio filters for FFmpeg transcoding.
+/// Plugins can inject per-play-session filters (for example volume expressions).
+/// </summary>
+public interface ISessionAudioFilterProvider
+{
+    /// <summary>
+    /// Returns an additional FFmpeg audio filter string for the given play session, or null if none.
+    /// The filter is appended to the existing audio filter chain.
+    /// </summary>
+    /// <param name="playSessionId">The play session ID from the request, or null if not available.</param>
+    /// <param name="deviceId">The device ID from the request; use as fallback when playSessionId does not match.</param>
+    /// <param name="startTimeSeconds">
+    /// Stream start offset in seconds (from <c>-ss</c> / StartTimeTicks). Absolute media times
+    /// must be shifted into FFmpeg filter time <c>t</c>, which resets after input seeking.
+    /// </param>
+    /// <returns>Filter string or null.</returns>
+    string? GetAdditionalAudioFilter(string? playSessionId, string? deviceId, double startTimeSeconds = 0);
+}

--- a/MediaBrowser.Controller/MediaEncoding/ISessionMediaEditGraphProvider.cs
+++ b/MediaBrowser.Controller/MediaEncoding/ISessionMediaEditGraphProvider.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// Provides a session-scoped FFmpeg <c>-filter_complex</c> graph that replaces the stock
+/// video/audio filter chain for that play session.
+/// </summary>
+public interface ISessionMediaEditGraphProvider
+{
+    /// <summary>
+    /// Returns true when this session needs an A/V edit graph.
+    /// </summary>
+    /// <param name="playSessionId">Play session id.</param>
+    /// <param name="deviceId">Device id.</param>
+    /// <returns>True if an edit graph should be applied.</returns>
+    bool HasEditGraph(string? playSessionId, string? deviceId);
+
+    /// <summary>
+    /// Builds the edit graph, or null if none.
+    /// </summary>
+    /// <param name="playSessionId">Play session id.</param>
+    /// <param name="deviceId">Device id.</param>
+    /// <param name="context">Duration / start / burn-in context.</param>
+    /// <returns>The graph, or null.</returns>
+    SessionMediaEditGraph? GetEditGraph(string? playSessionId, string? deviceId, SessionMediaEditGraphContext context);
+}

--- a/MediaBrowser.Controller/MediaEncoding/ISessionPlaybackPlanLoader.cs
+++ b/MediaBrowser.Controller/MediaEncoding/ISessionPlaybackPlanLoader.cs
@@ -1,0 +1,30 @@
+#nullable enable
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// Optional plugin service that loads per-session playback state before the first FFmpeg request
+/// checks for an audio filter or edit graph.
+/// </summary>
+public interface ISessionPlaybackPlanLoader
+{
+    /// <summary>
+    /// Ensures any plugin playback plan for this play session is loaded.
+    /// Called immediately before checking for a session audio filter or edit graph.
+    /// </summary>
+    /// <param name="playSessionId">Play session ID from the stream request (may be null or empty).</param>
+    /// <param name="deviceId">Device ID from the stream request (may be null or empty).</param>
+    /// <param name="itemId">Item ID from the stream request (may be null).</param>
+    /// <param name="mediaSourceId">Media source id from the stream request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task EnsurePlanLoadedAsync(
+        string? playSessionId,
+        string? deviceId,
+        string? itemId,
+        string? mediaSourceId,
+        CancellationToken cancellationToken);
+}

--- a/MediaBrowser.Controller/MediaEncoding/NoOpSessionAudioFilterProvider.cs
+++ b/MediaBrowser.Controller/MediaEncoding/NoOpSessionAudioFilterProvider.cs
@@ -1,0 +1,12 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// No-op <see cref="ISessionAudioFilterProvider"/> used when no plugin supplies session audio filters.
+/// </summary>
+public sealed class NoOpSessionAudioFilterProvider : ISessionAudioFilterProvider
+{
+    /// <inheritdoc />
+    public string? GetAdditionalAudioFilter(string? playSessionId, string? deviceId, double startTimeSeconds = 0) => null;
+}

--- a/MediaBrowser.Controller/MediaEncoding/NoOpSessionMediaEditGraphProvider.cs
+++ b/MediaBrowser.Controller/MediaEncoding/NoOpSessionMediaEditGraphProvider.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// No-op <see cref="ISessionMediaEditGraphProvider"/>.
+/// </summary>
+public sealed class NoOpSessionMediaEditGraphProvider : ISessionMediaEditGraphProvider
+{
+    /// <inheritdoc />
+    public bool HasEditGraph(string? playSessionId, string? deviceId) => false;
+
+    /// <inheritdoc />
+    public SessionMediaEditGraph? GetEditGraph(string? playSessionId, string? deviceId, SessionMediaEditGraphContext context)
+        => null;
+}

--- a/MediaBrowser.Controller/MediaEncoding/SessionMediaEditGraph.cs
+++ b/MediaBrowser.Controller/MediaEncoding/SessionMediaEditGraph.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// A session-scoped FFmpeg edit graph supplied by a plugin.
+/// </summary>
+public sealed class SessionMediaEditGraph
+{
+    /// <summary>
+    /// Gets the <c>-filter_complex</c> body (no prefix).
+    /// </summary>
+    public required string FilterComplex { get; init; }
+
+    /// <summary>
+    /// Gets the labeled video output pad name (e.g. vout).
+    /// </summary>
+    public required string VideoMapLabel { get; init; }
+
+    /// <summary>
+    /// Gets the labeled audio output pad name (e.g. aout), or null if video-only.
+    /// </summary>
+    public string? AudioMapLabel { get; init; }
+}

--- a/MediaBrowser.Controller/MediaEncoding/SessionMediaEditGraphContext.cs
+++ b/MediaBrowser.Controller/MediaEncoding/SessionMediaEditGraphContext.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+namespace MediaBrowser.Controller.MediaEncoding;
+
+/// <summary>
+/// Context for building a session media edit graph.
+/// </summary>
+public sealed class SessionMediaEditGraphContext
+{
+    /// <summary>
+    /// Gets the media-source duration in seconds, or 0 if unknown.
+    /// </summary>
+    public double DurationSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the requested stream start offset in seconds on the delivered timeline.
+    /// </summary>
+    public double StartTimeSeconds { get; init; }
+
+    /// <summary>
+    /// Gets the source audio channel layout string (e.g. <c>5.1</c>, <c>stereo</c>), or empty if unknown.
+    /// </summary>
+    public string InputChannelLayout { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the source audio channel count, or 0 if unknown.
+    /// </summary>
+    public int InputChannelCount { get; init; }
+
+    /// <summary>
+    /// Gets the requested output audio channel count, or 0 if unknown / unchanged.
+    /// </summary>
+    public int OutputAudioChannels { get; init; }
+
+    /// <summary>
+    /// Gets an optional FFmpeg stereo-downmix filter to apply after channel-level audio edits.
+    /// </summary>
+    public string? StereoDownmixFilter { get; init; }
+
+    /// <summary>
+    /// Gets the FFmpeg input file index for a graphical subtitle burn-in
+    /// (0 = internal in the main file, 1 = external second <c>-i</c>), or null.
+    /// </summary>
+    public int? BurnInGraphicalSubtitleInputIndex { get; init; }
+
+    /// <summary>
+    /// Gets the FFmpeg stream index within that input of a graphical subtitle to burn in
+    /// on the original timeline before length-changing filters, or null when not burning.
+    /// </summary>
+    public int? BurnInGraphicalSubtitleStreamIndex { get; init; }
+
+    /// <summary>
+    /// Gets scale/format filters for the graphical subtitle stream (no pad labels), or null.
+    /// </summary>
+    public string? BurnInGraphicalSubtitleFilters { get; init; }
+
+    /// <summary>
+    /// Gets an FFmpeg <c>subtitles=</c> filter for text/ASS burn-in on the original
+    /// timeline, or null when not burning text.
+    /// </summary>
+    public string? BurnInTextSubtitleFilter { get; init; }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSessionHooksTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSessionHooksTests.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.IO;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Dlna;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using Moq;
+using Xunit;
+using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding;
+
+public class EncodingHelperSessionHooksTests
+{
+    [Fact]
+    public void GetAudioFilterParam_NoProvider_DoesNotAddSessionFilter()
+    {
+        var args = CreateHelper().GetAudioFilterParam(BuildState(), new EncodingOptions());
+
+        Assert.DoesNotContain("volume=0", args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetAudioFilterParam_Provider_AppendsFilter()
+    {
+        const string filter = "volume=0:enable='between(t,1,2)'";
+        var provider = new Mock<ISessionAudioFilterProvider>();
+        provider
+            .Setup(p => p.GetAdditionalAudioFilter(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<double>()))
+            .Returns(filter);
+
+        var args = CreateHelper(audio: provider.Object).GetAudioFilterParam(BuildState(), new EncodingOptions());
+
+        Assert.Contains("-af \"", args, StringComparison.Ordinal);
+        Assert.Contains(filter, args, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HasSessionAudioFilterForRequest_Provider_ReturnsTrue()
+    {
+        var provider = new Mock<ISessionAudioFilterProvider>();
+        provider
+            .Setup(p => p.GetAdditionalAudioFilter("play", "dev", 0))
+            .Returns("volume=0");
+
+        Assert.True(CreateHelper(audio: provider.Object).HasSessionAudioFilterForRequest("play", "dev"));
+        Assert.False(CreateHelper().HasSessionAudioFilterForRequest("play", "dev"));
+    }
+
+    [Fact]
+    public void TryGetSessionEditGraph_NoProvider_ReturnsNull()
+    {
+        Assert.Null(CreateHelper().TryGetSessionEditGraph(BuildState()));
+    }
+
+    [Fact]
+    public void TryGetSessionEditGraph_Provider_ReturnsGraph()
+    {
+        var graph = new SessionMediaEditGraph
+        {
+            FilterComplex = "[0:v]copy[vout];[0:a]anull[aout]",
+            VideoMapLabel = "vout",
+            AudioMapLabel = "aout"
+        };
+        var provider = CreateGraphProvider(graph);
+
+        var result = CreateHelper(graph: provider.Object).TryGetSessionEditGraph(BuildState());
+
+        Assert.NotNull(result);
+        Assert.Equal(graph.FilterComplex, result.FilterComplex);
+        Assert.Equal("vout", result.VideoMapLabel);
+        Assert.Equal("aout", result.AudioMapLabel);
+    }
+
+    [Fact]
+    public void TryGetSessionEditGraph_EmptyFilterComplex_ReturnsNull()
+    {
+        var provider = CreateGraphProvider(new SessionMediaEditGraph
+        {
+            FilterComplex = " ",
+            VideoMapLabel = "vout"
+        });
+
+        Assert.Null(CreateHelper(graph: provider.Object).TryGetSessionEditGraph(BuildState()));
+    }
+
+    [Fact]
+    public void TryGetSessionEditGraphMapArgs_IncludesFilterComplexAndMaps()
+    {
+        var provider = CreateGraphProvider(new SessionMediaEditGraph
+        {
+            FilterComplex = "[0:v]copy[vout];[0:a]anull[aout]",
+            VideoMapLabel = "vout",
+            AudioMapLabel = "aout"
+        });
+
+        var ok = CreateHelper(graph: provider.Object)
+            .TryGetSessionEditGraphMapArgs(BuildState(), out var filterComplexArg, out var mapArgs);
+
+        Assert.True(ok);
+        Assert.Equal("-filter_complex \"[0:v]copy[vout];[0:a]anull[aout]\"", filterComplexArg);
+        Assert.Contains("-map \"[vout]\"", mapArgs, StringComparison.Ordinal);
+        Assert.Contains("-map \"[aout]\"", mapArgs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HasSessionEditGraphForRequest_Provider_ReturnsTrue()
+    {
+        var provider = new Mock<ISessionMediaEditGraphProvider>();
+        provider.Setup(p => p.HasEditGraph("play", "dev")).Returns(true);
+
+        Assert.True(CreateHelper(graph: provider.Object).HasSessionEditGraphForRequest("play", "dev"));
+        Assert.False(CreateHelper().HasSessionEditGraphForRequest("play", "dev"));
+    }
+
+    private static Mock<ISessionMediaEditGraphProvider> CreateGraphProvider(SessionMediaEditGraph graph)
+    {
+        var provider = new Mock<ISessionMediaEditGraphProvider>();
+        provider.Setup(p => p.HasEditGraph(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+        provider
+            .Setup(p => p.GetEditGraph(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SessionMediaEditGraphContext>()))
+            .Returns(graph);
+        return provider;
+    }
+
+    private static EncodingJobInfo BuildState()
+    {
+        var video = new MediaStream { Index = 0, Type = MediaStreamType.Video, Codec = "h264" };
+        var audio = new MediaStream { Index = 1, Type = MediaStreamType.Audio, Codec = "aac", Channels = 2 };
+
+        return new EncodingJobInfo(TranscodingJobType.Progressive)
+        {
+            MediaSource = new MediaSourceInfo
+            {
+                Container = "mkv",
+                MediaStreams = new List<MediaStream> { video, audio },
+            },
+            VideoStream = video,
+            AudioStream = audio,
+            BaseRequest = new VideoRequestDto(),
+            IsVideoRequest = true,
+            IsInputVideo = true,
+            RunTimeTicks = TimeSpan.FromMinutes(10).Ticks,
+        };
+    }
+
+    private static EncodingHelper CreateHelper(
+        ISessionAudioFilterProvider? audio = null,
+        ISessionMediaEditGraphProvider? graph = null)
+    {
+        return new EncodingHelper(
+            Mock.Of<IApplicationPaths>(),
+            Mock.Of<IMediaEncoder>(),
+            Mock.Of<ISubtitleEncoder>(),
+            Mock.Of<IConfiguration>(),
+            Mock.Of<IConfigurationManager>(),
+            Mock.Of<IPathManager>(),
+            audio is null ? null : [audio],
+            graph is null ? null : [graph]);
+    }
+}

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSessionHooksTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSessionHooksTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.IO;
 using MediaBrowser.Controller.Library;
@@ -117,6 +119,73 @@ public class EncodingHelperSessionHooksTests
         Assert.True(CreateHelper(graph: provider.Object).HasSessionEditGraphForRequest("play", "dev"));
         Assert.False(CreateHelper().HasSessionEditGraphForRequest("play", "dev"));
     }
+
+    [Fact]
+    public async Task ApplyPlaybackPlanTranscodeFlagsAsync_InvokesLoader()
+    {
+        var loader = new Mock<ISessionPlaybackPlanLoader>();
+        loader
+            .Setup(l => l.EnsurePlanLoadedAsync("play", "dev", "item", "source", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await CreateHelper().ApplyPlaybackPlanTranscodeFlagsAsync(
+            [loader.Object],
+            BuildStreamingRequest(),
+            "item",
+            CancellationToken.None);
+
+        loader.Verify(
+            l => l.EnsurePlanLoadedAsync("play", "dev", "item", "source", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ApplyPlaybackPlanTranscodeFlagsAsync_AudioFilter_DisablesAudioCopyOnly()
+    {
+        var audio = new Mock<ISessionAudioFilterProvider>();
+        audio.Setup(p => p.GetAdditionalAudioFilter("play", "dev", 0)).Returns("volume=0");
+
+        var request = BuildStreamingRequest();
+        var result = await CreateHelper(audio: audio.Object).ApplyPlaybackPlanTranscodeFlagsAsync(
+            Array.Empty<ISessionPlaybackPlanLoader>(),
+            request,
+            "item",
+            CancellationToken.None);
+
+        Assert.False(result.HasEditGraph);
+        Assert.True(result.HasAudioFilter);
+        Assert.False(request.AllowAudioStreamCopy);
+        Assert.True(request.AllowVideoStreamCopy);
+    }
+
+    [Fact]
+    public async Task ApplyPlaybackPlanTranscodeFlagsAsync_EditGraph_DisablesStreamCopy()
+    {
+        var graph = new Mock<ISessionMediaEditGraphProvider>();
+        graph.Setup(p => p.HasEditGraph("play", "dev")).Returns(true);
+
+        var request = BuildStreamingRequest();
+        var result = await CreateHelper(graph: graph.Object).ApplyPlaybackPlanTranscodeFlagsAsync(
+            null,
+            request,
+            "item",
+            CancellationToken.None);
+
+        Assert.True(result.HasEditGraph);
+        Assert.False(result.HasAudioFilter);
+        Assert.False(request.AllowAudioStreamCopy);
+        Assert.False(request.AllowVideoStreamCopy);
+    }
+
+    private static StreamingRequestDto BuildStreamingRequest()
+        => new()
+        {
+            PlaySessionId = "play",
+            DeviceId = "dev",
+            MediaSourceId = "source",
+            AllowAudioStreamCopy = true,
+            AllowVideoStreamCopy = true
+        };
 
     private static Mock<ISessionMediaEditGraphProvider> CreateGraphProvider(SessionMediaEditGraph graph)
     {


### PR DESCRIPTION
Let plugins inject per-session -af filters or supply a labeled filter_complex graph. Stock playback is unchanged when no plugin implements the interfaces.


**Changes**
Plugins can now inject a per-session FFmpeg audio filter (`ISessionAudioFilterProvider`) or replace the A/V filter chain with a labeled `-filter_complex` graph (`ISessionMediaEditGraphProvider`). A plan loader runs before the first FFmpeg request so a plugin can attach session state. With no plugin implementation, playback is unchanged.

Related
This does not implement these features in core. It lets a plugin do them during transcode without forking EncodingHelper or exposing raw FFmpeg args in the UI.

- Mute ranges for content-filtering plugins: https://features.jellyfin.org/posts/3396
- Volume boost during transcode: https://github.com/jellyfin/jellyfin/issues/4556
- Night-mode compressor during transcode: https://features.jellyfin.org/posts/1112
- Custom FFmpeg field (declined for security; this is a plugin-scoped alternative): https://features.jellyfin.org/posts/2563
- EDL mute/cut applied in the encoder (not EDL import / client skip, which Media Segments already covers)

**Code assistance**
An LLM (Cursor Grok 4.6) was used to locate call sites in EncodingHelper / HLS / progressive video and to draft the new interfaces and wiring. I directed the design (generic hooks, no plugin-specific types, stock path unchanged) and reviewed the diff before committing.

**Issues**
Fixes #17807

