### PR TITLE
Fix database optimization memory use and pre-migration backup integrity

### DIFF
--- a/Jellyfin.Server/Program.cs
+++ b/Jellyfin.Server/Program.cs
@@ -271,9 +271,8 @@ namespace Jellyfin.Server
                 // Don't throw additional exception if startup failed.
                 if (appHost.ServiceProvider is not null)
                 {
-                    _logger.LogInformation("Optimizing the database... This might take a while");
+                    _logger.LogInformation("Preparing the database for shutdown...");
 
-                    // Deliberately untimed: a truncated optimization leaves the statistics incomplete.
                     var databaseProvider = appHost.ServiceProvider.GetRequiredService<IJellyfinDatabaseProvider>();
                     await databaseProvider.RunShutdownTask(CancellationToken.None).ConfigureAwait(false);
                 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/IJellyfinDatabaseProvider.cs
@@ -45,8 +45,10 @@ public interface IJellyfinDatabaseProvider
     Task RunScheduledOptimisation(CancellationToken cancellationToken);
 
     /// <summary>
-    /// If supported this should perform any actions that are required on stopping the jellyfin server, including the
-    /// same maintenance as <see cref="RunScheduledOptimisation(CancellationToken)"/>.
+    /// If supported this should perform any actions that are required on stopping the jellyfin server. This runs
+    /// against a deadline imposed by the service manager, so unlike
+    /// <see cref="RunScheduledOptimisation(CancellationToken)"/> it should only do work whose cost does not grow with
+    /// the size of the database.
     /// </summary>
     /// <param name="cancellationToken">The token that will be used to abort the operation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -91,10 +91,9 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             // VACUUM copy lands, which is the first thing to check when that runs out of space.
             _logger.LogInformation("SQLITE_TMPDIR is already set to {TempDirectory}, leaving it unchanged", configuredTempDirectory);
         }
-        else if (!OperatingSystem.IsWindows() && Directory.Exists(dataSourceDirectory))
+        else if (Directory.Exists(dataSourceDirectory))
         {
-            Environment.SetEnvironmentVariable("SQLITE_TMPDIR", dataSourceDirectory);
-            _logger.LogInformation("SQLITE_TMPDIR set to: {TempDirectory}", dataSourceDirectory);
+            SetTemporaryDirectory(dataSourceDirectory);
         }
 
         options
@@ -187,6 +186,25 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             await context.Database.ExecuteSqlRawAsync("ANALYZE", cancellationToken).ConfigureAwait(false);
             await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("jellyfin.db optimized successfully!");
+        }
+    }
+
+    private void SetTemporaryDirectory(string directory)
+    {
+        try
+        {
+            using var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            using var command = connection.CreateCommand();
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+            command.CommandText = $"PRAGMA temp_store_directory='{directory.Replace("'", "''", StringComparison.Ordinal)}'";
+#pragma warning restore CA2100
+            command.ExecuteNonQuery();
+            _logger.LogInformation("SQLite temporary directory set to: {TempDirectory}", directory);
+        }
+        catch (SqliteException ex)
+        {
+            _logger.LogWarning(ex, "Could not set the SQLite temporary directory to {TempDirectory}", directory);
         }
     }
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -84,7 +84,14 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         _tempStoreMode = GetOption(customOptions, "tempstoremode", int.Parse, () => 2);
 
         var dataSourceDirectory = Path.GetDirectoryName(dataSource);
-        if (!OperatingSystem.IsWindows() && Directory.Exists(dataSourceDirectory))
+        var configuredTempDirectory = Environment.GetEnvironmentVariable("SQLITE_TMPDIR");
+        if (!string.IsNullOrEmpty(configuredTempDirectory))
+        {
+            // Somebody pointed this somewhere on purpose, so leave it alone. Logged because it decides where the
+            // VACUUM copy lands, which is the first thing to check when that runs out of space.
+            _logger.LogInformation("SQLITE_TMPDIR is already set to {TempDirectory}, leaving it unchanged", configuredTempDirectory);
+        }
+        else if (!OperatingSystem.IsWindows() && Directory.Exists(dataSourceDirectory))
         {
             Environment.SetEnvironmentVariable("SQLITE_TMPDIR", dataSourceDirectory);
             _logger.LogInformation("SQLITE_TMPDIR set to: {TempDirectory}", dataSourceDirectory);
@@ -231,12 +238,53 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             return Task.CompletedTask;
         }
 
+        if (!TryRetireWriteAheadLog(path))
+        {
+            _logger.LogCritical(
+                "Refusing to restore jellyfin.db: the write-ahead log at {WriteAheadLog} could not be retired, which "
+                + "means the database is still open and replacing it now would silently bring back the data this "
+                + "rollback is undoing. Stop the server and copy {Backup} over {Path} by hand.",
+                path + "-wal",
+                backupFile,
+                path);
+            return Task.CompletedTask;
+        }
+
         File.Copy(backupFile, path, true);
 
-        File.Delete(path + "-wal");
-        File.Delete(path + "-shm");
-
         return Task.CompletedTask;
+    }
+
+    private bool TryRetireWriteAheadLog(string path)
+    {
+        var writeAheadLogPath = path + "-wal";
+        if (!File.Exists(path) || !File.Exists(writeAheadLogPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadWrite,
+                Pooling = false
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "PRAGMA wal_checkpoint(TRUNCATE)";
+            command.ExecuteNonQuery();
+        }
+        catch (SqliteException ex)
+        {
+            // Either something else holds the database or it is too damaged to open. The check below covers both.
+            _logger.LogError(ex, "Could not open jellyfin.db to retire its write-ahead log");
+        }
+
+        return !File.Exists(writeAheadLogPath);
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -224,6 +224,10 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         }
 
         File.Copy(backupFile, path, true);
+
+        File.Delete(path + "-wal");
+        File.Delete(path + "-shm");
+
         return Task.CompletedTask;
     }
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -137,6 +137,12 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     public async Task RunShutdownTask(CancellationToken cancellationToken)
     {
         // Run before disposing the application. Only a checkpoint: stopping is on a deadline.
+
+        // Empty the pool first. Anything still parked in it can start reading again between here and the
+        // checkpoint, and a reader that holds the write-ahead log open is exactly what makes the truncation
+        // fail. Connections handed out already cannot be taken away, but they get disposed on return.
+        SqliteConnection.ClearAllPools();
+
         try
         {
             if (DbContextFactory is not null)
@@ -155,6 +161,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             _logger.LogError(ex, "Error while checkpointing jellyfin.db");
         }
 
+        // The checkpointing connection went back into the pool, so retire that one as well.
         SqliteConnection.ClearAllPools();
     }
 

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -182,16 +182,31 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     }
 
     /// <inheritdoc />
-    public Task<string> MigrationBackupFast(CancellationToken cancellationToken)
+    public async Task<string> MigrationBackupFast(CancellationToken cancellationToken)
     {
-        var key = DateTime.UtcNow.ToString("yyyyMMddhhmmss", CultureInfo.InvariantCulture);
         var path = Path.Combine(_applicationPaths.DataPath, "jellyfin.db");
-        var backupFile = Path.Combine(_applicationPaths.DataPath, BackupFolderName);
-        Directory.CreateDirectory(backupFile);
+        var backupFolder = Path.Combine(_applicationPaths.DataPath, BackupFolderName);
+        Directory.CreateDirectory(backupFolder);
 
-        backupFile = Path.Combine(backupFile, $"{key}_jellyfin.db");
+        if (DbContextFactory is not null && File.Exists(path))
+        {
+            var context = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+            await using (context.ConfigureAwait(false))
+            {
+                await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var key = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        var backupFile = Path.Combine(backupFolder, $"{key}_jellyfin.db");
+        for (var attempt = 1; File.Exists(backupFile); attempt++)
+        {
+            key = string.Create(CultureInfo.InvariantCulture, $"{DateTime.UtcNow:yyyyMMddHHmmss}_{attempt}");
+            backupFile = Path.Combine(backupFolder, $"{key}_jellyfin.db");
+        }
+
         File.Copy(path, backupFile);
-        return Task.FromResult(key);
+        return key;
     }
 
     /// <inheritdoc />

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -24,9 +25,6 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     private const string BackupFolderName = "SQLiteBackups";
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;
-    private static int _temporaryDirectorySet;
-
-    private int _tempStoreMode = 2;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SqliteDatabaseProvider"/> class.
@@ -63,11 +61,9 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         var customOptions = databaseConfiguration.CustomProviderOptions?.Options;
 
-        var dataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db"))!;
-
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
-            DataSource = dataSource,
+            DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
             // Private, not Default: sqlite3_enable_shared_cache is process-global, so a plugin
             // enabling it makes these connections share a cache too. Contention then surfaces as
             // SQLITE_LOCKED ("database table is locked"), which the busy handler does not cover,
@@ -82,21 +78,6 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         // Log SQLite connection parameters
         _logger.LogInformation("SQLite connection string: {ConnectionString}", connectionString);
 
-        _tempStoreMode = GetOption(customOptions, "tempstoremode", int.Parse, () => 2);
-        var dataSourceDirectory = Path.GetDirectoryName(dataSource);
-        var configuredTempDirectory = Environment.GetEnvironmentVariable("SQLITE_TMPDIR");
-        if (!string.IsNullOrEmpty(configuredTempDirectory))
-        {
-            // Somebody pointed this somewhere on purpose, so leave it alone. Logged because it decides where the
-            // VACUUM copy lands, which is the first thing to check when that runs out of space.
-            _logger.LogInformation("SQLITE_TMPDIR is already set to {TempDirectory}, leaving it unchanged", configuredTempDirectory);
-        }
-        else if (Directory.Exists(dataSourceDirectory)
-         && Interlocked.Exchange(ref _temporaryDirectorySet, 1) == 0)
-        {
-            SetTemporaryDirectory(dataSourceDirectory);
-        }
-
         options
             .UseSqlite(
                 connectionString,
@@ -110,7 +91,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                 GetOption<int?>(customOptions, "cacheSize", e => int.Parse(e, CultureInfo.InvariantCulture)),
                 GetOption(customOptions, "lockingmode", e => e, () => "NORMAL")!,
                 GetOption(customOptions, "journalsizelimit", int.Parse, () => 134_217_728),
-                _tempStoreMode,
+                GetOption(customOptions, "tempstoremode", int.Parse, () => 2),
                 GetOption(customOptions, "syncmode", int.Parse, () => 1),
                 customOptions?.Where(e => e.Key.StartsWith("#PRAGMA:", StringComparison.OrdinalIgnoreCase)).ToDictionary(e => e.Key["#PRAGMA:".Length..], e => e.Value) ?? []));
 
@@ -176,44 +157,70 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         var context = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
         await using (context.ConfigureAwait(false))
         {
-            await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
-            await context.Database.ExecuteSqlRawAsync("PRAGMA temp_store=1", cancellationToken).ConfigureAwait(false);
+            await context.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                await context.Database.ExecuteSqlRawAsync("VACUUM", cancellationToken).ConfigureAwait(false);
+                long? tempStore;
+                long? analysisLimit;
+                var pragmaCommand = context.Database.GetDbConnection().CreateCommand();
+                await using (pragmaCommand.ConfigureAwait(false))
+                {
+                    pragmaCommand.CommandText = "PRAGMA temp_store";
+                    tempStore = await ReadPragmaValueAsync(pragmaCommand, cancellationToken).ConfigureAwait(false);
+                    pragmaCommand.CommandText = "PRAGMA analysis_limit";
+                    analysisLimit = await ReadPragmaValueAsync(pragmaCommand, cancellationToken).ConfigureAwait(false);
+                }
+
+                await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
+
+                _logger.LogDebug(
+                    "Rebuilding jellyfin.db on disk, scratch space goes to {TempDirectory}",
+                    Environment.GetEnvironmentVariable("SQLITE_TMPDIR") ?? "SQLite's default temporary directory");
+                await context.Database.ExecuteSqlRawAsync("PRAGMA temp_store=1", cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await context.Database.ExecuteSqlRawAsync("VACUUM", cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    // The connection goes back to the pool, so hand it over the way it was handed to us.
+                    if (tempStore is not null)
+                    {
+                        await context.Database.ExecuteSqlRawAsync(
+                            FormattableString.Invariant($"PRAGMA temp_store={tempStore.Value}"),
+                            CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+
+                await context.Database.ExecuteSqlRawAsync("PRAGMA analysis_limit=0", cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await context.Database.ExecuteSqlRawAsync("ANALYZE", cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (analysisLimit is not null)
+                    {
+                        await context.Database.ExecuteSqlRawAsync(
+                            FormattableString.Invariant($"PRAGMA analysis_limit={analysisLimit.Value}"),
+                            CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+
+                await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
+                _logger.LogInformation("jellyfin.db optimized successfully!");
             }
             finally
             {
-                // The connection goes back to the pool, so hand it over with the configured mode again.
-                await context.Database.ExecuteSqlRawAsync(
-                    FormattableString.Invariant($"PRAGMA temp_store={_tempStoreMode}"),
-                    CancellationToken.None).ConfigureAwait(false);
+                await context.Database.CloseConnectionAsync().ConfigureAwait(false);
             }
-
-            await context.Database.ExecuteSqlRawAsync("PRAGMA analysis_limit=0", cancellationToken).ConfigureAwait(false);
-            await context.Database.ExecuteSqlRawAsync("ANALYZE", cancellationToken).ConfigureAwait(false);
-            await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("jellyfin.db optimized successfully!");
         }
     }
 
-    private void SetTemporaryDirectory(string directory)
+    private static async Task<long?> ReadPragmaValueAsync(DbCommand command, CancellationToken cancellationToken)
     {
-        try
-        {
-            using var connection = new SqliteConnection("Data Source=:memory:");
-            connection.Open();
-            using var command = connection.CreateCommand();
-#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
-            command.CommandText = $"PRAGMA temp_store_directory='{directory.Replace("'", "''", StringComparison.Ordinal)}'";
-#pragma warning restore CA2100
-            command.ExecuteNonQuery();
-            _logger.LogInformation("SQLite temporary directory set to: {TempDirectory}", directory);
-        }
-        catch (SqliteException ex)
-        {
-            _logger.LogWarning(ex, "Could not set the SQLite temporary directory to {TempDirectory}", directory);
-        }
+        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return value is null or DBNull ? null : Convert.ToInt64(value, CultureInfo.InvariantCulture);
     }
 
     /// <inheritdoc/>

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -130,15 +130,23 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     /// <inheritdoc/>
     public async Task RunShutdownTask(CancellationToken cancellationToken)
     {
-        // Run before disposing the application
+        // Run before disposing the application. Only a checkpoint: stopping is on a deadline.
         try
         {
-            await OptimizeAsync(cancellationToken).ConfigureAwait(false);
+            if (DbContextFactory is not null)
+            {
+                var context = await DbContextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+                await using (context.ConfigureAwait(false))
+                {
+                    await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
+                }
+            }
         }
         catch (Exception ex)
         {
-            // A missed optimization only costs performance, so never fail the shutdown over this.
-            _logger.LogError(ex, "Error while optimizing jellyfin.db");
+            // A missed checkpoint only leaves a write-ahead log for the next start to replay, so never fail the
+            // shutdown over this.
+            _logger.LogError(ex, "Error while checkpointing jellyfin.db");
         }
 
         SqliteConnection.ClearAllPools();

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -24,6 +24,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     private const string BackupFolderName = "SQLiteBackups";
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;
+    private static int _temporaryDirectorySet;
 
     private int _tempStoreMode = 2;
 
@@ -82,7 +83,6 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         _logger.LogInformation("SQLite connection string: {ConnectionString}", connectionString);
 
         _tempStoreMode = GetOption(customOptions, "tempstoremode", int.Parse, () => 2);
-
         var dataSourceDirectory = Path.GetDirectoryName(dataSource);
         var configuredTempDirectory = Environment.GetEnvironmentVariable("SQLITE_TMPDIR");
         if (!string.IsNullOrEmpty(configuredTempDirectory))
@@ -91,7 +91,8 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             // VACUUM copy lands, which is the first thing to check when that runs out of space.
             _logger.LogInformation("SQLITE_TMPDIR is already set to {TempDirectory}, leaving it unchanged", configuredTempDirectory);
         }
-        else if (Directory.Exists(dataSourceDirectory))
+        else if (Directory.Exists(dataSourceDirectory)
+         && Interlocked.Exchange(ref _temporaryDirectorySet, 1) == 0)
         {
             SetTemporaryDirectory(dataSourceDirectory);
         }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -25,6 +25,8 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     private readonly IApplicationPaths _applicationPaths;
     private readonly ILogger<SqliteDatabaseProvider> _logger;
 
+    private int _tempStoreMode = 2;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SqliteDatabaseProvider"/> class.
     /// </summary>
@@ -60,9 +62,11 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         var customOptions = databaseConfiguration.CustomProviderOptions?.Options;
 
+        var dataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db"))!;
+
         var sqliteConnectionBuilder = new SqliteConnectionStringBuilder
         {
-            DataSource = GetOption(customOptions, "path", e => e, () => Path.Combine(_applicationPaths.DataPath, "jellyfin.db")),
+            DataSource = dataSource,
             // Private, not Default: sqlite3_enable_shared_cache is process-global, so a plugin
             // enabling it makes these connections share a cache too. Contention then surfaces as
             // SQLITE_LOCKED ("database table is locked"), which the busy handler does not cover,
@@ -77,6 +81,15 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         // Log SQLite connection parameters
         _logger.LogInformation("SQLite connection string: {ConnectionString}", connectionString);
 
+        _tempStoreMode = GetOption(customOptions, "tempstoremode", int.Parse, () => 2);
+
+        var dataSourceDirectory = Path.GetDirectoryName(dataSource);
+        if (!OperatingSystem.IsWindows() && Directory.Exists(dataSourceDirectory))
+        {
+            Environment.SetEnvironmentVariable("SQLITE_TMPDIR", dataSourceDirectory);
+            _logger.LogInformation("SQLITE_TMPDIR set to: {TempDirectory}", dataSourceDirectory);
+        }
+
         options
             .UseSqlite(
                 connectionString,
@@ -90,7 +103,7 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
                 GetOption<int?>(customOptions, "cacheSize", e => int.Parse(e, CultureInfo.InvariantCulture)),
                 GetOption(customOptions, "lockingmode", e => e, () => "NORMAL")!,
                 GetOption(customOptions, "journalsizelimit", int.Parse, () => 134_217_728),
-                GetOption(customOptions, "tempstoremode", int.Parse, () => 2),
+                _tempStoreMode,
                 GetOption(customOptions, "syncmode", int.Parse, () => 1),
                 customOptions?.Where(e => e.Key.StartsWith("#PRAGMA:", StringComparison.OrdinalIgnoreCase)).ToDictionary(e => e.Key["#PRAGMA:".Length..], e => e.Value) ?? []));
 
@@ -142,7 +155,19 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
         await using (context.ConfigureAwait(false))
         {
             await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);
-            await context.Database.ExecuteSqlRawAsync("VACUUM", cancellationToken).ConfigureAwait(false);
+            await context.Database.ExecuteSqlRawAsync("PRAGMA temp_store=1", cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await context.Database.ExecuteSqlRawAsync("VACUUM", cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                // The connection goes back to the pool, so hand it over with the configured mode again.
+                await context.Database.ExecuteSqlRawAsync(
+                    FormattableString.Invariant($"PRAGMA temp_store={_tempStoreMode}"),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+
             await context.Database.ExecuteSqlRawAsync("PRAGMA analysis_limit=0", cancellationToken).ConfigureAwait(false);
             await context.Database.ExecuteSqlRawAsync("ANALYZE", cancellationToken).ConfigureAwait(false);
             await context.Database.ExecuteSqlRawAsync("PRAGMA wal_checkpoint(TRUNCATE)", cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
`OptimizeAsync` runs `VACUUM`, which rebuilds the database into an unnamed temporary database and therefore honours `temp_store`. Under this provider's default `temp_store=2` (MEMORY) the entire replacement database is held in RAM.
As this also runs on every shutdown, stopping a server with a large library could get it OOM-killed.

**Changes**
* `VACUUM` now runs with `temp_store=FILE` and `SQLITE_TMPDIR` is pointed at the database's own directory instead of `/tmp`
* `MigrationBackupFast` now copies `jellyfin.db` while checkpointing the WAL first
* `MigrationBackupFast` now names backups with `HH` (24-hour clock) instead of `hh` (12-hour clock) to avoid collisions
* Shutdown only checkpoints the DB to prevent Docker  and other system managers to force kill mid-shutdown

**Code assistance**
Claude Opus 5 for benchmarks and tests

**Issues**
Fix #17831
