### PR TITLE
Fix FK constraint failure in ConsolidateLocalizedUserViews migration

### DIFF
--- a/Jellyfin.Server/Migrations/Routines/20260825200000_ConsolidateLocalizedUserViews.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260825200000_ConsolidateLocalizedUserViews.cs
@@ -311,7 +311,9 @@ internal class ConsolidateLocalizedUserViews : IAsyncMigrationRoutine
             return;
         }
 
-        // written while foreign key enforcement was off.
+        // AncestorIds can carry rows whose item no longer exists in BaseItems
+        // (written while foreign key enforcement was off). Re-inserting those
+        // pairs would fail the FK check, so only resurrect children that exist.
         var existingItemIds = (await dbContext.BaseItems
             .Where(e => items.Contains(e.Id))
             .Select(e => e.Id)

--- a/Jellyfin.Server/Migrations/Routines/20260825200000_ConsolidateLocalizedUserViews.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260825200000_ConsolidateLocalizedUserViews.cs
@@ -311,6 +311,13 @@ internal class ConsolidateLocalizedUserViews : IAsyncMigrationRoutine
             return;
         }
 
+        // written while foreign key enforcement was off.
+        var existingItemIds = (await dbContext.BaseItems
+            .Where(e => items.Contains(e.Id))
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false)).ToHashSet();
+            
         // The pair is the primary key, so anything already recorded against the canonical view stays put.
         var existing = await dbContext.AncestorIds
             .Where(e => e.ParentItemId.Equals(canonicalId))
@@ -318,7 +325,7 @@ internal class ConsolidateLocalizedUserViews : IAsyncMigrationRoutine
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        foreach (var itemId in items.Except(existing))
+        foreach (var itemId in items.Except(existing).Where(itemId => existingItemIds.Contains(itemId)))
         {
             dbContext.AncestorIds.Add(new AncestorId
             {


### PR DESCRIPTION
**Changes**

`20260825200000_ConsolidateLocalizedUserViews` blocks startup on databases
that contain orphaned `AncestorIds` rows — rows whose `ItemId` no longer
exists in `BaseItems`, accumulated while foreign key enforcement was off.

`MoveAncestorsAsync` reads the child `ItemId`s from `AncestorIds` rows
parented to the stale views, deletes those rows, then re-inserts each child
against the canonical view:

```csharp
var items = await dbContext.AncestorIds
    .WhereOneOrMany(staleIds, e => e.ParentItemId)
    .Select(e => e.ItemId)
    .Distinct()
    .ToListAsync(...);

await dbContext.AncestorIds
    .WhereOneOrMany(staleIds, e => e.ParentItemId)
    .ExecuteDeleteAsync(...);

foreach (var itemId in items.Except(existing))
{
    dbContext.AncestorIds.Add(new AncestorId { ItemId = itemId, ParentItemId = canonicalId, ... });
}
``` 

Nothing verifies itemId still exists in BaseItems, so any orphaned row is resurrected as a pair whose FK check fails, aborting the migration and blocking server startup. On my install the migration failed deterministically until 3,335 orphaned AncestorIds rows were removed.
Before / after

Before: every distinct ItemId parented to a stale view is re-added, regardless of whether the item survives in BaseItems.

After: only pairs whose child still exists in BaseItems are re-inserted. Deleted items' hierarchy records are discarded, which is lossless — nothing can ever dereference them.

Single addition in MoveAncestorsAsync, before the re-insert loop:
```csharp
// AncestorIds can carry rows whose item no longer exists in BaseItems
// (written while foreign key enforcement was off). Re-inserting those
// pairs would fail the FK check, so only resurrect children that exist.
var aliveItemIds = (await dbContext.BaseItems
    .Where(e => items.Contains(e.Id))
    .Select(e => e.Id)
    .ToListAsync(cancellationToken)
    .ConfigureAwait(false)).ToHashSet();

// The pair is the primary key, so anything already recorded against the
// canonical view stays put.
var existing = await dbContext.AncestorIds
    .Where(e => e.ParentItemId.Equals(canonicalId))
    .Select(e => e.ItemId)
    .ToListAsync(cancellationToken)
    .ConfigureAwait(false);

foreach (var itemId in items.Except(existing).Where(existingItemIds.Contains))
{
    // unchanged body
}
```

**Code assistance**
LLM used for debugging and suggested fixes for issue. I do not use C# and use SQL infrequently so a review and test build by someone more familiar would be appreciated.

**Issues**
Fixes #17875