### PR TITLE
Fix Blu-ray multi-angle concat generation

### DIFF
--- a/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
+++ b/MediaBrowser.MediaEncoding/BdInfo/BdInfoExaminer.cs
@@ -87,7 +87,7 @@ public class BdInfoExaminer : IBlurayExaminer
         if (playlist.StreamClips is not null && playlist.StreamClips.Count > 0)
         {
             // Get the files in the playlist
-            outputStream.Files = playlist.StreamClips.Select(i => i.StreamFile.FileInfo.FullName).ToArray();
+            outputStream.Files = playlist.StreamClips.Where(i => i.AngleIndex == 0).Select(i => i.StreamFile.FileInfo.FullName).ToArray();
         }
 
         return outputStream;


### PR DESCRIPTION
On some Blu-ray discs, a playlist may contain video clips from multiple angles.

Currently, when Jellyfin generates the concat file for a Blu-ray playlist, clips from different angles may all be added to the same concat file. This causes clips from multiple angles to be played sequentially instead of using the default angle.

This pull request fixes the issue by filtering the playlist clips to AngleIndex 0 when generating the concat file.

**Changes**
Filter Blu-ray playlist clips to AngleIndex == 0 when generating concat files to prevent clips from multiple angles from being played sequentially.

**Code assistance**
ChatGPT was used to assist with codebase navigation and understanding the relevant Blu-ray playlist handling logic.

**Issues**
https://github.com/jellyfin/jellyfin/issues/17823