### PR TITLE
Report image resolutions for TMDb images when no image size is configured

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -568,8 +568,8 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 return null;
             }
 
-            // Use "original" as default size if size is null or empty to prevent malformed URLs
-            var imageSize = string.IsNullOrEmpty(size) ? "original" : size;
+            // Use the original size as default if size is null or empty to prevent malformed URLs
+            var imageSize = string.IsNullOrEmpty(size) ? TmdbUtils.OriginalImageSize : size;
 
             return _tmDbClient.GetImageUrl(imageSize, path, true).ToString();
         }
@@ -660,7 +660,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         private IEnumerable<RemoteImageInfo> ConvertToRemoteImageInfo(IReadOnlyList<ImageData> images, string? size, ImageType type, string requestLanguage)
         {
             // sizes provided are for original resolution, don't store them when downloading scaled images
-            var scaleImage = !string.Equals(size, "original", StringComparison.OrdinalIgnoreCase);
+            var scaleImage = !TmdbUtils.IsOriginalImageSize(size);
 
             for (var i = 0; i < images.Count; i++)
             {

--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbUtils.cs
@@ -34,6 +34,11 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
         /// </summary>
         public const string ApiKey = "4219e299c89411838049ab0dab19ebd5";
 
+        /// <summary>
+        /// The image size representing the unscaled image as served by TMDb.
+        /// </summary>
+        public const string OriginalImageSize = "original";
+
         private const int TitleExactScore = 8;
         private const int TitlePrefixScore = 4;
         private const int YearExactScore = 2;
@@ -484,6 +489,15 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
                 ? string.Empty
                 : imageLanguage;
         }
+
+        /// <summary>
+        /// Determines whether the configured image size fetches the image at its original resolution.
+        /// An unset size falls back to <see cref="OriginalImageSize"/>, see TmdbClientManager.GetUrl.
+        /// </summary>
+        /// <param name="size">The configured image size.</param>
+        /// <returns><c>true</c> if the original image is fetched; otherwise, <c>false</c>.</returns>
+        public static bool IsOriginalImageSize(string? size)
+            => string.IsNullOrEmpty(size) || string.Equals(size, OriginalImageSize, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Combines the metadata country code and the parental rating from the API into the value we store in our database.

--- a/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Tmdb/TmdbUtilsTests.cs
@@ -105,6 +105,19 @@ namespace Jellyfin.Providers.Tests.Tmdb
         }
 
         [Theory]
+        // An unconfigured size fetches the original image, so it keeps the original resolution.
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("original", true)]
+        [InlineData("Original", true)]
+        [InlineData("w500", false)]
+        [InlineData("original2", false)]
+        public static void IsOriginalImageSize_Valid_Success(string? size, bool expected)
+        {
+            Assert.Equal(expected, TmdbUtils.IsOriginalImageSize(size));
+        }
+
+        [Theory]
         [MemberData(nameof(FindBestMatch_Movies_TestData))]
         public static void FindBestMatch_Movies_PicksExpected(string description, string name, int year, IReadOnlyList<SearchMovie> results, int expectedId)
         {


### PR DESCRIPTION
TMDb reports image dimensions for the original image, so `ConvertToRemoteImageInfo` drops `Width`/`Height` whenever a scaled size is fetched. The configured sizes default to `null`.

**Changes**
Centralises the "unset means original" rule in `TmdbUtils.IsOriginalImageSize` and uses it in both `GetUrl` and `ConvertToRemoteImageInfo`, with a test covering it.

**Code assistance**
None

**Issues**
Fixes #17857