### PR TITLE
Fix trickplay using the wrong video stream

### DIFF
--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -922,6 +922,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
                 inputArg = "-hwaccel_flags +low_priority " + inputArg;
             }
 
+            // Force the video stream, otherwise ffmpeg may pick a cover image.
+            inputArg += " -map 0:" + imageStream.Index.ToString(CultureInfo.InvariantCulture);
+
             var filterParam = encodingHelper.GetVideoProcessingFilterParam(jobState, options, vidEncoder).Trim();
             if (string.IsNullOrWhiteSpace(filterParam))
             {

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -923,7 +923,13 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // Force the video stream, otherwise ffmpeg may pick a cover image.
-            inputArg += " -map 0:" + EncodingHelper.FindIndex(mediaSource.MediaStreams, imageStream);
+            var streamIndex = EncodingHelper.FindIndex(mediaSource.MediaStreams, imageStream);
+            if (streamIndex < 0)
+            {
+                throw new InvalidOperationException($"Unable to locate requested stream {imageStream.Title}");
+            }
+
+            inputArg += " -map 0:" + streamIndex;
 
             var filterParam = encodingHelper.GetVideoProcessingFilterParam(jobState, options, vidEncoder).Trim();
             if (string.IsNullOrWhiteSpace(filterParam))

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -923,7 +923,7 @@ namespace MediaBrowser.MediaEncoding.Encoder
             }
 
             // Force the video stream, otherwise ffmpeg may pick a cover image.
-            inputArg += " -map 0:" + imageStream.Index.ToString(CultureInfo.InvariantCulture);
+            inputArg += " -map 0:" + EncodingHelper.FindIndex(mediaSource.MediaStreams, imageStream);
 
             var filterParam = encodingHelper.GetVideoProcessingFilterParam(jobState, options, vidEncoder).Trim();
             if (string.IsNullOrWhiteSpace(filterParam))


### PR DESCRIPTION
With a media file with streams 

```
  Stream #0:0: Video: h264 (High), 1 reference frame, yuv420p(tv, bt709, progressive, left), 1920x1080 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 1k tbn, start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : USP Video Handler
      ENCODER         : AVC Coding
      DURATION        : 00:46:21.487000000
  Stream #0:1(eng): Audio: eac3, 48000 Hz, stereo, fltp, 224 kb/s, start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : USP Sound Handler
      DURATION        : 00:46:21.491000000
  Stream #0:2(eng): Subtitle: subrip (srt), start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : SubtitleHandler
      ENCODER         : Lavc58.54.100 srt
      DURATION        : 00:45:38.340000000
  Stream #0:3: Video: png, 1 reference frame (MPNG / 0x474E504D), rgb24(pc, gbr/bt709/bt470m), 3840x2160 [SAR 5669:5669 DAR 16:9], 1k tbr, 1k tbn, start 0.083000
    Metadata:
      DURATION        : 00:00:00.083000000
  Stream #0:4(eng): Subtitle: subrip (srt), start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : SubtitleHandler
      ENCODER         : Lavc58.54.100 srt
      DURATION        : 00:45:38.340000000
```

The trickplay extraction is as follows

```
/usr/lib/jellyfin-ffmpeg/ffmpeg -loglevel verbose \
  -init_hw_device vaapi=va:,vendor_id=0x8086,driver=iHD \
  -init_hw_device qsv=qs@va -filter_hw_device qs \
  -hwaccel vaapi -hwaccel_output_format vaapi -noautorotate \
  -i file:"/virtual/media/tv/episode.mkv" \
  -noautoscale -an -sn \
  -vf "fps=0.10000000149011612,setparams=color_primaries=bt709:color_trc=bt709:colorspace=bt709,scale_vaapi=w=320:h=180:format=nv12:out_range=pc:mode=hq:extra_hw_frames=24,hwmap=derive_device=qsv,format=qsv" \
  -threads 4 -c:v mjpeg_qsv -global_quality:v 91 -fps_mode passthrough \
  -f image2 /tmp/trickplay-test/%08d.jpg
ffmpeg version 8.1.2-Jellyfin Copyright (c) 2000-2026 the FFmpeg developers
  built with gcc 14 (Debian 14.2.0-19)
  configuration: --prefix=/usr/lib/jellyfin-ffmpeg --target-os=linux --extra-version=Jellyfin --disable-unstable --disable-doc --disable-ffplay --disable-static --disable-libxcb --disable-libxcb-shm --disable-libxcb-xfixes --disable-libxcb-shape --disable-xlib --disable-sdl2 --enable-lto=auto --enable-gpl --enable-version3 --enable-shared --enable-gmp --enable-gnutls --enable-chromaprint --enable-opencl --enable-libdrm --enable-libxml2 --enable-libass --enable-libfreetype --enable-libfribidi --enable-libfontconfig --enable-libharfbuzz --enable-libbluray --enable-libmp3lame --enable-libopus --enable-libtheora --enable-libvorbis --enable-libopenmpt --enable-libdav1d --enable-libsvtav1 --enable-libwebp --enable-libvpx --enable-libx264 --enable-libx265 --enable-libzvbi --enable-libzimg --enable-libfdk-aac --enable-libshaderc --enable-libplacebo --enable-vulkan --enable-vulkan-static --enable-vaapi --enable-ffnvcodec --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvdec --enable-nvenc --arch=amd64 --enable-libvpl --enable-amf
  libavutil      60. 26.102 / 60. 26.102
  libavcodec     62. 28.102 / 62. 28.102
  libavformat    62. 12.102 / 62. 12.102
  libavdevice    62.  3.102 / 62.  3.102
  libavfilter    11. 14.102 / 11. 14.102
  libswscale      9.  5.102 /  9.  5.102
  libswresample   6.  3.102 /  6.  3.102
[VAAPI @ 0x7f30c4076c80] Trying to use DRM render node for device 0, with matching vendor id (0x8086).
[VAAPI @ 0x7f30c4076c80] libva: VA-API version 1.24.0
[VAAPI @ 0x7f30c4076c80] libva: User requested driver 'iHD'
[VAAPI @ 0x7f30c4076c80] libva: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
[VAAPI @ 0x7f30c4076c80] libva: Found init function __vaDriverInit_1_24
[VAAPI @ 0x7f30c4076c80] libva: va_openDriver() returns 0
[VAAPI @ 0x7f30c4076c80] Initialised VAAPI connection: version 1.24
[VAAPI @ 0x7f30c4076c80] VAAPI driver: Intel iHD driver for Intel(R) Gen Graphics - 26.2.4 (2aa8891).
[VAAPI @ 0x7f30c4076c80] Driver not found in known nonstandard list, using standard behaviour.
[QSV @ 0x7f30c4102800] Use Intel(R) oneVPL to create MFX session, API version is 2.17, the required implementation version is 1.3
libva info: VA-API version 1.24.0
libva info: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_24
libva info: va_openDriver() returns 0
libva info: VA-API version 1.24.0
libva info: Trying to open /usr/lib/jellyfin-ffmpeg/lib/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_24
libva info: va_openDriver() returns 0
[QSV @ 0x7f30c4102800] Initialize MFX session: implementation version is 2.17
[h264 @ 0x7f30c40f2500] Reinit context to 1920x1088, pix_fmt: yuv420p
[in#0/matroska,webm @ 0x7f30c40cea00] Stream #3: not enough frames to estimate rate; consider increasing probesize
[vist#0:0/h264 @ 0x7f30c40b2c00] Selecting decoder 'h264' because of requested hwaccel method vaapi
Input #0, matroska,webm, from 'file:/virtual/media/tv/episode.mkv':
  Metadata:
    MAJOR_BRAND     : isom
    MINOR_VERSION   : 512
    COMPATIBLE_BRANDS: isomdby1iso2avc1mp41
    SEASON_NUMBER   : 3
    GENRE           : ;;;
    ENCODER         : Lavf58.29.100
  Duration: 00:46:21.49, start: 0.083000, bitrate: 6106 kb/s
  Stream #0:0: Video: h264 (High), 1 reference frame, yuv420p(tv, bt709, progressive, left), 1920x1080 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 1k tbn, start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : USP Video Handler
      ENCODER         : AVC Coding
      DURATION        : 00:46:21.487000000
  Stream #0:1(eng): Audio: eac3, 48000 Hz, stereo, fltp, 224 kb/s, start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : USP Sound Handler
      DURATION        : 00:46:21.491000000
  Stream #0:2(eng): Subtitle: subrip (srt), start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : SubtitleHandler
      ENCODER         : Lavc58.54.100 srt
      DURATION        : 00:45:38.340000000
  Stream #0:3: Video: png, 1 reference frame (MPNG / 0x474E504D), rgb24(pc, gbr/bt709/bt470m), 3840x2160 [SAR 5669:5669 DAR 16:9], 1k tbr, 1k tbn, start 0.083000
    Metadata:
      DURATION        : 00:00:00.083000000
  Stream #0:4(eng): Subtitle: subrip (srt), start 0.083000 (default)
    Metadata:
      HANDLER_NAME    : SubtitleHandler
      ENCODER         : Lavc58.54.100 srt
      DURATION        : 00:45:38.340000000
[out#0/image2 @ 0x7f30c4103400] No explicit maps, mapping streams automatically...
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] Created video stream from input stream 0:3
[Parsed_fps_0 @ 0x7f30c4103280] 0 frames in, 0 frames out; 0 frames dropped, 0 frames duplicated.
Stream mapping:
  Stream #0:3 -> #0:0 (png (native) -> mjpeg (mjpeg_qsv))
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] Starting thread...
[vf#0:0 @ 0x7f30c40da400] Starting thread...
[vist#0:3/png @ 0x7f30c40b3080] [dec:png @ 0x7f30c4012d80] Starting thread...
[in#0/matroska,webm @ 0x7f30c4012b00] Starting thread...
Press [q] to stop, [?] for help
[graph -1 input from stream 0:3 @ 0x7f30a7813540] w:3840 h:2160 pixfmt:rgb24 tb:1/1000 fr:1000/1 sar:1/1 csp:gbr range:pc alpha:unspecified
[auto_scale_0 @ 0x7f30a7813840] w:iw h:ih flags:'' interl:0
[Parsed_scale_vaapi_2 @ 0x7f30a7813300] auto-inserting filter 'auto_scale_0' between the filter 'Parsed_setparams_1' and the filter 'Parsed_scale_vaapi_2'
Impossible to convert between the formats supported by the filter 'Parsed_setparams_1' and the filter 'auto_scale_0'
Link 'Parsed_setparams_1.default' -> 'auto_scale_0.default':
  Pixel formats:
    src: rgb24
    dst: rgb24
Link 'auto_scale_0.default' -> 'Parsed_scale_vaapi_2.default':
  Pixel formats:
    src: yuv420p yuyv422 rgb24 bgr24 yuv422p yuv444p yuv410p yuv411p gray monow monob pal8 yuvj420p yuvj422p yuvj444p uyvy422 bgr8 bgr4 bgr4_byte rgb8 rgb4 rgb4_byte nv12 nv21 argb rgba abgr bgra gray16be gray16le yuv440p yuvj440p yuva420p rgb48be rgb48le rgb565be rgb565le rgb555be rgb555le bgr565be bgr565le bgr555be bgr555le yuv420p16le yuv420p16be yuv422p16le yuv422p16be yuv444p16le yuv444p16be rgb444le rgb444be bgr444le bgr444be ya8 bgr48be bgr48le yuv420p9be yuv420p9le yuv420p10be yuv420p10le yuv422p10be yuv422p10le yuv444p9be yuv444p9le yuv444p10be yuv444p10le yuv422p9be yuv422p9le gbrp gbrp9be gbrp9le gbrp10be gbrp10le gbrp16be gbrp16le yuva422p yuva444p yuva420p9be yuva420p9le yuva422p9be yuva422p9le yuva444p9be yuva444p9le yuva420p10be yuva420p10le yuva422p10be yuva422p10le yuva444p10be yuva444p10le yuva420p16be yuva420p16le yuva422p16be yuva422p16le yuva444p16be yuva444p16le xyz12le xyz12be nv16 nv20le nv20be rgba64be rgba64le bgra64be bgra64le yvyu422 ya16be ya16le gbrap gbrap16be gbrap16le 0rgb rgb0 0bgr bgr0 yuv420p12be yuv420p12le yuv420p14be yuv420p14le yuv422p12be yuv422p12le yuv422p14be yuv422p14le yuv444p12be yuv444p12le yuv444p14be yuv444p14le gbrp12be gbrp12le gbrp14be gbrp14le yuvj411p yuv440p10le yuv440p10be yuv440p12le yuv440p12be ayuv64le ayuv64be p010le p010be gbrap12be gbrap12le gbrap10be gbrap10le gray12be gray12le gray10be gray10le p016le p016be gray9be gray9le gbrpf32be gbrpf32le gbrapf32be gbrapf32le gray14be gray14le grayf32be grayf32le yuva422p12be yuva422p12le yuva444p12be yuva444p12le nv24 nv42 y210le x2rgb10le x2bgr10le p210be p210le p410be p410le p216be p216le p416be p416le vuya vuyx p012le p012be y212le xv30le xv36be xv36le p212be p212le p412be p412le gbrap14be gbrap14le ayuv uyva vyu444 v30xle y216le xv48be xv48le yuv444p10msbbe yuv444p10msble yuv444p12msbbe yuv444p12msble gbrp10msbbe gbrp10msble gbrp12msbbe gbrp12msble
    dst: vaapi
[Parsed_fps_0 @ 0x7f30a78130c0] 0 frames in, 0 frames out; 0 frames dropped, 0 frames duplicated.
[vf#0:0 @ 0x7f30c40da400] Error reinitializing filters!
[vf#0:0 @ 0x7f30c40da400] Task finished with error code: -38 (Function not implemented)
[vf#0:0 @ 0x7f30c40da400] Terminating thread with return code -38 (Function not implemented)
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] [enc:mjpeg_qsv @ 0x7f30c4016f80] Encoder thread received EOF
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] [enc:mjpeg_qsv @ 0x7f30c4016f80] Could not open encoder before EOF
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] Task finished with error code: -22 (Invalid argument)
[vost#0:0/mjpeg_qsv @ 0x7f30c40cfb80] Terminating thread with return code -22 (Invalid argument)
[in#0/matroska,webm @ 0x7f30c4012b00] EOF while reading input
[in#0/matroska,webm @ 0x7f30c4012b00] Terminating thread with return code 0 (success)
[vist#0:3/png @ 0x7f30c40b3080] [dec:png @ 0x7f30c4012d80] Decoder thread received EOF packet
[vist#0:3/png @ 0x7f30c40b3080] [dec:png @ 0x7f30c4012d80] Decoder returned EOF, finishing
[vist#0:3/png @ 0x7f30c40b3080] [dec:png @ 0x7f30c4012d80] Terminating thread with return code 0 (success)
[out#0/image2 @ 0x7f30c4103400] Nothing was written into output file, because at least one of its streams received no packets.
frame=    0 fps=0.0 q=0.0 Lsize=       0KiB time=N/A bitrate=N/A speed=N/A elapsed=0:00:20.97
[in#0/matroska,webm @ 0x7f30c4012b00] Input file #0 (file:/virtual/media/tv/episode.mkv):
[in#0/matroska,webm @ 0x7f30c4012b00]   Input stream #0:3 (video): 1 packets read (18749523 bytes); 1 frames decoded; 0 decode errors;
[in#0/matroska,webm @ 0x7f30c4012b00]   Total: 1 packets (18749523 bytes) demuxed
[AVIOContext @ 0x7f30c4012c40] Statistics: 2123168740 bytes read, 1 seeks
Conversion failed!

Exiting with exit code -38 
```

ffmpeg auto-selects the png stream instead of the expected video stream. This fix passes a flag to tell ffmpeg what stream to extract from