### PR TITLE
Fix a deadlock and leaks in the WebSocket connection

### DIFF
--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -22,6 +22,8 @@ namespace Emby.Server.Implementations.HttpServer
     /// </summary>
     public class WebSocketConnection : IWebSocketConnection
     {
+        private const int MaxMessageSize = 64 * 1024;
+
         /// <summary>
         /// The logger.
         /// </summary>
@@ -115,69 +117,88 @@ namespace Emby.Server.Implementations.HttpServer
         /// <inheritdoc />
         public async Task ReceiveAsync(CancellationToken cancellationToken = default)
         {
-            var pipe = new Pipe();
+            // This loop is both producer and consumer, so pipe backpressure would deadlock it.
+            // The unconsumed byte count is bounded by MaxMessageSize instead.
+            var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0, resumeWriterThreshold: 0));
             var writer = pipe.Writer;
+            var closeStatus = WebSocketCloseStatus.NormalClosure;
+            long buffered = 0;
 
-            ValueWebSocketReceiveResult receiveResult;
-            do
+            try
             {
-                // Allocate at least 512 bytes from the PipeWriter
-                Memory<byte> memory = writer.GetMemory(512);
-                try
+                ValueWebSocketReceiveResult receiveResult;
+                do
                 {
-                    receiveResult = await _socket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
-                {
-                    // ObjectDisposedException/OperationCanceledException: the socket was torn
-                    // down underneath us (e.g. by the keep-alive watchdog after the connection
-                    // was declared lost). Fall through so Closed is still raised and the
-                    // session can release this connection.
-                    _logger.LogWarning("WS {IP} error receiving data: {Message}", RemoteEndPoint, ex.Message);
-                    break;
-                }
+                    // Allocate at least 512 bytes from the PipeWriter
+                    Memory<byte> memory = writer.GetMemory(512);
+                    try
+                    {
+                        receiveResult = await _socket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
+                    {
+                        // ObjectDisposedException/OperationCanceledException: the socket was torn
+                        // down underneath us (e.g. by the keep-alive watchdog after the connection
+                        // was declared lost). Fall through so Closed is still raised and the
+                        // session can release this connection.
+                        _logger.LogWarning("WS {IP} error receiving data: {Message}", RemoteEndPoint, ex.Message);
+                        break;
+                    }
 
-                int bytesRead = receiveResult.Count;
-                if (bytesRead == 0)
-                {
-                    break;
+                    int bytesRead = receiveResult.Count;
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    buffered += bytesRead;
+                    if (buffered > MaxMessageSize)
+                    {
+                        _logger.LogWarning("WS {IP} message exceeds the {Limit} byte limit", RemoteEndPoint, MaxMessageSize);
+                        closeStatus = WebSocketCloseStatus.MessageTooBig;
+                        break;
+                    }
+
+                    // Tell the PipeWriter how much was read from the Socket
+                    writer.Advance(bytesRead);
+
+                    // Make the data available to the PipeReader
+                    FlushResult flushResult = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    if (flushResult.IsCompleted)
+                    {
+                        // The PipeReader stopped reading
+                        break;
+                    }
+
+                    LastActivityDate = DateTime.UtcNow;
+
+                    if (receiveResult.EndOfMessage)
+                    {
+                        buffered -= await ProcessInternal(pipe.Reader).ConfigureAwait(false);
+                    }
                 }
-
-                // Tell the PipeWriter how much was read from the Socket
-                writer.Advance(bytesRead);
-
-                // Make the data available to the PipeReader
-                FlushResult flushResult = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-                if (flushResult.IsCompleted)
-                {
-                    // The PipeReader stopped reading
-                    break;
-                }
-
-                LastActivityDate = DateTime.UtcNow;
-
-                if (receiveResult.EndOfMessage)
-                {
-                    await ProcessInternal(pipe.Reader).ConfigureAwait(false);
-                }
+                while ((_socket.State == WebSocketState.Open || _socket.State == WebSocketState.Connecting)
+                    && receiveResult.MessageType != WebSocketMessageType.Close);
             }
-            while ((_socket.State == WebSocketState.Open || _socket.State == WebSocketState.Connecting)
-                && receiveResult.MessageType != WebSocketMessageType.Close);
-
-            Closed?.Invoke(this, EventArgs.Empty);
+            finally
+            {
+                await writer.CompleteAsync().ConfigureAwait(false);
+                await pipe.Reader.CompleteAsync().ConfigureAwait(false);
+                Closed?.Invoke(this, EventArgs.Empty);
+            }
 
             if (_socket.State == WebSocketState.Open
                 || _socket.State == WebSocketState.CloseReceived
                 || _socket.State == WebSocketState.CloseSent)
             {
                 await _socket.CloseAsync(
-                    WebSocketCloseStatus.NormalClosure,
+                    closeStatus,
                     string.Empty,
                     cancellationToken).ConfigureAwait(false);
             }
         }
 
-        private async Task ProcessInternal(PipeReader reader)
+        private async Task<long> ProcessInternal(PipeReader reader)
         {
             ReadResult result = await reader.ReadAsync().ConfigureAwait(false);
             ReadOnlySequence<byte> buffer = result.Buffer;
@@ -186,7 +207,7 @@ namespace Emby.Server.Implementations.HttpServer
             {
                 // Tell the PipeReader how much of the buffer we have consumed
                 reader.AdvanceTo(buffer.End);
-                return;
+                return buffer.Length;
             }
 
             InboundWebSocketMessage<object>? stub;
@@ -200,13 +221,14 @@ namespace Emby.Server.Implementations.HttpServer
                 // Tell the PipeReader how much of the buffer we have consumed
                 reader.AdvanceTo(buffer.End);
                 _logger.LogError(ex, "Error processing web socket message: {Data}", Encoding.UTF8.GetString(buffer));
-                return;
+                return buffer.Length;
             }
 
             if (stub is null)
             {
+                reader.AdvanceTo(buffer.End);
                 _logger.LogError("Error processing web socket message");
-                return;
+                return buffer.Length;
             }
 
             // Tell the PipeReader how much of the buffer we have consumed
@@ -235,6 +257,8 @@ namespace Emby.Server.Implementations.HttpServer
                     _logger.LogWarning(exception, "Failed to process WebSocket message");
                 }
             }
+
+            return bytesConsumed;
         }
 
         internal InboundWebSocketMessage<object>? DeserializeWebSocketMessage(ReadOnlySequence<byte> bytes, out long bytesConsumed)

--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -117,72 +117,18 @@ namespace Emby.Server.Implementations.HttpServer
         /// <inheritdoc />
         public async Task ReceiveAsync(CancellationToken cancellationToken = default)
         {
-            // This loop is both producer and consumer, so pipe backpressure would deadlock it.
-            // The unconsumed byte count is bounded by MaxMessageSize instead.
+            // The receive loop is both producer and consumer, so pipe backpressure would
+            // deadlock it. The unconsumed byte count is bounded by MaxMessageSize instead.
             var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 0, resumeWriterThreshold: 0));
-            var writer = pipe.Writer;
-            var closeStatus = WebSocketCloseStatus.NormalClosure;
-            long buffered = 0;
+            WebSocketCloseStatus closeStatus;
 
             try
             {
-                ValueWebSocketReceiveResult receiveResult;
-                do
-                {
-                    // Allocate at least 512 bytes from the PipeWriter
-                    Memory<byte> memory = writer.GetMemory(512);
-                    try
-                    {
-                        receiveResult = await _socket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
-                    {
-                        // ObjectDisposedException/OperationCanceledException: the socket was torn
-                        // down underneath us (e.g. by the keep-alive watchdog after the connection
-                        // was declared lost). Fall through so Closed is still raised and the
-                        // session can release this connection.
-                        _logger.LogWarning("WS {IP} error receiving data: {Message}", RemoteEndPoint, ex.Message);
-                        break;
-                    }
-
-                    int bytesRead = receiveResult.Count;
-                    if (bytesRead == 0)
-                    {
-                        break;
-                    }
-
-                    buffered += bytesRead;
-                    if (buffered > MaxMessageSize)
-                    {
-                        _logger.LogWarning("WS {IP} message exceeds the {Limit} byte limit", RemoteEndPoint, MaxMessageSize);
-                        closeStatus = WebSocketCloseStatus.MessageTooBig;
-                        break;
-                    }
-
-                    // Tell the PipeWriter how much was read from the Socket
-                    writer.Advance(bytesRead);
-
-                    // Make the data available to the PipeReader
-                    FlushResult flushResult = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
-                    if (flushResult.IsCompleted)
-                    {
-                        // The PipeReader stopped reading
-                        break;
-                    }
-
-                    LastActivityDate = DateTime.UtcNow;
-
-                    if (receiveResult.EndOfMessage)
-                    {
-                        buffered -= await ProcessInternal(pipe.Reader).ConfigureAwait(false);
-                    }
-                }
-                while ((_socket.State == WebSocketState.Open || _socket.State == WebSocketState.Connecting)
-                    && receiveResult.MessageType != WebSocketMessageType.Close);
+                closeStatus = await ReceiveLoopAsync(pipe, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
-                await writer.CompleteAsync().ConfigureAwait(false);
+                await pipe.Writer.CompleteAsync().ConfigureAwait(false);
                 await pipe.Reader.CompleteAsync().ConfigureAwait(false);
                 Closed?.Invoke(this, EventArgs.Empty);
             }
@@ -196,6 +142,67 @@ namespace Emby.Server.Implementations.HttpServer
                     string.Empty,
                     cancellationToken).ConfigureAwait(false);
             }
+        }
+
+        private async Task<WebSocketCloseStatus> ReceiveLoopAsync(Pipe pipe, CancellationToken cancellationToken)
+        {
+            var writer = pipe.Writer;
+            long buffered = 0;
+
+            ValueWebSocketReceiveResult receiveResult;
+            do
+            {
+                // Allocate at least 512 bytes from the PipeWriter
+                Memory<byte> memory = writer.GetMemory(512);
+                try
+                {
+                    receiveResult = await _socket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
+                {
+                    // ObjectDisposedException/OperationCanceledException: the socket was torn
+                    // down underneath us (e.g. by the keep-alive watchdog after the connection
+                    // was declared lost). Fall through so Closed is still raised and the
+                    // session can release this connection.
+                    _logger.LogWarning("WS {IP} error receiving data: {Message}", RemoteEndPoint, ex.Message);
+                    break;
+                }
+
+                int bytesRead = receiveResult.Count;
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                buffered += bytesRead;
+                if (buffered > MaxMessageSize)
+                {
+                    _logger.LogWarning("WS {IP} message exceeds the {Limit} byte limit", RemoteEndPoint, MaxMessageSize);
+                    return WebSocketCloseStatus.MessageTooBig;
+                }
+
+                // Tell the PipeWriter how much was read from the Socket
+                writer.Advance(bytesRead);
+
+                // Make the data available to the PipeReader
+                FlushResult flushResult = await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                if (flushResult.IsCompleted)
+                {
+                    // The PipeReader stopped reading
+                    break;
+                }
+
+                LastActivityDate = DateTime.UtcNow;
+
+                if (receiveResult.EndOfMessage)
+                {
+                    buffered -= await ProcessInternal(pipe.Reader).ConfigureAwait(false);
+                }
+            }
+            while ((_socket.State == WebSocketState.Open || _socket.State == WebSocketState.Connecting)
+                && receiveResult.MessageType != WebSocketMessageType.Close);
+
+            return WebSocketCloseStatus.NormalClosure;
         }
 
         private async Task<long> ProcessInternal(PipeReader reader)
@@ -326,7 +333,7 @@ namespace Emby.Server.Implementations.HttpServer
             }
             catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
             {
-                _logger.LogWarning("WS {IP} error sending the close frame: {Message}", RemoteEndPoint, ex.Message);
+                _logger.LogWarning(ex, "WS {IP} error sending the close frame", RemoteEndPoint);
             }
             finally
             {

--- a/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
+++ b/Emby.Server.Implementations/HttpServer/WebSocketConnection.cs
@@ -317,12 +317,21 @@ namespace Emby.Server.Implementations.HttpServer
         /// <returns>A ValueTask.</returns>
         protected virtual async ValueTask DisposeAsyncCore()
         {
-            if (_socket.State == WebSocketState.Open)
+            try
             {
-                await _socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "System Shutdown", CancellationToken.None).ConfigureAwait(false);
+                if (_socket.State == WebSocketState.Open)
+                {
+                    await _socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "System Shutdown", CancellationToken.None).ConfigureAwait(false);
+                }
             }
-
-            _socket.Dispose();
+            catch (Exception ex) when (ex is WebSocketException or ObjectDisposedException or OperationCanceledException)
+            {
+                _logger.LogWarning("WS {IP} error sending the close frame: {Message}", RemoteEndPoint, ex.Message);
+            }
+            finally
+            {
+                _socket.Dispose();
+            }
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
@@ -112,6 +112,32 @@ namespace Jellyfin.Server.Implementations.Tests.HttpServer
         }
 
         [Fact]
+        public async Task ReceiveAsync_MessageAtSizeLimit_IsProcessed()
+        {
+            var payload = Message(new string('a', (64 * 1024) - Message(string.Empty).Length));
+            Assert.Equal(64 * 1024, payload.Length);
+
+            var socket = new ScriptedWebSocket(payload);
+            var received = 0;
+            var con = new WebSocketConnection(new NullLogger<WebSocketConnection>(), socket, null!, null!)
+            {
+                OnReceive = _ =>
+                {
+                    received++;
+                    return Task.CompletedTask;
+                }
+            };
+
+            var receive = con.ReceiveAsync(TestContext.Current.CancellationToken);
+            var finished = await Task.WhenAny(receive, Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+            Assert.Same(receive, finished);
+            await receive.ConfigureAwait(true);
+            Assert.Equal(1, received);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, socket.CloseStatusSent);
+        }
+
+        [Fact]
         public async Task DisposeAsync_CloseOutputFails_StillDisposesSocket()
         {
             var socket = new ScriptedWebSocket

--- a/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
@@ -1,7 +1,12 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
+using System.Net.WebSockets;
+using System.Text;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Emby.Server.Implementations.HttpServer;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -48,6 +53,70 @@ namespace Jellyfin.Server.Implementations.Tests.HttpServer
             Assert.Throws<JsonException>(() => con.DeserializeWebSocketMessage(new ReadOnlySequence<byte>(bytes), out var bytesConsumed));
         }
 
+        [Fact]
+        public async Task ReceiveAsync_OversizedMessage_ClosesInsteadOfBlocking()
+        {
+            var socket = new ScriptedWebSocket(Message(new string('a', 128 * 1024)));
+            var received = 0;
+            var con = new WebSocketConnection(new NullLogger<WebSocketConnection>(), socket, null!, null!)
+            {
+                OnReceive = _ =>
+                {
+                    received++;
+                    return Task.CompletedTask;
+                }
+            };
+
+            var receive = con.ReceiveAsync(TestContext.Current.CancellationToken);
+            var finished = await Task.WhenAny(receive, Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+            Assert.Same(receive, finished);
+            await receive.ConfigureAwait(true);
+            Assert.Equal(WebSocketCloseStatus.MessageTooBig, socket.CloseStatusSent);
+            Assert.Equal(0, received);
+        }
+
+        [Fact]
+        public async Task ReceiveAsync_NullMessage_KeepsProcessingLaterMessages()
+        {
+            var socket = new ScriptedWebSocket(Raw("null"), Message("payload"));
+            var received = 0;
+            var con = new WebSocketConnection(new NullLogger<WebSocketConnection>(), socket, null!, null!)
+            {
+                OnReceive = _ =>
+                {
+                    received++;
+                    return Task.CompletedTask;
+                }
+            };
+
+            await con.ReceiveAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+            Assert.Equal(1, received);
+        }
+
+        [Fact]
+        public async Task ReceiveAsync_UnhandledException_StillRaisesClosed()
+        {
+            var socket = new ScriptedWebSocket(Message("payload"))
+            {
+                ReceiveException = new InvalidOperationException("receive failed")
+            };
+            var con = new WebSocketConnection(new NullLogger<WebSocketConnection>(), socket, null!, null!);
+            var closed = 0;
+            con.Closed += (_, _) => closed++;
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => con.ReceiveAsync(TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+            Assert.Equal(1, closed);
+        }
+
+        private static byte[] Message(string data)
+            => Raw($"{{\"MessageType\":\"SessionsStart\",\"Data\":\"{data}\"}}");
+
+        private static byte[] Raw(string json)
+            => Encoding.UTF8.GetBytes(json);
+
         internal sealed class BufferSegment : ReadOnlySequenceSegment<byte>
         {
             public BufferSegment(Memory<byte> memory)
@@ -64,6 +133,99 @@ namespace Jellyfin.Server.Implementations.Tests.HttpServer
                 Next = segment;
                 return segment;
             }
+        }
+
+        internal sealed class ScriptedWebSocket : WebSocket
+        {
+            private readonly IReadOnlyList<byte[]> _messages;
+            private WebSocketState _state = WebSocketState.Open;
+            private int _message;
+            private int _offset;
+
+            public ScriptedWebSocket(params byte[][] messages)
+            {
+                _messages = messages;
+            }
+
+            public Exception? ReceiveException { get; set; }
+
+            public Exception? CloseOutputException { get; set; }
+
+            public bool IsDisposed { get; private set; }
+
+            public WebSocketCloseStatus? CloseStatusSent { get; private set; }
+
+            public override WebSocketCloseStatus? CloseStatus => null;
+
+            public override string? CloseStatusDescription => null;
+
+            public override string? SubProtocol => null;
+
+            public override WebSocketState State => _state;
+
+            public override void Abort() => _state = WebSocketState.Aborted;
+
+            public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+            {
+                CloseStatusSent = closeStatus;
+                _state = WebSocketState.Closed;
+                return Task.CompletedTask;
+            }
+
+            public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+            {
+                if (CloseOutputException is not null)
+                {
+                    return Task.FromException(CloseOutputException);
+                }
+
+                CloseStatusSent = closeStatus;
+                _state = WebSocketState.CloseSent;
+                return Task.CompletedTask;
+            }
+
+            public override void Dispose()
+            {
+                IsDisposed = true;
+                _state = WebSocketState.Closed;
+            }
+
+            public override ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            {
+                if (ReceiveException is not null)
+                {
+                    return ValueTask.FromException<ValueWebSocketReceiveResult>(ReceiveException);
+                }
+
+                if (_message >= _messages.Count)
+                {
+                    _state = WebSocketState.CloseReceived;
+                    return ValueTask.FromResult(new ValueWebSocketReceiveResult(0, WebSocketMessageType.Close, true));
+                }
+
+                var payload = _messages[_message];
+                var count = Math.Min(payload.Length - _offset, buffer.Length);
+                payload.AsSpan(_offset, count).CopyTo(buffer.Span);
+                _offset += count;
+
+                var endOfMessage = _offset == payload.Length;
+                if (endOfMessage)
+                {
+                    _message++;
+                    _offset = 0;
+                }
+
+                return ValueTask.FromResult(new ValueWebSocketReceiveResult(count, WebSocketMessageType.Text, endOfMessage));
+            }
+
+            public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+                => throw new NotSupportedException();
+
+            public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+                => Task.CompletedTask;
+
+            public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+                => ValueTask.CompletedTask;
         }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/HttpServer/WebSocketConnectionTests.cs
@@ -111,6 +111,20 @@ namespace Jellyfin.Server.Implementations.Tests.HttpServer
             Assert.Equal(1, closed);
         }
 
+        [Fact]
+        public async Task DisposeAsync_CloseOutputFails_StillDisposesSocket()
+        {
+            var socket = new ScriptedWebSocket
+            {
+                CloseOutputException = new WebSocketException(WebSocketError.ConnectionClosedPrematurely)
+            };
+            var con = new WebSocketConnection(new NullLogger<WebSocketConnection>(), socket, null!, null!);
+
+            await con.DisposeAsync().ConfigureAwait(true);
+
+            Assert.True(socket.IsDisposed);
+        }
+
         private static byte[] Message(string data)
             => Raw($"{{\"MessageType\":\"SessionsStart\",\"Data\":\"{data}\"}}");
 


### PR DESCRIPTION
**Changes**

Four defects in `WebSocketConnection`, each with a regression test that fails without the fix.

A message larger than the pipe's pause threshold deadlocks the connection permanently. The receive loop is both the producer and the consumer of the pipe: it writes every frame and only drains the reader at `EndOfMessage`, so once `FlushAsync` pauses the writer, the reader that would resume it never runs. Backpressure cannot work in that shape, so it is disabled and replaced with an explicit 64 KiB limit checked against the pipe's unconsumed bytes, closing with `MessageTooBig` instead of hanging. That limit is the threshold the code already used: a default `Pipe` pauses at exactly 65536 unconsumed bytes, and a message of that size hangs on current master but is processed after this change, so nothing that works today is affected.

A message consisting of the JSON literal `null` deserializes to a null stub, and that branch returned without calling `AdvanceTo`. The pipe read is left outstanding and the next message throws `InvalidOperationException: Reading is already in progress.`

Any exception outside the narrow filter around `_socket.ReceiveAsync` skipped the `Closed` event, so `WebSocketController` and `SessionWebSocketListener` never learned the connection had gone and kept it registered for the life of the session. The loop is now wrapped so `Closed` is raised and the pipe completed on every exit path. #17079 widened that catch filter for three exception types, with a comment that `Closed` must still be raised so the session can release the connection; this generalises the same intent to every exit path rather than three named types.

`CloseOutputAsync` throwing in `DisposeAsyncCore`, which happens whenever the peer has already disconnected, skipped `_socket.Dispose()` and left the socket undisposed.

One ordering note: raising `Closed` on failure paths routes them into `WebSocketController.OnConnectionClosed`, which is `async void` and throws `ObjectDisposedException` after disposal. That is the crash reported in #16457, so this is best merged after #17839.

**Code assistance**

The defects were found by GPT Astra during an audit of the server code. The fixes and the regression tests were written with Claude Opus 5, which verified the mechanisms against the source and ran the test suite.

**Issues**

None.
