### PR TITLE
fix(api): return created API key on POST /Auth/Keys

### DIFF
--- a/Jellyfin.Api/Controllers/ApiKeyController.cs
+++ b/Jellyfin.Api/Controllers/ApiKeyController.cs
@@ -47,16 +47,16 @@ public class ApiKeyController : BaseJellyfinApiController
     /// Create a new api key.
     /// </summary>
     /// <param name="app">Name of the app using the authentication key.</param>
-    /// <response code="204">Api key created.</response>
-    /// <returns>A <see cref="NoContentResult"/>.</returns>
+    /// <response code="200">Api key created.</response>
+    /// <returns>An <see cref="AuthenticationInfo"/> object.</returns>
     [HttpPost("Keys")]
     [Authorize(Policy = Policies.RequiresElevation)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public async Task<ActionResult> CreateKey([FromQuery, Required] string app)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<AuthenticationInfo>> CreateKey([FromQuery, Required] string app)
     {
-        await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
+        var key = await _authenticationManager.CreateApiKey(app).ConfigureAwait(false);
 
-        return NoContent();
+        return key;
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
+++ b/Jellyfin.Server.Implementations/Security/AuthenticationManager.cs
@@ -23,14 +23,25 @@ namespace Jellyfin.Server.Implementations.Security
         }
 
         /// <inheritdoc />
-        public async Task CreateApiKey(string name)
+        public async Task<AuthenticationInfo> CreateApiKey(string name)
         {
             var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
             await using (dbContext.ConfigureAwait(false))
             {
-                dbContext.ApiKeys.Add(new ApiKey(name));
+                var apiKey = new ApiKey(name);
+                dbContext.ApiKeys.Add(apiKey);
 
                 await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+                return new AuthenticationInfo
+                {
+                    AppName = apiKey.Name,
+                    AccessToken = apiKey.AccessToken,
+                    DateCreated = apiKey.DateCreated,
+                    DeviceId = string.Empty,
+                    DeviceName = string.Empty,
+                    AppVersion = string.Empty
+                };
             }
         }
 

--- a/MediaBrowser.Controller/Security/IAuthenticationManager.cs
+++ b/MediaBrowser.Controller/Security/IAuthenticationManager.cs
@@ -13,7 +13,7 @@ namespace MediaBrowser.Controller.Security
         /// </summary>
         /// <param name="name">The name of the key.</param>
         /// <returns>A task representing the creation of the key.</returns>
-        Task CreateApiKey(string name);
+        Task<AuthenticationInfo> CreateApiKey(string name);
 
         /// <summary>
         /// Gets the API keys.


### PR DESCRIPTION
Fixes #16258.

## What changed
When creating a new API key via POST /Auth/Keys, the endpoint previously returned 204 NoContent. This PR updates CreateKey to return 200 OK along with the created AuthenticationInfo object containing the newly generated token.

## Changes
* IAuthenticationManager — CreateApiKey now returns Task<AuthenticationInfo> instead of Task.
* AuthenticationManager — CreateApiKey implementation now constructs and returns the AuthenticationInfo after saving the ApiKey entity to the database, identical to the mapping done in GetApiKeys.
* ApiKeyController — CreateKey is updated to [ProducesResponseType(StatusCodes.Status200OK)] and returns ActionResult<AuthenticationInfo>.

Signed-off-by: Jabrail <78273416+jabrailkhalil@users.noreply.github.com>