### PR TITLE
Fix stale ItemValues.CleanValue breaking Artists/Genres/Studios views

### DIFF
--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -312,6 +312,21 @@ public class ItemPersistenceService : IItemPersistenceService
             .AsEnumerable()
             .Where(e => allListedItemValuesSet.Contains((e.Type, e.Value)))
             .ToArray();
+
+        // Repair any existing ItemValue whose CleanValue no longer matches what GetCleanValue()
+        // would produce today (e.g. it was written before a change to the cleaning algorithm).
+        // By-name views (Artists, Genres, Studios, ...) join on CleanValue == BaseItem.CleanName,
+        // so a stale CleanValue leaves an item permanently unmatchable there. A rescan alone never
+        // corrects it, because the lookup above only keys on Type/Value, not CleanValue.
+        foreach (var existingValue in existingValues)
+        {
+            var correctCleanValue = existingValue.Value.GetCleanValue();
+            if (!string.Equals(existingValue.CleanValue, correctCleanValue, StringComparison.Ordinal))
+            {
+                existingValue.CleanValue = correctCleanValue;
+            }
+        }
+
         var missingItemValues = allListedItemValues.Except(existingValues.Select(f => (MagicNumber: f.Type, f.Value))).Select(f => new ItemValue()
         {
             CleanValue = f.Value.GetCleanValue(),


### PR DESCRIPTION
**Changes**

`ItemPersistenceService.SaveItems` reuses an existing `ItemValues` row (matched by `(Type, Value)`) without ever re-validating its `CleanValue` against what `GetCleanValue()` would produce today. By-name views (Artists, AlbumArtists, Genres, Studios — everything built on `BaseItemRepository.GetItemValues`) require `ItemValues.CleanValue == BaseItem.CleanName` exactly, so a row with a stale `CleanValue` (e.g. written before a change to the cleaning algorithm) makes its item permanently invisible in those views, with no rescan, metadata refresh, or item recreation able to fix it, since none of those paths touch an existing `ItemValues` row. This PR repairs a reused row's `CleanValue` in place whenever it no longer matches the current `GetCleanValue()` output, so it self-heals the next time any item referencing it is saved.

Verified locally: `dotnet build` on `Jellyfin.Server.Implementations` (0 errors, no new warnings) and `dotnet test` on `Jellyfin.Server.Implementations.Tests` filtered to `Item` (207/207 passed). Reproduced and confirmed fixed against a real library that had exactly this stale-`CleanValue` condition for an artist tag containing `&`.

**Code assistance**

Diagnosed and drafted with Claude Code: it read the actual `BaseItemRepository.ByName.cs`/`ItemPersistenceService.cs` source from this repo to trace why a specific artist was permanently missing from the Artists view despite a structurally correct database, identified the `CleanValue`/`CleanName` mismatch as the root cause, and proposed this fix. I reviewed the diagnosis against the live database and the diff before committing.

**Issues**

Fixes #17866
