### PR TITLE
Skip rows the database cannot read instead of aborting the migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/20250420210000_MoveExtractedFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/20250420210000_MoveExtractedFiles.cs
@@ -92,11 +92,11 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
                           .WithPartitionProgress((partition) => _logger.LogInformation("Checked: {Count} - Moved: {Items} - Time: {Time}", partition * Limit, itemCount, sw.Elapsed))
                           .SkippingUnreadableItems(
                               e => e.Id,
-                              (ex, id, row) => _logger.LogError(
+                              (ex, key, index) => _logger.LogError(
                                   ex,
-                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                  row,
-                                  id))
+                                  "Skipping BaseItems row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                  key,
+                                  index))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20250420210000_MoveExtractedFiles.cs
+++ b/Jellyfin.Server/Migrations/Routines/20250420210000_MoveExtractedFiles.cs
@@ -90,6 +90,13 @@ public class MoveExtractedFiles : IAsyncMigrationRoutine
                           })
                           .OrderBy(e => e.Id)
                           .WithPartitionProgress((partition) => _logger.LogInformation("Checked: {Count} - Moved: {Items} - Time: {Time}", partition * Limit, itemCount, sw.Elapsed))
+                          .SkippingUnreadableItems(
+                              e => e.Id,
+                              (ex, id, row) => _logger.LogError(
+                                  ex,
+                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                  row,
+                                  id))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20250620180000_FixDates.cs
+++ b/Jellyfin.Server/Migrations/Routines/20250620180000_FixDates.cs
@@ -73,6 +73,13 @@ public class FixDates : IAsyncMigrationRoutine
                                     Math.Min((partition + 1) * PageSize, records),
                                     records,
                                     sw.Elapsed))
+                        .SkippingUnreadableItems(
+                            e => e.Id,
+                            (ex, id, row) => _logger.LogError(
+                                ex,
+                                "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                row,
+                                id))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))
@@ -107,6 +114,13 @@ public class FixDates : IAsyncMigrationRoutine
                                     Math.Min((partition + 1) * PageSize, records),
                                     records,
                                     sw.Elapsed))
+                        .SkippingUnreadableItems(
+                            e => e.ItemId,
+                            (ex, id, row) => _logger.LogError(
+                                ex,
+                                "Skipping Chapters row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                row,
+                                id))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))
@@ -137,6 +151,13 @@ public class FixDates : IAsyncMigrationRoutine
                                     Math.Min((partition + 1) * PageSize, records),
                                     records,
                                     sw.Elapsed))
+                        .SkippingUnreadableItems(
+                            e => e.Id,
+                            (ex, id, row) => _logger.LogError(
+                                ex,
+                                "Skipping BaseItemImageInfos row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                row,
+                                id))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20250620180000_FixDates.cs
+++ b/Jellyfin.Server/Migrations/Routines/20250620180000_FixDates.cs
@@ -75,11 +75,11 @@ public class FixDates : IAsyncMigrationRoutine
                                     sw.Elapsed))
                         .SkippingUnreadableItems(
                             e => e.Id,
-                            (ex, id, row) => _logger.LogError(
+                            (ex, key, index) => _logger.LogError(
                                 ex,
-                                "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                row,
-                                id))
+                                "Skipping BaseItems row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                key,
+                                index))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))
@@ -116,11 +116,11 @@ public class FixDates : IAsyncMigrationRoutine
                                     sw.Elapsed))
                         .SkippingUnreadableItems(
                             e => e.ItemId,
-                            (ex, id, row) => _logger.LogError(
+                            (ex, key, index) => _logger.LogError(
                                 ex,
-                                "Skipping Chapters row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                row,
-                                id))
+                                "Skipping Chapters row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                key,
+                                index))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))
@@ -153,11 +153,11 @@ public class FixDates : IAsyncMigrationRoutine
                                     sw.Elapsed))
                         .SkippingUnreadableItems(
                             e => e.Id,
-                            (ex, id, row) => _logger.LogError(
+                            (ex, key, index) => _logger.LogError(
                                 ex,
-                                "Skipping BaseItemImageInfos row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                row,
-                                id))
+                                "Skipping BaseItemImageInfos row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                key,
+                                index))
                         .PartitionEagerAsync(PageSize, cancellationToken)
                         .WithCancellation(cancellationToken)
                         .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20260610120000_RefreshCleanNamesAndValues.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260610120000_RefreshCleanNamesAndValues.cs
@@ -58,6 +58,13 @@ public class RefreshCleanNamesAndValues : IAsyncMigrationRoutine
                           .Where(b => !string.IsNullOrEmpty(b.Name))
                           .OrderBy(e => e.Id)
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
+                          .SkippingUnreadableItems(
+                              e => e.Id,
+                              (ex, id, row) => _logger.LogError(
+                                  ex,
+                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                  row,
+                                  id))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))
@@ -123,6 +130,13 @@ public class RefreshCleanNamesAndValues : IAsyncMigrationRoutine
                           .Where(b => !string.IsNullOrEmpty(b.Value))
                           .OrderBy(e => e.ItemValueId)
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
+                          .SkippingUnreadableItems(
+                              e => e.ItemValueId,
+                              (ex, id, row) => _logger.LogError(
+                                  ex,
+                                  "Skipping ItemValues row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                  row,
+                                  id))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20260610120000_RefreshCleanNamesAndValues.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260610120000_RefreshCleanNamesAndValues.cs
@@ -60,11 +60,11 @@ public class RefreshCleanNamesAndValues : IAsyncMigrationRoutine
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
                           .SkippingUnreadableItems(
                               e => e.Id,
-                              (ex, id, row) => _logger.LogError(
+                              (ex, key, index) => _logger.LogError(
                                   ex,
-                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                  row,
-                                  id))
+                                  "Skipping BaseItems row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                  key,
+                                  index))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))
@@ -132,11 +132,11 @@ public class RefreshCleanNamesAndValues : IAsyncMigrationRoutine
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
                           .SkippingUnreadableItems(
                               e => e.ItemValueId,
-                              (ex, id, row) => _logger.LogError(
+                              (ex, key, index) => _logger.LogError(
                                   ex,
-                                  "Skipping ItemValues row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                  row,
-                                  id))
+                                  "Skipping ItemValues row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                  key,
+                                  index))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20260722120000_RefreshForcedSortNames.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260722120000_RefreshForcedSortNames.cs
@@ -64,11 +64,11 @@ public class RefreshForcedSortNames : IAsyncMigrationRoutine
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
                           .SkippingUnreadableItems(
                               e => e.Id,
-                              (ex, id, row) => _logger.LogError(
+                              (ex, key, index) => _logger.LogError(
                                   ex,
-                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
-                                  row,
-                                  id))
+                                  "Skipping BaseItems row {Key} at index {Index}, it could not be read. Repair the row to include it",
+                                  key,
+                                  index))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/Jellyfin.Server/Migrations/Routines/20260722120000_RefreshForcedSortNames.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260722120000_RefreshForcedSortNames.cs
@@ -62,6 +62,13 @@ public class RefreshForcedSortNames : IAsyncMigrationRoutine
                           .Where(b => !string.IsNullOrEmpty(b.ForcedSortName))
                           .OrderBy(e => e.Id)
                           .WithPartitionProgress((partition) => _logger.LogInformation("Processed: {Offset}/{Total} - Updated: {UpdatedCount} - Time: {Elapsed}", partition * Limit, records, itemCount, sw.Elapsed))
+                          .SkippingUnreadableItems(
+                              e => e.Id,
+                              (ex, id, row) => _logger.LogError(
+                                  ex,
+                                  "Skipping BaseItems row {Row} with key {Key}, which the database cannot read. Repair that row and run the upgrade again to include it",
+                                  row,
+                                  id))
                           .PartitionEagerAsync(Limit, cancellationToken)
                           .WithCancellation(cancellationToken)
                           .ConfigureAwait(false))

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ProgressablePartitionReporting.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ProgressablePartitionReporting.cs
@@ -61,6 +61,6 @@ public class ProgressablePartitionReporting<TEntity>
 
     internal void ItemFailed(Exception exception, object? key, int rowIndex)
     {
-        OnItemFailed!.Invoke(exception, key, rowIndex);
+        OnItemFailed?.Invoke(exception, key, rowIndex);
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/ProgressablePartitionReporting.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/ProgressablePartitionReporting.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Jellyfin.Database.Implementations;
 
@@ -29,6 +31,10 @@ public class ProgressablePartitionReporting<TEntity>
 
     internal Action<int, TimeSpan>? OnEndPartition { get; set; }
 
+    internal Action<Exception, object?, int>? OnItemFailed { get; set; }
+
+    internal Func<int, CancellationToken, Task<object?>>? KeyLookup { get; set; }
+
     internal IOrderedQueryable<TEntity> Source => _source;
 
     internal void BeginItem(TEntity entity, int iteration, int itemIndex)
@@ -51,5 +57,10 @@ public class ProgressablePartitionReporting<TEntity>
     internal void EndPartition(int iteration)
     {
         OnEndPartition?.Invoke(iteration, _partitionTime.Elapsed);
+    }
+
+    internal void ItemFailed(Exception exception, object? key, int rowIndex)
+    {
+        OnItemFailed!.Invoke(exception, key, rowIndex);
     }
 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/QueryPartitionHelpers.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/QueryPartitionHelpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,32 @@ namespace Jellyfin.Database.Implementations;
 /// </summary>
 public static class QueryPartitionHelpers
 {
+    // A row that cannot be read leaves the enumerator's position undefined. Skipping is only safe while it
+    // keeps moving, so a run of failures with no row in between is treated as a dead reader rather than as
+    // more bad rows.
+    private const int MaxConsecutiveItemFailures = 10;
+
+    /// <summary>
+    /// Reads the key of a row that could not be loaded, so the log can name it. Reading the key alone
+    /// avoids the columns that made the row unreadable, but it is still best effort.
+    /// </summary>
+    private static async Task<object?> ReadKeyAsync<TEntity>(ProgressablePartitionReporting<TEntity> progressablePartition, int rowIndex, CancellationToken cancellationToken)
+    {
+        if (progressablePartition.KeyLookup is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return await progressablePartition.KeyLookup(rowIndex, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     /// <summary>
     /// Adds a callback to any directly following calls of Partition for every partition thats been invoked.
     /// </summary>
@@ -77,6 +104,46 @@ public static class QueryPartitionHelpers
     }
 
     /// <summary>
+    /// Allows the following calls of Partition to skip rows the database cannot turn into an entity, instead
+    /// of aborting. Without this the enumeration keeps its existing behaviour and the failure propagates.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity to load.</typeparam>
+    /// <typeparam name="TKey">The key to report the offending row by.</typeparam>
+    /// <param name="query">The source query.</param>
+    /// <param name="keySelector">Selects the key to report, read on its own so the unreadable columns are not touched.</param>
+    /// <param name="onItemFailed">Invoked with the failure, the row's key when it could be read, and its index in the query.</param>
+    /// <returns>A queryable that can be used to partition.</returns>
+    public static ProgressablePartitionReporting<TEntity> SkippingUnreadableItems<TEntity, TKey>(
+        this IOrderedQueryable<TEntity> query,
+        Expression<Func<TEntity, TKey>> keySelector,
+        Action<Exception, object?, int> onItemFailed)
+        => new ProgressablePartitionReporting<TEntity>(query).SkippingUnreadableItems(keySelector, onItemFailed);
+
+    /// <summary>
+    /// Allows the following calls of Partition to skip rows the database cannot turn into an entity, instead
+    /// of aborting. Without this the enumeration keeps its existing behaviour and the failure propagates.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity to load.</typeparam>
+    /// <typeparam name="TKey">The key to report the offending row by.</typeparam>
+    /// <param name="progressable">The source query.</param>
+    /// <param name="keySelector">Selects the key to report, read on its own so the unreadable columns are not touched.</param>
+    /// <param name="onItemFailed">Invoked with the failure, the row's key when it could be read, and its index in the query.</param>
+    /// <returns>A queryable that can be used to partition.</returns>
+    public static ProgressablePartitionReporting<TEntity> SkippingUnreadableItems<TEntity, TKey>(
+        this ProgressablePartitionReporting<TEntity> progressable,
+        Expression<Func<TEntity, TKey>> keySelector,
+        Action<Exception, object?, int> onItemFailed)
+    {
+        ArgumentNullException.ThrowIfNull(progressable);
+
+        var source = progressable.Source;
+        progressable.OnItemFailed = onItemFailed;
+        progressable.KeyLookup = async (index, cancellationToken) =>
+            await source.Skip(index).Take(1).Select(keySelector).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+        return progressable;
+    }
+
+    /// <summary>
     /// Enumerates the source query by loading the entities in partitions in a lazy manner reading each item from the database as its requested.
     /// </summary>
     /// <typeparam name="TEntity">The entity to load.</typeparam>
@@ -124,27 +191,60 @@ public static class QueryPartitionHelpers
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var iterator = 0;
-        int itemCounter;
+        int rowsRead;
         do
         {
             progressablePartition?.BeginPartition(iterator);
-            itemCounter = 0;
-            await foreach (var item in query
+            var itemCounter = 0;
+            rowsRead = 0;
+            var consecutiveFailures = 0;
+
+            var enumerator = query
                 .Skip(partitionSize * iterator)
                 .Take(partitionSize)
                 .AsAsyncEnumerable()
-                .WithCancellation(cancellationToken)
-                .ConfigureAwait(false))
+                .GetAsyncEnumerator(cancellationToken);
+            await using (enumerator.ConfigureAwait(false))
             {
-                progressablePartition?.BeginItem(item, iterator, itemCounter);
-                yield return item;
-                progressablePartition?.EndItem(item, iterator, itemCounter);
-                itemCounter++;
+                while (true)
+                {
+                    TEntity item;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+
+                        item = enumerator.Current;
+                        consecutiveFailures = 0;
+                    }
+                    catch (Exception ex)
+                    {
+                        consecutiveFailures++;
+                        if (progressablePartition?.OnItemFailed is null || consecutiveFailures > MaxConsecutiveItemFailures)
+                        {
+                            throw;
+                        }
+
+                        var rowIndex = (partitionSize * iterator) + rowsRead;
+                        progressablePartition.ItemFailed(ex, await ReadKeyAsync(progressablePartition, rowIndex, cancellationToken).ConfigureAwait(false), rowIndex);
+                        rowsRead++;
+                        continue;
+                    }
+
+                    rowsRead++;
+                    progressablePartition?.BeginItem(item, iterator, itemCounter);
+                    yield return item;
+                    progressablePartition?.EndItem(item, iterator, itemCounter);
+                    itemCounter++;
+                }
             }
 
             progressablePartition?.EndPartition(iterator);
             iterator++;
-        } while (itemCounter == partitionSize && !cancellationToken.IsCancellationRequested);
+            // Counting rows rather than yielded items, so a skipped row cannot end the walk early.
+        } while (rowsRead == partitionSize && !cancellationToken.IsCancellationRequested);
     }
 
     /// <summary>
@@ -163,22 +263,52 @@ public static class QueryPartitionHelpers
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var iterator = 0;
-        int itemCounter;
+        int rowsRead;
         var items = ArrayPool<TEntity>.Shared.Rent(partitionSize);
         try
         {
             do
             {
                 progressablePartition?.BeginPartition(iterator);
-                itemCounter = 0;
-                await foreach (var item in query
+                var itemCounter = 0;
+                rowsRead = 0;
+                var consecutiveFailures = 0;
+
+                var enumerator = query
                     .Skip(partitionSize * iterator)
                     .Take(partitionSize)
                     .AsAsyncEnumerable()
-                    .WithCancellation(cancellationToken)
-                    .ConfigureAwait(false))
+                    .GetAsyncEnumerator(cancellationToken);
+                await using (enumerator.ConfigureAwait(false))
                 {
-                    items[itemCounter++] = item;
+                    while (true)
+                    {
+                        try
+                        {
+                            if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                            {
+                                break;
+                            }
+
+                            items[itemCounter++] = enumerator.Current;
+                            consecutiveFailures = 0;
+                        }
+                        catch (Exception ex)
+                        {
+                            consecutiveFailures++;
+                            if (progressablePartition?.OnItemFailed is null || consecutiveFailures > MaxConsecutiveItemFailures)
+                            {
+                                throw;
+                            }
+
+                            var rowIndex = (partitionSize * iterator) + rowsRead;
+                            progressablePartition.ItemFailed(ex, await ReadKeyAsync(progressablePartition, rowIndex, cancellationToken).ConfigureAwait(false), rowIndex);
+                            rowsRead++;
+                            continue;
+                        }
+
+                        rowsRead++;
+                    }
                 }
 
                 for (int i = 0; i < itemCounter; i++)
@@ -190,7 +320,8 @@ public static class QueryPartitionHelpers
 
                 progressablePartition?.EndPartition(iterator);
                 iterator++;
-            } while (itemCounter == partitionSize && !cancellationToken.IsCancellationRequested);
+                // Counting rows rather than yielded items, so a skipped row cannot end the walk early.
+            } while (rowsRead == partitionSize && !cancellationToken.IsCancellationRequested);
         }
         finally
         {

--- a/src/Jellyfin.Database/Jellyfin.Database.Implementations/QueryPartitionHelpers.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Implementations/QueryPartitionHelpers.cs
@@ -176,6 +176,63 @@ public static class QueryPartitionHelpers
     }
 
     /// <summary>
+    /// Reads one partition into the buffer, skipping rows that cannot be read when the caller asked for
+    /// that. Returns how many entities were buffered and how many rows were consumed, which differ when a
+    /// row was skipped and only the second may decide whether another partition follows.
+    /// </summary>
+    private static async Task<(int ItemCount, int RowsRead)> FillPartitionAsync<TEntity>(
+        IOrderedQueryable<TEntity> query,
+        int partitionSize,
+        int iterator,
+        TEntity[] items,
+        ProgressablePartitionReporting<TEntity>? progressablePartition,
+        CancellationToken cancellationToken)
+    {
+        var itemCounter = 0;
+        var rowsRead = 0;
+        var consecutiveFailures = 0;
+
+        var enumerator = query
+            .Skip(partitionSize * iterator)
+            .Take(partitionSize)
+            .AsAsyncEnumerable()
+            .GetAsyncEnumerator(cancellationToken);
+        await using (enumerator.ConfigureAwait(false))
+        {
+            while (true)
+            {
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    items[itemCounter++] = enumerator.Current;
+                    consecutiveFailures = 0;
+                }
+                catch (Exception ex)
+                {
+                    consecutiveFailures++;
+                    if (progressablePartition?.OnItemFailed is null || consecutiveFailures > MaxConsecutiveItemFailures)
+                    {
+                        throw;
+                    }
+
+                    var rowIndex = (partitionSize * iterator) + rowsRead;
+                    progressablePartition.ItemFailed(ex, await ReadKeyAsync(progressablePartition, rowIndex, cancellationToken).ConfigureAwait(false), rowIndex);
+                    rowsRead++;
+                    continue;
+                }
+
+                rowsRead++;
+            }
+        }
+
+        return (itemCounter, rowsRead);
+    }
+
+    /// <summary>
     /// Enumerates the source query by loading the entities in partitions in a lazy manner reading each item from the database as its requested.
     /// </summary>
     /// <typeparam name="TEntity">The entity to load.</typeparam>
@@ -270,46 +327,8 @@ public static class QueryPartitionHelpers
             do
             {
                 progressablePartition?.BeginPartition(iterator);
-                var itemCounter = 0;
-                rowsRead = 0;
-                var consecutiveFailures = 0;
-
-                var enumerator = query
-                    .Skip(partitionSize * iterator)
-                    .Take(partitionSize)
-                    .AsAsyncEnumerable()
-                    .GetAsyncEnumerator(cancellationToken);
-                await using (enumerator.ConfigureAwait(false))
-                {
-                    while (true)
-                    {
-                        try
-                        {
-                            if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
-                            {
-                                break;
-                            }
-
-                            items[itemCounter++] = enumerator.Current;
-                            consecutiveFailures = 0;
-                        }
-                        catch (Exception ex)
-                        {
-                            consecutiveFailures++;
-                            if (progressablePartition?.OnItemFailed is null || consecutiveFailures > MaxConsecutiveItemFailures)
-                            {
-                                throw;
-                            }
-
-                            var rowIndex = (partitionSize * iterator) + rowsRead;
-                            progressablePartition.ItemFailed(ex, await ReadKeyAsync(progressablePartition, rowIndex, cancellationToken).ConfigureAwait(false), rowIndex);
-                            rowsRead++;
-                            continue;
-                        }
-
-                        rowsRead++;
-                    }
-                }
+                int itemCounter;
+                (itemCounter, rowsRead) = await FillPartitionAsync(query, partitionSize, iterator, items, progressablePartition, cancellationToken).ConfigureAwait(false);
 
                 for (int i = 0; i < itemCounter; i++)
                 {

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/PartitionSkipUnreadableTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/PartitionSkipUnreadableTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+/// <summary>
+/// A row the database cannot turn into an entity used to abort the whole migration. Callers that opt in
+/// now skip it and carry on, and the walk must not stop early because of the gap it leaves.
+/// </summary>
+public sealed class PartitionSkipUnreadableTests : SqliteDbTestFixture
+{
+    private const string UnreadableDate = "2023-01-17 03:02:94.3383473";
+    private const int PartitionSize = 2;
+
+    private const string TestType = "PartitionSkipUnreadableTests";
+
+    private readonly Guid[] _ids =
+    [
+        .. Enumerable.Range(1, 5).Select(i => Guid.Parse($"10000000-0000-0000-0000-00000000000{i}"))
+    ];
+
+    public PartitionSkipUnreadableTests()
+    {
+        using var context = CreateDbContext();
+        foreach (var id in _ids)
+        {
+            context.BaseItems.Add(new BaseItemEntity
+            {
+                Id = id,
+                Type = TestType,
+                Name = id.ToString("N"),
+                PresentationUniqueKey = id.ToString("N"),
+                DateCreated = DateTime.UtcNow
+            });
+        }
+
+        context.SaveChanges();
+
+        // The second row, so its partition is still full and the walk has to continue past it.
+        context.Database.ExecuteSqlRaw(
+            "UPDATE BaseItems SET DateCreated = {0} WHERE Id = {1}", UnreadableDate, _ids[1]);
+    }
+
+    [Fact]
+    public async Task PartitionEagerAsync_OptedIn_ReportsTheRowKeyAndKeepsGoing()
+    {
+        var failures = new List<(object? Key, int Row)>();
+        var seen = new List<Guid>();
+
+        await using var context = CreateDbContext();
+        await foreach (var item in Query(context)
+                           .SkippingUnreadableItems(e => e.Id, (_, key, row) => failures.Add((key, row)))
+                           .PartitionEagerAsync(PartitionSize, TestContext.Current.CancellationToken)
+                           .WithCancellation(TestContext.Current.CancellationToken)
+                           .ConfigureAwait(false))
+        {
+            seen.Add(item.Id);
+        }
+
+        // The row is named by its key, not just its offset, so it can be found without counting.
+        Assert.Equal([(_ids[1], 1)], failures);
+        // Everything but the unreadable row, including the rows in later partitions.
+        Assert.Equal(_ids.Where(id => !id.Equals(_ids[1])), seen);
+    }
+
+    [Fact]
+    public async Task PartitionEagerAsync_NotOptedIn_StillFails()
+    {
+        await using var context = CreateDbContext();
+
+        await Assert.ThrowsAsync<FormatException>(async () =>
+        {
+            await foreach (var item in Query(context)
+                               .PartitionEagerAsync(PartitionSize, cancellationToken: TestContext.Current.CancellationToken)
+                               .WithCancellation(TestContext.Current.CancellationToken)
+                               .ConfigureAwait(false))
+            {
+                _ = item;
+            }
+        }).ConfigureAwait(true);
+    }
+
+    private static IOrderedQueryable<BaseItemEntity> Query(JellyfinDbContext context)
+        => context.BaseItems.Where(e => e.Type == TestType).OrderBy(e => e.Id);
+}


### PR DESCRIPTION
**Changes**

A single row the database cannot turn into an entity aborts the whole migration, so the server never starts and retries on a loop. The error names neither the table nor the row, and the only way out is to find the offending value by hand with no idea where to look.

In #17849 that value is `2023-01-17 03:02:94.3383473`, where the seconds are out of range. Nothing in Jellyfin can write it: `DateTime` cannot hold 94 seconds, and `'1'` and `'9'` are a single bit apart, so it looks like `03:02:14` with one flipped bit in storage. Repairing data like that is not really ours to do, and a fixup migration per incident does not scale. Surviving it is ours.

The migrations already guard their loop bodies, which does not help, because the failure happens while EF materialises the row inside `MoveNextAsync`, one step outside that guard. This moves the guard to the enumeration in `QueryPartitionHelpers`, which all the partitioned migrations share, so it covers any unreadable row rather than dates specifically.

It is opt-in through `SkippingUnreadableItems`. Without it the enumeration behaves exactly as it does today and the failure still propagates, which there is a test for. Every current call site opts in.

On a failure it logs the table, the row's key and its index, so the row can be found and repaired directly. The key is read on its own, which avoids the columns that made the row unreadable.

Two details worth pointing out for review:

- Skipping is bounded. A row that cannot be read leaves the enumerator's position undefined, so a run of failures with no successful row in between is treated as a dead reader and rethrows rather than spinning.
- The partition loop decided whether to fetch another page by counting yielded items. A skipped row would therefore have silently ended the walk and left the rest of the table unprocessed. It now counts rows read. The test uses a partition size of two with the bad row in the first partition to cover exactly that, and it fails without the fix.

Until this ships, affected users can find the bad values with `datetime()`, which returns NULL for exactly the values that cannot be read:

```sql
SELECT Id, 'DateCreated' AS Col, DateCreated AS Value FROM BaseItems
WHERE typeof(DateCreated) = 'text' AND datetime(DateCreated) IS NULL;
```

Replaces #17854, which tried to repair the values instead.

**Code assistance**

Opus 5 for tracing the failure to the enumeration rather than the loop body, for finding the early-termination bug in the partition counting, and for the tests. I reviewed the change and ran the suite.

**Issues**

Fixes #17849
