### PR TITLE
Fix bump_version by removing Jellyfin.MediaEncoding.Keyframes

### DIFF
--- a/bump_version
+++ b/bump_version
@@ -27,7 +27,6 @@ jellyfin_subprojects=(
   MediaBrowser.Model/MediaBrowser.Model.csproj
   Emby.Naming/Emby.Naming.csproj
   src/Jellyfin.Extensions/Jellyfin.Extensions.csproj
-  src/Jellyfin.MediaEncoding.Keyframes/Jellyfin.MediaEncoding.Keyframes.csproj
 )
 issue_template_file="./.github/ISSUE_TEMPLATE/issue report.yml"
 


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
This file previously had the version in it, but it was removed in #17582 which caused this to fail. Remove it here.

**Code assistance**
N/A

**Issues**
N/A
