### PR TITLE
Fix Date Played sorting for series with incomplete episode playback

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -313,35 +313,11 @@ public sealed partial class BaseItemRepository
         // SeriesDatePlayed requires special handling to avoid correlated subqueries.
         // Instead of running a MAX() subquery per-row in ORDER BY, we pre-aggregate
         // max played dates per series in one query and left-join it.
-        if (!hasSearch && orderBy.Any(o => o.OrderBy == ItemSortBy.SeriesDatePlayed))
+        if ((!hasSearch && orderBy.Any(o => o.OrderBy == ItemSortBy.SeriesDatePlayed))
+            || (orderBy.Any(o => o.OrderBy == ItemSortBy.DatePlayed)
+                && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Contains(BaseItemKind.Series))))
         {
-            return ApplySeriesDatePlayedOrder(query, filter, context, orderBy);
-        }
-
-        if (orderBy.Any(o => o.OrderBy == ItemSortBy.DatePlayed)
-            && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Contains(BaseItemKind.Series)))
-        {
-            // Mixed libraries use DatePlayed. Aggregate episode dates once, as for SeriesDatePlayed.
-            var userData = filter.User is null
-                ? context.UserData
-                : context.UserData.Where(ud => ud.UserId == filter.User.Id);
-            var seriesMaxDates = userData
-                .Join(
-                    context.BaseItems,
-                    ud => ud.ItemId,
-                    bi => bi.Id,
-                    (ud, bi) => new { bi.SeriesPresentationUniqueKey, ud.LastPlayedDate })
-                .Where(x => x.SeriesPresentationUniqueKey != null)
-                .GroupBy(x => x.SeriesPresentationUniqueKey)
-                .Select(g => new { SeriesKey = g.Key!, MaxDate = g.Max(x => x.LastPlayedDate) });
-            var joined = query.LeftJoin(
-                seriesMaxDates,
-                e => e.PresentationUniqueKey,
-                s => s.SeriesKey,
-                (e, s) => new { Item = e, MaxDate = s != null ? s.MaxDate : (DateTime?)null });
-
-            return ApplyOrderCore(joined, filter, context, orderBy, e => e.Item, e => e.MaxDate)
-                .Select(e => e.Item);
+            return ApplyPlaybackDateOrder(query, filter, context, orderBy);
         }
 
         return ApplyOrderCore(query, filter, context, orderBy, e => e);
@@ -355,97 +331,90 @@ public sealed partial class BaseItemRepository
         Expression<Func<T, BaseItemEntity>> itemSelector,
         Expression<Func<T, DateTime?>>? seriesDate = null)
     {
-        Expression<Func<T, TValue>> Project<TValue>(Expression<Func<BaseItemEntity, TValue>> expression)
-            => Expression.Lambda<Func<T, TValue>>(
-                ReplacingExpressionVisitor.Replace(expression.Parameters[0], itemSelector.Body, expression.Body),
-                itemSelector.Parameters);
-
         var hasSearch = !string.IsNullOrEmpty(filter.SearchTerm);
         IOrderedQueryable<T>? orderedQuery = null;
 
-        if (hasSearch)
+        if (!string.IsNullOrEmpty(filter.SearchTerm))
         {
-            var relevanceExpression = Project(OrderMapper.MapSearchRelevanceOrder(filter.SearchTerm!));
+            var relevanceExpression = ProjectOrderKey(OrderMapper.MapSearchRelevanceOrder(filter.SearchTerm), itemSelector);
             orderedQuery = query.OrderBy(relevanceExpression);
         }
 
-        // Folders carry no played flag of their own, so these two keys go through the same predicate
-        // the isPlayed filter uses rather than through the stored-column lookup in OrderMapper.
-        Expression<Func<T, object?>> MapOrderByField(ItemSortBy sortBy)
+        for (var index = 0; index < orderBy.Length; index++)
         {
-            var field = sortBy switch
+            var ordering = orderBy[index];
+            var expression = MapProjectedOrderKey(ordering.OrderBy, filter, context, itemSelector, seriesDate);
+            orderedQuery = (orderedQuery, ordering.SortOrder) switch
             {
-                ItemSortBy.IsPlayed when filter.User is not null
-                    => AsOrderKey(BuildIsPlayedFilter(context, filter.User)),
-                ItemSortBy.IsUnplayed when filter.User is not null
-                    => AsOrderKey(BuildIsPlayedFilter(context, filter.User).Not()),
-                _ => OrderMapper.MapOrderByField(sortBy, filter, context)
+                (null, SortOrder.Ascending) => query.OrderBy(expression),
+                (null, _) => query.OrderByDescending(expression),
+                ({ } ordered, SortOrder.Ascending) => ordered.ThenBy(expression),
+                ({ } ordered, _) => ordered.ThenByDescending(expression)
             };
-            var projected = Project(field);
-            if (sortBy != ItemSortBy.DatePlayed || seriesDate is null)
-            {
-                return projected;
-            }
 
-            var isSeries = Project(e => e.Type == typeof(Series).FullName);
-            var date = ReplacingExpressionVisitor.Replace(seriesDate.Parameters[0], itemSelector.Parameters[0], seriesDate.Body);
-            var itemDate = projected.Body is UnaryExpression { NodeType: ExpressionType.Convert } conversion
-                ? conversion.Operand
-                : projected.Body;
-            return Expression.Lambda<Func<T, object?>>(
-                Expression.Convert(Expression.Condition(isSeries.Body, date, itemDate), typeof(object)),
-                itemSelector.Parameters);
-        }
-
-        if (orderBy.Length > 0)
-        {
-            var firstOrdering = orderBy[0];
-            var expression = MapOrderByField(firstOrdering.OrderBy);
-
-            if (orderedQuery is null)
+            if (index == 0 && ordering.OrderBy is ItemSortBy.Default or ItemSortBy.SortName)
             {
-                orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
-                    ? query.OrderBy(expression)
-                    : query.OrderByDescending(expression);
-            }
-            else
-            {
-                orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
-                    ? orderedQuery.ThenBy(expression)
-                    : orderedQuery.ThenByDescending(expression);
-            }
-
-            if (firstOrdering.OrderBy is ItemSortBy.Default or ItemSortBy.SortName)
-            {
-                orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
-                    ? orderedQuery.ThenBy(Project(e => e.Name))
-                    : orderedQuery.ThenByDescending(Project(e => e.Name));
-            }
-
-            foreach (var item in orderBy.Skip(1))
-            {
-                expression = MapOrderByField(item.OrderBy);
-                orderedQuery = item.SortOrder == SortOrder.Ascending
-                    ? orderedQuery.ThenBy(expression)
-                    : orderedQuery.ThenByDescending(expression);
+                var nameExpression = ProjectOrderKey(e => e.Name, itemSelector);
+                orderedQuery = ordering.SortOrder == SortOrder.Ascending
+                    ? orderedQuery.ThenBy(nameExpression)
+                    : orderedQuery.ThenByDescending(nameExpression);
             }
         }
 
         if (orderedQuery is null)
         {
-            return query.OrderBy(Project(e => e.SortName));
+            return query.OrderBy(ProjectOrderKey(e => e.SortName, itemSelector));
         }
 
         // Add SortName as final tiebreaker
         if (!hasSearch && (orderBy.Length == 0 || orderBy.All(o => o.OrderBy is not ItemSortBy.SortName and not ItemSortBy.Name)))
         {
-            orderedQuery = orderedQuery.ThenBy(Project(e => e.SortName));
+            orderedQuery = orderedQuery.ThenBy(ProjectOrderKey(e => e.SortName, itemSelector));
         }
 
         return orderedQuery;
     }
 
-    private IQueryable<BaseItemEntity> ApplySeriesDatePlayedOrder(
+    private static Expression<Func<T, TValue>> ProjectOrderKey<T, TValue>(
+        Expression<Func<BaseItemEntity, TValue>> expression,
+        Expression<Func<T, BaseItemEntity>> itemSelector)
+        => Expression.Lambda<Func<T, TValue>>(
+            ReplacingExpressionVisitor.Replace(expression.Parameters[0], itemSelector.Body, expression.Body),
+            itemSelector.Parameters);
+
+    private Expression<Func<T, object?>> MapProjectedOrderKey<T>(
+        ItemSortBy sortBy,
+        InternalItemsQuery filter,
+        JellyfinDbContext context,
+        Expression<Func<T, BaseItemEntity>> itemSelector,
+        Expression<Func<T, DateTime?>>? seriesDate)
+    {
+        // Folders use the same played predicate for ordering and filtering.
+        var field = sortBy switch
+        {
+            ItemSortBy.IsPlayed when filter.User is not null
+                => AsOrderKey(BuildIsPlayedFilter(context, filter.User)),
+            ItemSortBy.IsUnplayed when filter.User is not null
+                => AsOrderKey(BuildIsPlayedFilter(context, filter.User).Not()),
+            _ => OrderMapper.MapOrderByField(sortBy, filter, context)
+        };
+        var projected = ProjectOrderKey(field, itemSelector);
+        if (sortBy != ItemSortBy.DatePlayed || seriesDate is null)
+        {
+            return projected;
+        }
+
+        var isSeries = ProjectOrderKey(e => e.Type == typeof(Series).FullName, itemSelector);
+        var date = ReplacingExpressionVisitor.Replace(seriesDate.Parameters[0], itemSelector.Parameters[0], seriesDate.Body);
+        var itemDate = projected.Body is UnaryExpression { NodeType: ExpressionType.Convert } conversion
+            ? conversion.Operand
+            : projected.Body;
+        return Expression.Lambda<Func<T, object?>>(
+            Expression.Convert(Expression.Condition(isSeries.Body, date, itemDate), typeof(object)),
+            itemSelector.Parameters);
+    }
+
+    private IQueryable<BaseItemEntity> ApplyPlaybackDateOrder(
         IQueryable<BaseItemEntity> query,
         InternalItemsQuery filter,
         JellyfinDbContext context,
@@ -466,7 +435,7 @@ public sealed partial class BaseItemRepository
                 (ud, bi) => new { bi.SeriesPresentationUniqueKey, ud.LastPlayedDate })
             .Where(x => x.SeriesPresentationUniqueKey != null)
             .GroupBy(x => x.SeriesPresentationUniqueKey)
-            .Select(g => new { SeriesKey = g.Key!, MaxDate = g.Max(x => x.LastPlayedDate) });
+            .Select(g => new { SeriesKey = g.Key, MaxDate = g.Max(x => x.LastPlayedDate) });
 
         var joined = query.LeftJoin(
             seriesMaxDates,
@@ -474,11 +443,16 @@ public sealed partial class BaseItemRepository
             s => s.SeriesKey,
             (e, s) => new { Item = e, MaxDate = s != null ? s.MaxDate : (DateTime?)null });
 
-        var seriesSort = orderBy.First(o => o.OrderBy == ItemSortBy.SeriesDatePlayed);
+        if (string.IsNullOrEmpty(filter.SearchTerm) && orderBy.Any(o => o.OrderBy == ItemSortBy.SeriesDatePlayed))
+        {
+            var seriesSort = orderBy.First(o => o.OrderBy == ItemSortBy.SeriesDatePlayed);
+            return seriesSort.SortOrder == SortOrder.Ascending
+                ? joined.OrderBy(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item)
+                : joined.OrderByDescending(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item);
+        }
 
-        return seriesSort.SortOrder == SortOrder.Ascending
-            ? joined.OrderBy(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item)
-            : joined.OrderByDescending(x => x.MaxDate).ThenBy(x => x.Item.SortName).Select(x => x.Item);
+        return ApplyOrderCore(joined, filter, context, orderBy, e => e.Item, e => e.MaxDate)
+            .Select(e => e.Item);
     }
 
     /// <summary>

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -14,9 +14,11 @@ using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Extensions;
 using Jellyfin.Server.Implementations.Extensions;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 using BaseItemEntity = Jellyfin.Database.Implementations.Entities.BaseItemEntity;
 
 namespace Jellyfin.Server.Implementations.Item;
@@ -316,24 +318,84 @@ public sealed partial class BaseItemRepository
             return ApplySeriesDatePlayedOrder(query, filter, context, orderBy);
         }
 
-        IOrderedQueryable<BaseItemEntity>? orderedQuery = null;
+        if (orderBy.Any(o => o.OrderBy == ItemSortBy.DatePlayed)
+            && (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Contains(BaseItemKind.Series)))
+        {
+            // Mixed libraries use DatePlayed. Aggregate episode dates once, as for SeriesDatePlayed.
+            var userData = filter.User is null
+                ? context.UserData
+                : context.UserData.Where(ud => ud.UserId == filter.User.Id);
+            var seriesMaxDates = userData
+                .Join(
+                    context.BaseItems,
+                    ud => ud.ItemId,
+                    bi => bi.Id,
+                    (ud, bi) => new { bi.SeriesPresentationUniqueKey, ud.LastPlayedDate })
+                .Where(x => x.SeriesPresentationUniqueKey != null)
+                .GroupBy(x => x.SeriesPresentationUniqueKey)
+                .Select(g => new { SeriesKey = g.Key!, MaxDate = g.Max(x => x.LastPlayedDate) });
+            var joined = query.LeftJoin(
+                seriesMaxDates,
+                e => e.PresentationUniqueKey,
+                s => s.SeriesKey,
+                (e, s) => new { Item = e, MaxDate = s != null ? s.MaxDate : (DateTime?)null });
+
+            return ApplyOrderCore(joined, filter, context, orderBy, e => e.Item, e => e.MaxDate)
+                .Select(e => e.Item);
+        }
+
+        return ApplyOrderCore(query, filter, context, orderBy, e => e);
+    }
+
+    private IQueryable<T> ApplyOrderCore<T>(
+        IQueryable<T> query,
+        InternalItemsQuery filter,
+        JellyfinDbContext context,
+        (ItemSortBy OrderBy, SortOrder SortOrder)[] orderBy,
+        Expression<Func<T, BaseItemEntity>> itemSelector,
+        Expression<Func<T, DateTime?>>? seriesDate = null)
+    {
+        Expression<Func<T, TValue>> Project<TValue>(Expression<Func<BaseItemEntity, TValue>> expression)
+            => Expression.Lambda<Func<T, TValue>>(
+                ReplacingExpressionVisitor.Replace(expression.Parameters[0], itemSelector.Body, expression.Body),
+                itemSelector.Parameters);
+
+        var hasSearch = !string.IsNullOrEmpty(filter.SearchTerm);
+        IOrderedQueryable<T>? orderedQuery = null;
 
         if (hasSearch)
         {
-            var relevanceExpression = OrderMapper.MapSearchRelevanceOrder(filter.SearchTerm!);
+            var relevanceExpression = Project(OrderMapper.MapSearchRelevanceOrder(filter.SearchTerm!));
             orderedQuery = query.OrderBy(relevanceExpression);
         }
 
         // Folders carry no played flag of their own, so these two keys go through the same predicate
         // the isPlayed filter uses rather than through the stored-column lookup in OrderMapper.
-        Expression<Func<BaseItemEntity, object?>> MapOrderByField(ItemSortBy sortBy) => sortBy switch
+        Expression<Func<T, object?>> MapOrderByField(ItemSortBy sortBy)
         {
-            ItemSortBy.IsPlayed when filter.User is not null
-                => AsOrderKey(BuildIsPlayedFilter(context, filter.User)),
-            ItemSortBy.IsUnplayed when filter.User is not null
-                => AsOrderKey(BuildIsPlayedFilter(context, filter.User).Not()),
-            _ => OrderMapper.MapOrderByField(sortBy, filter, context)
-        };
+            var field = sortBy switch
+            {
+                ItemSortBy.IsPlayed when filter.User is not null
+                    => AsOrderKey(BuildIsPlayedFilter(context, filter.User)),
+                ItemSortBy.IsUnplayed when filter.User is not null
+                    => AsOrderKey(BuildIsPlayedFilter(context, filter.User).Not()),
+                _ => OrderMapper.MapOrderByField(sortBy, filter, context)
+            };
+            var projected = Project(field);
+            if (sortBy != ItemSortBy.DatePlayed || seriesDate is null)
+            {
+                return projected;
+            }
+
+            var isSeries = Project(e => e.Type == typeof(Series).FullName);
+            var date = ReplacingExpressionVisitor.Replace(seriesDate.Parameters[0], itemSelector.Parameters[0], seriesDate.Body);
+            var itemDate = projected.Body is UnaryExpression { NodeType: ExpressionType.Convert } conversion
+                ? conversion.Operand
+                : projected.Body;
+            return Expression.Lambda<Func<T, object?>>(
+                Expression.Convert(Expression.Condition(isSeries.Body, date, itemDate), typeof(object)),
+                itemSelector.Parameters);
+        }
 
         if (orderBy.Length > 0)
         {
@@ -356,8 +418,8 @@ public sealed partial class BaseItemRepository
             if (firstOrdering.OrderBy is ItemSortBy.Default or ItemSortBy.SortName)
             {
                 orderedQuery = firstOrdering.SortOrder == SortOrder.Ascending
-                    ? orderedQuery.ThenBy(e => e.Name)
-                    : orderedQuery.ThenByDescending(e => e.Name);
+                    ? orderedQuery.ThenBy(Project(e => e.Name))
+                    : orderedQuery.ThenByDescending(Project(e => e.Name));
             }
 
             foreach (var item in orderBy.Skip(1))
@@ -371,13 +433,13 @@ public sealed partial class BaseItemRepository
 
         if (orderedQuery is null)
         {
-            return query.OrderBy(e => e.SortName);
+            return query.OrderBy(Project(e => e.SortName));
         }
 
         // Add SortName as final tiebreaker
         if (!hasSearch && (orderBy.Length == 0 || orderBy.All(o => o.OrderBy is not ItemSortBy.SortName and not ItemSortBy.Name)))
         {
-            orderedQuery = orderedQuery.ThenBy(e => e.SortName);
+            orderedQuery = orderedQuery.ThenBy(Project(e => e.SortName));
         }
 
         return orderedQuery;

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -393,8 +393,8 @@ public sealed partial class BaseItemRepository
         // This generates a single: SELECT SeriesPresentationUniqueKey, MAX(LastPlayedDate) ... GROUP BY
         // instead of a correlated subquery per outer row.
         IQueryable<UserData> userDataQuery = filter.User is not null
-            ? context.UserData.Where(ud => ud.UserId == filter.User.Id && ud.Played)
-            : context.UserData.Where(ud => ud.Played);
+            ? context.UserData.Where(ud => ud.UserId == filter.User.Id)
+            : context.UserData;
 
         var seriesMaxDates = userDataQuery
             .Join(

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -367,7 +367,7 @@ public sealed partial class BaseItemRepository
         }
 
         // Add SortName as final tiebreaker
-        if (!hasSearch && (orderBy.Length == 0 || orderBy.All(o => o.OrderBy is not ItemSortBy.SortName and not ItemSortBy.Name)))
+        if (!hasSearch && orderBy.All(o => o.OrderBy is not ItemSortBy.SortName and not ItemSortBy.Name))
         {
             orderedQuery = orderedQuery.ThenBy(ProjectOrderKey(e => e.SortName, itemSelector));
         }

--- a/Jellyfin.Server.Implementations/Item/OrderMapper.cs
+++ b/Jellyfin.Server.Implementations/Item/OrderMapper.cs
@@ -79,11 +79,11 @@ public static class OrderMapper
             // This correlated subquery fallback is only reached when combined with search.
             (ItemSortBy.SeriesDatePlayed, not null) => e =>
                 jellyfinDbContext.UserData
-                    .Where(w => w.UserId == query.User.Id && w.Played && w.Item!.SeriesPresentationUniqueKey == e.PresentationUniqueKey)
+                    .Where(w => w.UserId == query.User.Id && w.Item!.SeriesPresentationUniqueKey == e.PresentationUniqueKey)
                     .Max(f => f.LastPlayedDate),
             (ItemSortBy.SeriesDatePlayed, null) => e =>
                 jellyfinDbContext.UserData
-                    .Where(w => w.Played && w.Item!.SeriesPresentationUniqueKey == e.PresentationUniqueKey)
+                    .Where(w => w.Item!.SeriesPresentationUniqueKey == e.PresentationUniqueKey)
                     .Max(f => f.LastPlayedDate),
             _ => e => e.SortName
         };

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositorySeriesDatePlayedTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositorySeriesDatePlayedTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Linq;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller.Entities;
+using Xunit;
+using BaseItemKind = Jellyfin.Data.Enums.BaseItemKind;
+using ItemSortBy = Jellyfin.Data.Enums.ItemSortBy;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+/// <summary>
+/// Verifies that SeriesDatePlayed uses the newest associated playback timestamp, including partial playback.
+/// </summary>
+public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixture
+{
+    private const string SeriesType = "MediaBrowser.Controller.Entities.TV.Series";
+    private const string EpisodeType = "MediaBrowser.Controller.Entities.TV.Episode";
+
+    private static readonly DateTime CompletedDate = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime ControlDate = new(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime PartialDate = new(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime PartialOnlyDate = new(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime OtherUserDate = new(2026, 9, 12, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly User _userA = new("user-a", "auth-provider", "reset-provider");
+    private readonly User _userB = new("user-b", "auth-provider", "reset-provider");
+    private readonly Guid _seriesA = Guid.NewGuid();
+    private readonly Guid _seriesB = Guid.NewGuid();
+    private readonly Guid _seriesC = Guid.NewGuid();
+    private readonly Guid _seriesD = Guid.NewGuid();
+    private readonly BaseItemRepository _repository;
+
+    public BaseItemRepositorySeriesDatePlayedTests()
+    {
+        using (var context = CreateDbContext())
+        {
+            Seed(context);
+        }
+
+        _repository = CreateBaseItemRepository(new ItemTypeLookup());
+    }
+
+    [Theory]
+    [InlineData(false, true, SortOrder.Descending)]
+    [InlineData(false, true, SortOrder.Ascending)]
+    [InlineData(true, true, SortOrder.Descending)]
+    [InlineData(true, true, SortOrder.Ascending)]
+    [InlineData(false, false, SortOrder.Descending)]
+    [InlineData(true, false, SortOrder.Descending)]
+    public void SeriesDatePlayed_UsesLatestAssociatedDate(bool search, bool userScoped, SortOrder sortOrder)
+    {
+        var query = CreateQuery(search, userScoped, sortOrder);
+        var ids = _repository.GetItemList(query).Select(item => item.Id).ToList();
+
+        Assert.Equal(4, ids.Count);
+        Assert.Contains(_seriesD, ids);
+
+        Guid[] expectedDatedOrder = userScoped
+            ? sortOrder == SortOrder.Descending
+                ? [_seriesC, _seriesA, _seriesB]
+                : [_seriesB, _seriesA, _seriesC]
+            : [_seriesB, _seriesC, _seriesA];
+
+        Assert.Equal(expectedDatedOrder, ids.Where(IsDatedSeries).ToArray());
+
+        if (!search && userScoped && sortOrder == SortOrder.Descending)
+        {
+            var pageQuery = CreateQuery(search, userScoped, sortOrder);
+            pageQuery.Limit = 1;
+
+            var page = _repository.GetItems(pageQuery);
+
+            Assert.Equal(4, page.TotalRecordCount);
+            Assert.Equal(_seriesC, Assert.Single(page.Items).Id);
+        }
+    }
+
+    private InternalItemsQuery CreateQuery(bool search, bool userScoped, SortOrder sortOrder)
+        => new(userScoped ? _userA : null)
+        {
+            IncludeItemTypes = [BaseItemKind.Series],
+            OrderBy = [(ItemSortBy.SeriesDatePlayed, sortOrder)],
+            SearchTerm = search ? "probe" : null
+        };
+
+    private bool IsDatedSeries(Guid id)
+        => !id.Equals(_seriesD);
+
+    private void Seed(JellyfinDbContext context)
+    {
+        context.Users.AddRange(_userA, _userB);
+
+        AddSeries(
+            context,
+            _seriesA,
+            "probe alpha",
+            (CompletedDate, true, 0L, _userA),
+            (PartialDate, false, 900L, _userA));
+        AddSeries(
+            context,
+            _seriesB,
+            "probe beta",
+            (ControlDate, true, 0L, _userA),
+            (OtherUserDate, true, 0L, _userB));
+        AddSeries(context, _seriesC, "probe gamma", (PartialOnlyDate, false, 900L, _userA));
+        AddSeries(context, _seriesD, "probe delta", (null, false, 0L, _userA));
+
+        context.SaveChanges();
+    }
+
+    private void AddSeries(
+        JellyfinDbContext context,
+        Guid seriesId,
+        string name,
+        params (DateTime? LastPlayedDate, bool Played, long PlaybackPositionTicks, User User)[] episodes)
+    {
+        var seriesKey = seriesId.ToString("N");
+        var cleanName = name.ToLowerInvariant();
+
+        context.BaseItems.Add(new BaseItemEntity
+        {
+            Id = seriesId,
+            Type = SeriesType,
+            Name = name,
+            CleanName = cleanName,
+            SortName = cleanName,
+            PresentationUniqueKey = seriesKey,
+            IsFolder = true,
+            IsSeries = true,
+            IsVirtualItem = false
+        });
+
+        for (var i = 0; i < episodes.Length; i++)
+        {
+            var episodeId = Guid.NewGuid();
+            var episodeName = $"{name} episode {i}";
+
+            context.BaseItems.Add(new BaseItemEntity
+            {
+                Id = episodeId,
+                Type = EpisodeType,
+                Name = episodeName,
+                CleanName = episodeName,
+                SortName = episodeName,
+                MediaType = "Video",
+                SeriesId = seriesId,
+                SeriesName = name,
+                SeriesPresentationUniqueKey = seriesKey,
+                PresentationUniqueKey = episodeId.ToString("N"),
+                IsFolder = false,
+                IsVirtualItem = false
+            });
+
+            var episode = episodes[i];
+            context.UserData.Add(new UserData
+            {
+                ItemId = episodeId,
+                UserId = episode.User.Id,
+                CustomDataKey = $"{episodeId:N}-{episode.User.Id:N}",
+                LastPlayedDate = episode.LastPlayedDate,
+                Played = episode.Played,
+                PlaybackPositionTicks = episode.PlaybackPositionTicks,
+                Item = null!,
+                User = episode.User
+            });
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositorySeriesDatePlayedTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/BaseItemRepositorySeriesDatePlayedTests.cs
@@ -17,12 +17,17 @@ namespace Jellyfin.Server.Implementations.Tests.Item;
 /// </summary>
 public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixture
 {
+    private const string CollectionFolderType = "MediaBrowser.Controller.Entities.CollectionFolder";
     private const string SeriesType = "MediaBrowser.Controller.Entities.TV.Series";
     private const string EpisodeType = "MediaBrowser.Controller.Entities.TV.Episode";
+    private const string MovieType = "MediaBrowser.Controller.Entities.Movies.Movie";
 
     private static readonly DateTime CompletedDate = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime ControlDate = new(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime PartialDate = new(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime MovieOwnDate = new(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime MovieAlternateDate = new(2026, 9, 9, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime OtherUserMovieDate = new(2026, 9, 9, 12, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime PartialOnlyDate = new(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc);
     private static readonly DateTime OtherUserDate = new(2026, 9, 12, 0, 0, 0, DateTimeKind.Utc);
 
@@ -32,6 +37,10 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
     private readonly Guid _seriesB = Guid.NewGuid();
     private readonly Guid _seriesC = Guid.NewGuid();
     private readonly Guid _seriesD = Guid.NewGuid();
+    private readonly Guid _library = Guid.NewGuid();
+    private readonly Guid _movieOwn = Guid.NewGuid();
+    private readonly Guid _movieAlternatePrimary = Guid.NewGuid();
+    private readonly Guid _movieAlternate = Guid.NewGuid();
     private readonly BaseItemRepository _repository;
 
     public BaseItemRepositorySeriesDatePlayedTests()
@@ -79,6 +88,53 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
         }
     }
 
+    [Theory]
+    [InlineData(false, true, SortOrder.Descending)]
+    [InlineData(false, true, SortOrder.Ascending)]
+    [InlineData(true, true, SortOrder.Descending)]
+    [InlineData(true, true, SortOrder.Ascending)]
+    [InlineData(false, false, SortOrder.Descending)]
+    [InlineData(true, false, SortOrder.Descending)]
+    public void DatePlayed_InterleavesSeriesAndMovies(bool search, bool userScoped, SortOrder sortOrder)
+    {
+        var query = CreateMixedQuery(search, userScoped, sortOrder);
+        var ids = _repository.GetItemList(query).Select(item => item.Id).ToList();
+
+        Assert.Equal(6, ids.Count);
+        Assert.Contains(_seriesD, ids);
+        Assert.Contains(_movieAlternatePrimary, ids);
+        Assert.DoesNotContain(_movieAlternate, ids);
+
+        Guid[] expectedDatedOrder = userScoped
+            ? sortOrder == SortOrder.Descending
+                ? [_seriesC, _movieAlternatePrimary, _movieOwn, _seriesA, _seriesB]
+                : [_seriesB, _seriesA, _movieOwn, _movieAlternatePrimary, _seriesC]
+            : [_seriesB, _seriesC, _movieOwn, _movieAlternatePrimary, _seriesA];
+
+        Assert.Equal(expectedDatedOrder, ids.Where(id => !id.Equals(_seriesD) && !id.Equals(_movieAlternate)).ToArray());
+
+        if (!search && userScoped && sortOrder == SortOrder.Descending)
+        {
+            var pageQuery = CreateMixedQuery(search, userScoped, sortOrder);
+            pageQuery.Limit = 1;
+
+            var page = _repository.GetItems(pageQuery);
+
+            Assert.Equal(6, page.TotalRecordCount);
+            Assert.Equal(_seriesC, Assert.Single(page.Items).Id);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResumableMixedDatePlayed_IncludesPartialSeriesAndMovies(bool search)
+    {
+        var ids = _repository.GetItemList(CreateResumableMixedQuery(search));
+
+        Assert.Equal([_seriesC, _movieAlternate, _movieOwn, _seriesA], ids.Select(item => item.Id));
+    }
+
     private InternalItemsQuery CreateQuery(bool search, bool userScoped, SortOrder sortOrder)
         => new(userScoped ? _userA : null)
         {
@@ -87,12 +143,43 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
             SearchTerm = search ? "probe" : null
         };
 
+    private InternalItemsQuery CreateMixedQuery(bool search, bool userScoped, SortOrder sortOrder)
+        => new(userScoped ? _userA : null)
+        {
+            IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series],
+            OrderBy = [(ItemSortBy.DatePlayed, sortOrder)],
+            SearchTerm = search ? "probe" : null
+        };
+
+    private InternalItemsQuery CreateResumableMixedQuery(bool search)
+        => new(_userA)
+        {
+            AncestorIds = [_library],
+            IncludeItemTypes = [BaseItemKind.Movie, BaseItemKind.Series],
+            IsResumable = true,
+            OrderBy = [(ItemSortBy.DatePlayed, SortOrder.Descending), (ItemSortBy.SortName, SortOrder.Descending)],
+            Recursive = true,
+            SearchTerm = search ? "probe" : null,
+            TopParentIds = [_library]
+        };
+
     private bool IsDatedSeries(Guid id)
         => !id.Equals(_seriesD);
 
     private void Seed(JellyfinDbContext context)
     {
         context.Users.AddRange(_userA, _userB);
+        context.BaseItems.Add(new BaseItemEntity
+        {
+            Id = _library,
+            Type = CollectionFolderType,
+            Name = "Mixed library",
+            CleanName = "mixed library",
+            SortName = "mixed library",
+            PresentationUniqueKey = _library.ToString("N"),
+            IsFolder = true,
+            IsVirtualItem = false
+        });
 
         AddSeries(
             context,
@@ -100,19 +187,29 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
             "probe alpha",
             (CompletedDate, true, 0L, _userA),
             (PartialDate, false, 900L, _userA));
-        AddSeries(
+        var seriesBEpisodes = AddSeries(
             context,
             _seriesB,
             "probe beta",
-            (ControlDate, true, 0L, _userA),
-            (OtherUserDate, true, 0L, _userB));
+            (ControlDate, true, 0L, _userA));
+        AddUserData(context, seriesBEpisodes[0], OtherUserDate, true, 0L, _userB);
         AddSeries(context, _seriesC, "probe gamma", (PartialOnlyDate, false, 900L, _userA));
         AddSeries(context, _seriesD, "probe delta", (null, false, 0L, _userA));
+
+        AddMovie(
+            context,
+            _movieOwn,
+            "probe movie own",
+            null,
+            (MovieOwnDate, false, 900L, _userA),
+            (OtherUserMovieDate, false, 900L, _userB));
+        AddMovie(context, _movieAlternatePrimary, "probe movie alternate", null);
+        AddMovie(context, _movieAlternate, "probe movie alternate", _movieAlternatePrimary, (MovieAlternateDate, false, 900L, _userA));
 
         context.SaveChanges();
     }
 
-    private void AddSeries(
+    private Guid[] AddSeries(
         JellyfinDbContext context,
         Guid seriesId,
         string name,
@@ -130,13 +227,16 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
             SortName = cleanName,
             PresentationUniqueKey = seriesKey,
             IsFolder = true,
-            IsSeries = true,
+            TopParentId = _library,
             IsVirtualItem = false
         });
+        AddAncestor(context, seriesId, _library);
 
+        var episodeIds = new Guid[episodes.Length];
         for (var i = 0; i < episodes.Length; i++)
         {
             var episodeId = Guid.NewGuid();
+            episodeIds[i] = episodeId;
             var episodeName = $"{name} episode {i}";
 
             context.BaseItems.Add(new BaseItemEntity
@@ -152,21 +252,76 @@ public sealed class BaseItemRepositorySeriesDatePlayedTests : SqliteDbTestFixtur
                 SeriesPresentationUniqueKey = seriesKey,
                 PresentationUniqueKey = episodeId.ToString("N"),
                 IsFolder = false,
+                TopParentId = _library,
                 IsVirtualItem = false
             });
+            AddAncestor(context, episodeId, seriesId);
+            AddAncestor(context, episodeId, _library);
 
             var episode = episodes[i];
-            context.UserData.Add(new UserData
-            {
-                ItemId = episodeId,
-                UserId = episode.User.Id,
-                CustomDataKey = $"{episodeId:N}-{episode.User.Id:N}",
-                LastPlayedDate = episode.LastPlayedDate,
-                Played = episode.Played,
-                PlaybackPositionTicks = episode.PlaybackPositionTicks,
-                Item = null!,
-                User = episode.User
-            });
+            AddUserData(context, episodeId, episode.LastPlayedDate, episode.Played, episode.PlaybackPositionTicks, episode.User);
+        }
+
+        return episodeIds;
+    }
+
+    private void AddMovie(
+        JellyfinDbContext context,
+        Guid movieId,
+        string name,
+        Guid? primaryVersionId,
+        params (DateTime? LastPlayedDate, bool Played, long PlaybackPositionTicks, User User)[] userData)
+    {
+        var presentationKey = (primaryVersionId ?? movieId).ToString("N");
+        var cleanName = name.ToLowerInvariant();
+
+        context.BaseItems.Add(new BaseItemEntity
+        {
+            Id = movieId,
+            Type = MovieType,
+            Name = name,
+            CleanName = cleanName,
+            SortName = cleanName,
+            MediaType = "Video",
+            IsFolder = false,
+            IsVirtualItem = false,
+            PresentationUniqueKey = presentationKey,
+            PrimaryVersionId = primaryVersionId,
+            TopParentId = _library
+        });
+        AddAncestor(context, movieId, _library);
+
+        foreach (var data in userData)
+        {
+            AddUserData(context, movieId, data.LastPlayedDate, data.Played, data.PlaybackPositionTicks, data.User);
         }
     }
+
+    private static void AddUserData(
+        JellyfinDbContext context,
+        Guid itemId,
+        DateTime? lastPlayedDate,
+        bool played,
+        long playbackPositionTicks,
+        User user)
+        => context.UserData.Add(new UserData
+        {
+            ItemId = itemId,
+            UserId = user.Id,
+            CustomDataKey = $"{itemId:N}-{user.Id:N}",
+            LastPlayedDate = lastPlayedDate,
+            Played = played,
+            PlaybackPositionTicks = playbackPositionTicks,
+            Item = null!,
+            User = user
+        });
+
+    private static void AddAncestor(JellyfinDbContext context, Guid itemId, Guid ancestorId)
+        => context.AncestorIds.Add(new AncestorId
+        {
+            ItemId = itemId,
+            ParentItemId = ancestorId,
+            Item = null!,
+            ParentItem = null!
+        });
 }


### PR DESCRIPTION
**Changes**
Date Played sorting now reflects the last time you watched any episode of a series, even if you stopped part way through.

TV libraries previously ignored incomplete episodes when calculating that date and mixed movie/TV libraries did not use episode playback history when sorting series.

Recently watched series now appear in the correct position in both library types, including filtered by: Continue Watching, sorted by: Date Played. Movie sorting and the rules for which items appear in Continue Watching are unchanged.

For TV Show based libraries, SeriesDatePlayed no longer requires Played=true when taking the latest LastPlayedDate (user scoping is unchanged).

For Mixed movies & tv show libraries, DatePlayed for a Series uses the latest associated episode date, and movies still use their own/alternate-version dates.

**Code assistance**
OpenAI Codex helped with investigation, implementation, regression tests, and packaging. I reviewed the changes and confirmed the behavior on a live Unraid install for both a regular TV library and a mixed movie/TV library.