### PR TITLE
Preserve existing user data during reattachment

### DIFF
--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -227,19 +227,22 @@ public class ItemPersistenceService : IItemPersistenceService
                 await dbContext.UserData
                     .Where(e => e.ItemId == BaseItemRepository.PlaceholderId)
                     .Where(e => userKeys.Contains(e.CustomDataKey))
+                    .Where(e => !dbContext.UserData.Any(current =>
+                        current.ItemId == item.Id && current.UserId == e.UserId && current.CustomDataKey == e.CustomDataKey))
                     .ExecuteUpdateAsync(
                         e => e
                             .SetProperty(f => f.ItemId, item.Id)
                             .SetProperty(f => f.RetentionDate, retentionDate),
                         cancellationToken).ConfigureAwait(false);
 
-                item.UserData = await dbContext.UserData
+                var userData = await dbContext.UserData
                     .AsNoTracking()
                     .Where(e => e.ItemId == item.Id)
                     .ToArrayAsync(cancellationToken)
                     .ConfigureAwait(false);
 
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                item.UserData = userData;
             }
         }
     }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceReattachUserDataConcurrencyTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceReattachUserDataConcurrencyTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Data.Common;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Locking;
+using Jellyfin.Database.Providers.Sqlite;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class ItemPersistenceServiceReattachUserDataConcurrencyTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReattachUserDataAsync_OverlappingPlaybackSave_PreservesPlaybackData(bool reattachmentFirst)
+    {
+        var directory = Directory.CreateTempSubdirectory("jellyfin-reattachment-");
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = Path.Combine(directory.FullName, "jellyfin.db"),
+            Pooling = false,
+            DefaultTimeout = 5
+        }.ToString();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+        var cancellationToken = timeout.Token;
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarting = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = Task.CompletedTask;
+        var second = Task.CompletedTask;
+
+        try
+        {
+            var item = new Folder { Id = Guid.NewGuid() };
+            var user = new User("user", "auth-provider", "reset-provider");
+            var key = item.GetUserDataKeys()[0];
+            var retentionDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+            await using (var context = CreateContext(connectionString))
+            {
+                await context.Database.EnsureCreatedAsync(cancellationToken);
+                context.Users.Add(user);
+                context.BaseItems.Add(new BaseItemEntity { Id = item.Id, Type = typeof(Folder).FullName!, IsFolder = true });
+                context.UserData.Add(new UserData
+                {
+                    ItemId = BaseItemRepository.PlaceholderId,
+                    Item = null,
+                    UserId = user.Id,
+                    User = null,
+                    CustomDataKey = key,
+                    RetentionDate = retentionDate,
+                    PlaybackPositionTicks = 1234,
+                    Rating = 2
+                });
+                await context.SaveChangesAsync(cancellationToken);
+            }
+
+            var reattachmentFactory = CreateFactory(
+                connectionString,
+                new TransactionOrderInterceptor(reattachmentFirst, firstStarted, secondStarting, cancellationToken));
+            var playbackFactory = CreateFactory(
+                connectionString,
+                new TransactionOrderInterceptor(!reattachmentFirst, firstStarted, secondStarting, cancellationToken));
+            var service = new ItemPersistenceService(
+                reattachmentFactory,
+                Mock.Of<IServerApplicationHost>(),
+                NullLogger<ItemPersistenceService>.Instance);
+            var configuration = new Mock<IServerConfigurationManager>();
+            configuration.SetupGet(e => e.Configuration).Returns(new ServerConfiguration());
+            var manager = new UserDataManager(configuration.Object, playbackFactory);
+            var playbackData = new UserItemData
+            {
+                Key = key,
+                PlaybackPositionTicks = 9876,
+                IsFavorite = true,
+                Rating = 9,
+                PlayCount = 3
+            };
+            Func<Task> reattach = () => service.ReattachUserDataAsync(item, cancellationToken);
+            Func<Task> savePlayback = () =>
+            {
+                manager.SaveUserData(user, item, playbackData, UserDataSaveReason.PlaybackProgress, cancellationToken);
+                return Task.CompletedTask;
+            };
+
+            // Hold the first transaction until the other connection starts its transaction.
+            // SQLite must serialize these writers without either operation losing user data.
+            first = Task.Run(reattachmentFirst ? reattach : savePlayback, cancellationToken);
+            await firstStarted.Task.WaitAsync(cancellationToken);
+            second = Task.Run(reattachmentFirst ? savePlayback : reattach, cancellationToken);
+            await Task.WhenAll(first, second).WaitAsync(cancellationToken);
+
+            await using var after = CreateContext(connectionString);
+            var current = await after.UserData.SingleAsync(e => e.ItemId.Equals(item.Id), cancellationToken);
+            Assert.Equal(playbackData.PlaybackPositionTicks, current.PlaybackPositionTicks);
+            Assert.Equal(playbackData.IsFavorite, current.IsFavorite);
+            Assert.Equal(playbackData.Rating, current.Rating);
+            Assert.Equal(playbackData.PlayCount, current.PlayCount);
+            Assert.Null(current.RetentionDate);
+            var retained = await after.UserData.Where(e => e.ItemId.Equals(BaseItemRepository.PlaceholderId))
+                .ToArrayAsync(cancellationToken);
+            if (reattachmentFirst)
+            {
+                Assert.Empty(retained);
+            }
+            else
+            {
+                Assert.Equal(retentionDate, Assert.Single(retained).RetentionDate);
+                Assert.Equal(1234, retained[0].PlaybackPositionTicks);
+                Assert.Equal(2, retained[0].Rating);
+            }
+        }
+        finally
+        {
+            secondStarting.TrySetResult();
+            try
+            {
+                await Task.WhenAll(first, second);
+            }
+            finally
+            {
+                directory.Delete(true);
+            }
+        }
+    }
+
+    private static JellyfinDbContext CreateContext(string connectionString, params IInterceptor[] interceptors) => new(
+        new DbContextOptionsBuilder<JellyfinDbContext>().UseSqlite(connectionString).AddInterceptors(interceptors).Options,
+        NullLogger<JellyfinDbContext>.Instance,
+        new SqliteDatabaseProvider(Mock.Of<IApplicationPaths>(), NullLogger<SqliteDatabaseProvider>.Instance),
+        new NoLockBehavior(NullLogger<NoLockBehavior>.Instance));
+
+    private static IDbContextFactory<JellyfinDbContext> CreateFactory(string connectionString, IInterceptor interceptor)
+    {
+        var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
+        factory.Setup(e => e.CreateDbContext()).Returns(() => CreateContext(connectionString, interceptor));
+        factory.Setup(e => e.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => CreateContext(connectionString, interceptor));
+        return factory.Object;
+    }
+
+    private sealed class TransactionOrderInterceptor(
+        bool first,
+        TaskCompletionSource firstStarted,
+        TaskCompletionSource secondStarting,
+        CancellationToken cancellationToken) : DbTransactionInterceptor
+    {
+        public override InterceptionResult<DbTransaction> TransactionStarting(
+            DbConnection connection, TransactionStartingEventData eventData, InterceptionResult<DbTransaction> result)
+        {
+            if (!first)
+            {
+                secondStarting.TrySetResult();
+            }
+
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbTransaction>> TransactionStartingAsync(
+            DbConnection connection,
+            TransactionStartingEventData eventData,
+            InterceptionResult<DbTransaction> result,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(TransactionStarting(connection, eventData, result));
+
+        public override DbTransaction TransactionStarted(
+            DbConnection connection, TransactionEndEventData eventData, DbTransaction result)
+        {
+            WaitForOtherTransaction().GetAwaiter().GetResult();
+            return result;
+        }
+
+        public override async ValueTask<DbTransaction> TransactionStartedAsync(
+            DbConnection connection,
+            TransactionEndEventData eventData,
+            DbTransaction result,
+            CancellationToken cancellationToken = default)
+        {
+            await WaitForOtherTransaction();
+            return result;
+        }
+
+        private Task WaitForOtherTransaction()
+        {
+            if (!first)
+            {
+                return Task.CompletedTask;
+            }
+
+            firstStarted.TrySetResult();
+            return secondStarting.Task.WaitAsync(cancellationToken);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceReattachUserDataTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ItemPersistenceServiceReattachUserDataTests.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Emby.Server.Implementations.Library;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using AudioBook = MediaBrowser.Controller.Entities.AudioBook;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class ItemPersistenceServiceReattachUserDataTests : SqliteDbTestFixture
+{
+    private readonly ItemPersistenceService _service;
+    private readonly CommitFailureInterceptor _commitFailure;
+    private readonly AudioBook _item = new()
+    {
+        Id = Guid.NewGuid(),
+        Name = "Book",
+        Album = "Series",
+        AlbumArtists = ["Author"],
+        IndexNumber = 1
+    };
+
+    private readonly User _user = new("user", "auth-provider", "reset-provider");
+
+    public ItemPersistenceServiceReattachUserDataTests()
+        : this(new CommitFailureInterceptor())
+    {
+    }
+
+    private ItemPersistenceServiceReattachUserDataTests(CommitFailureInterceptor commitFailure)
+        : base(commitFailure)
+    {
+        _commitFailure = commitFailure;
+        _service = new ItemPersistenceService(
+            CreateDbContextFactory(),
+            Mock.Of<IServerApplicationHost>(),
+            NullLogger<ItemPersistenceService>.Instance);
+
+        using var context = CreateDbContext();
+        context.Users.Add(_user);
+        context.BaseItems.Add(new BaseItemEntity { Id = _item.Id, Type = typeof(AudioBook).FullName! });
+        context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_RetainedOnly_MovesMatchingRowsAndRefreshesItem()
+    {
+        var retained = CreateRetainedRow(_user.Id, _item.GetUserDataKeys()[0]);
+        var unrelated = CreateRetainedRow(_user.Id, "unrelated-key");
+        Seed(retained, unrelated);
+
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+
+        using var context = CreateDbContext();
+        AssertRow(retained, Assert.Single(context.UserData.Where(e => e.ItemId.Equals(_item.Id))), _item.Id);
+        AssertRow(unrelated, Assert.Single(context.UserData.Where(e => e.ItemId.Equals(BaseItemRepository.PlaceholderId))));
+        AssertRow(retained, Assert.Single(_item.UserData), _item.Id);
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_ExistingDestination_PreservesBothRowsOnRepeatedCalls()
+    {
+        var retained = CreateRetainedRow(_user.Id, _item.GetUserDataKeys()[0]);
+        var current = CreateCurrentRow(retained.CustomDataKey);
+        Seed(retained, current);
+
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+
+        using var context = CreateDbContext();
+        Assert.Equal(2, context.UserData.Count());
+        AssertRow(retained, Assert.Single(context.UserData.Where(e => e.ItemId.Equals(BaseItemRepository.PlaceholderId))));
+        AssertRow(current, Assert.Single(context.UserData.Where(e => e.ItemId.Equals(_item.Id))));
+        AssertRow(current, Assert.Single(_item.UserData));
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_MixedUsersAndKeys_SkipsOnlyTheConflictingTuple()
+    {
+        var otherUser = new User("other-user", "auth-provider", "reset-provider");
+        using (var context = CreateDbContext())
+        {
+            context.Users.Add(otherUser);
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var keys = _item.GetUserDataKeys();
+        var conflicting = CreateRetainedRow(_user.Id, keys[0]);
+        var current = CreateCurrentRow(keys[0]);
+        var otherKey = CreateRetainedRow(_user.Id, keys[1]);
+        var otherUsersPrimary = CreateRetainedRow(otherUser.Id, keys[0]);
+        var otherUsersFallback = CreateRetainedRow(otherUser.Id, keys[1]);
+        Seed(conflicting, current, otherKey, otherUsersPrimary, otherUsersFallback);
+
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+
+        using var after = CreateDbContext();
+        Assert.Equal(5, after.UserData.Count());
+        AssertRow(conflicting, Assert.Single(after.UserData.Where(e => e.ItemId.Equals(BaseItemRepository.PlaceholderId))));
+        var attached = after.UserData.Where(e => e.ItemId.Equals(_item.Id)).ToDictionary(e => (e.UserId, e.CustomDataKey));
+        Assert.Equal(4, attached.Count);
+        AssertRow(current, attached[(_user.Id, keys[0])]);
+        foreach (var row in new[] { otherKey, otherUsersPrimary, otherUsersFallback })
+        {
+            AssertRow(row, attached[(row.UserId, row.CustomDataKey)], _item.Id);
+        }
+
+        Assert.Equal(attached.Count, _item.UserData.Count);
+        foreach (var row in _item.UserData)
+        {
+            AssertRow(attached[(row.UserId, row.CustomDataKey)], row);
+        }
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_NoRetainedRows_RefreshesExistingItemData()
+    {
+        var current = CreateCurrentRow(_item.GetUserDataKeys()[0]);
+        Seed(current);
+
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+
+        AssertRow(current, Assert.Single(_item.UserData));
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_Cancelled_DoesNotChangeDatabaseOrItemData()
+    {
+        var retained = CreateRetainedRow(_user.Id, _item.GetUserDataKeys()[0]);
+        Seed(retained);
+        _item.UserData = [CreateCurrentRow(retained.CustomDataKey)];
+        var originalItemData = _item.UserData;
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _service.ReattachUserDataAsync(_item, cancellation.Token));
+
+        using var context = CreateDbContext();
+        AssertRow(retained, Assert.Single(context.UserData));
+        Assert.Same(originalItemData, _item.UserData);
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_CommitFails_RollsBackAndKeepsOriginalItemData()
+    {
+        var retained = CreateRetainedRow(_user.Id, _item.GetUserDataKeys()[0]);
+        Seed(retained);
+        _item.UserData = [CreateCurrentRow(retained.CustomDataKey)];
+        var originalItemData = _item.UserData;
+        _commitFailure.FailCommit = true;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken));
+
+        Assert.Equal("Injected commit failure", exception.Message);
+        Assert.Equal(1, _commitFailure.CommitAttempts);
+        using var context = CreateDbContext();
+        AssertRow(retained, Assert.Single(context.UserData));
+        Assert.Same(originalItemData, _item.UserData);
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_CancelledAtCommit_RollsBackAndKeepsOriginalItemData()
+    {
+        var retained = CreateRetainedRow(_user.Id, _item.GetUserDataKeys()[0]);
+        Seed(retained);
+        _item.UserData = [CreateCurrentRow(retained.CustomDataKey)];
+        var originalItemData = _item.UserData;
+        using var cancellation = new CancellationTokenSource();
+        _commitFailure.CancelAtCommit = cancellation;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _service.ReattachUserDataAsync(_item, cancellation.Token));
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal(1, _commitFailure.CommitAttempts);
+        using var context = CreateDbContext();
+        AssertRow(retained, Assert.Single(context.UserData));
+        Assert.Same(originalItemData, _item.UserData);
+    }
+
+    [Fact]
+    public async Task ReattachUserDataAsync_RetainedPrimaryAndCurrentFallback_PreservesExistingKeyPrecedence()
+    {
+        var keys = _item.GetUserDataKeys();
+        var retained = CreateRetainedRow(_user.Id, keys[0]);
+        var current = CreateCurrentRow(keys[1]);
+        Seed(retained, current);
+
+        await _service.ReattachUserDataAsync(_item, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, _item.UserData.Count);
+        AssertRow(current, Assert.Single(_item.UserData, e => e.CustomDataKey == keys[1]));
+        AssertRow(retained, Assert.Single(_item.UserData, e => e.CustomDataKey == keys[0]), _item.Id);
+
+        // Reattachment preserves rows by key; the existing read path still prefers the primary key.
+        var configuration = new Mock<IServerConfigurationManager>();
+        configuration.SetupGet(e => e.Configuration).Returns(new ServerConfiguration());
+        var manager = new UserDataManager(configuration.Object, CreateDbContextFactory());
+        var resolved = manager.GetUserData(_user, _item);
+        Assert.NotNull(resolved);
+        Assert.Equal(keys[0], resolved.Key);
+        Assert.Equal(retained.PlaybackPositionTicks, resolved.PlaybackPositionTicks);
+    }
+
+    private static UserData CreateRetainedRow(Guid userId, string key) => new()
+    {
+        ItemId = BaseItemRepository.PlaceholderId,
+        Item = null,
+        UserId = userId,
+        User = null,
+        CustomDataKey = key,
+        RetentionDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        IsFavorite = false,
+        Rating = 2,
+        Likes = false,
+        PlaybackPositionTicks = 1234,
+        PlayCount = 1,
+        Played = false,
+        LastPlayedDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        AudioStreamIndex = 1,
+        SubtitleStreamIndex = 2
+    };
+
+    private UserData CreateCurrentRow(string key) => new()
+    {
+        ItemId = _item.Id,
+        Item = null,
+        UserId = _user.Id,
+        User = null,
+        CustomDataKey = key,
+        IsFavorite = true,
+        Rating = 9,
+        Likes = true,
+        PlaybackPositionTicks = 9876,
+        PlayCount = 3,
+        Played = true,
+        LastPlayedDate = new DateTime(2026, 9, 8, 0, 0, 0, DateTimeKind.Utc),
+        AudioStreamIndex = 3,
+        SubtitleStreamIndex = 4
+    };
+
+    private static void AssertRow(UserData expected, UserData actual, Guid? attachedItemId = null)
+    {
+        Assert.Equal(attachedItemId ?? expected.ItemId, actual.ItemId);
+        Assert.Equal(attachedItemId.HasValue ? null : expected.RetentionDate, actual.RetentionDate);
+        Assert.Equal(expected.UserId, actual.UserId);
+        Assert.Equal(expected.CustomDataKey, actual.CustomDataKey);
+        Assert.Equal(expected.IsFavorite, actual.IsFavorite);
+        Assert.Equal(expected.Rating, actual.Rating);
+        Assert.Equal(expected.Likes, actual.Likes);
+        Assert.Equal(expected.PlaybackPositionTicks, actual.PlaybackPositionTicks);
+        Assert.Equal(expected.PlayCount, actual.PlayCount);
+        Assert.Equal(expected.Played, actual.Played);
+        Assert.Equal(expected.LastPlayedDate, actual.LastPlayedDate);
+        Assert.Equal(expected.AudioStreamIndex, actual.AudioStreamIndex);
+        Assert.Equal(expected.SubtitleStreamIndex, actual.SubtitleStreamIndex);
+    }
+
+    private void Seed(params UserData[] rows)
+    {
+        using var context = CreateDbContext();
+        context.UserData.AddRange(rows);
+        context.SaveChanges();
+    }
+
+    private sealed class CommitFailureInterceptor : DbTransactionInterceptor
+    {
+        public bool FailCommit { get; set; }
+
+        public CancellationTokenSource? CancelAtCommit { get; set; }
+
+        public int CommitAttempts { get; private set; }
+
+        public override async ValueTask<InterceptionResult> TransactionCommittingAsync(
+            DbTransaction transaction,
+            TransactionEventData eventData,
+            InterceptionResult result,
+            CancellationToken cancellationToken = default)
+        {
+            CommitAttempts++;
+            if (FailCommit)
+            {
+                throw new InvalidOperationException("Injected commit failure");
+            }
+
+            if (CancelAtCommit is not null)
+            {
+                await CancelAtCommit.CancelAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/SqliteDbTestFixture.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/SqliteDbTestFixture.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Model.Configuration;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -26,7 +27,7 @@ public abstract class SqliteDbTestFixture : IDisposable
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
 
-    protected SqliteDbTestFixture()
+    protected SqliteDbTestFixture(params IInterceptor[] interceptors)
     {
         ApplicationPaths = new Mock<IApplicationPaths>().Object;
 
@@ -35,6 +36,7 @@ public abstract class SqliteDbTestFixture : IDisposable
 
         _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
             .UseSqlite(_connection)
+            .AddInterceptors(interceptors)
             .Options;
 
         using var context = CreateDbContext();


### PR DESCRIPTION
**Changes**
`ReattachUserDataAsync` can throw duplicate-key errors when the destination already has a row for the same user and custom key. Update now checks for an existing destination row before moving each placeholder. Non-conflicting rows still reattach, and in-memory data gets updated after transaction commits.

Added 10 sqlite regression cases covering reattachment, conflicts, rollback, cancellation and overlapping playback saves.

**Validation**
- Full release suite: 3779 passed / 8 skipped
- Duplicate-key failure reproduced on live server before applying fix
- Five scenarios tested and passed on my local server

**Code assistance**
Used OpenAI Codex to explain the code base and help write tests.

**Issues**
Related reports of same error:
- https://github.com/jellyfin/jellyfin/issues/15166#issuecomment-3835091658
- https://github.com/jellyfin/jellyfin/issues/15641#issuecomment-4361039078