### PR TITLE
Validate custom splashscreen uploads before saving

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -241,6 +241,7 @@
  - [m0g3r](https://github.com/m0g3r)
  - [martin-77](https://github.com/martin-77)
  - [Oggeb1](https://github.com/Oggeb1)
+ - [arcusbuilds](https://github.com/arcusbuilds)
 
 # Emby Contributors
 

--- a/Jellyfin.Api/Controllers/ImageController.cs
+++ b/Jellyfin.Api/Controllers/ImageController.cs
@@ -1715,7 +1715,7 @@ public class ImageController : BaseJellyfinApiController
     /// </summary>
     /// <returns>A <see cref="NoContentResult"/> indicating success.</returns>
     /// <response code="204">Successfully uploaded new splashscreen.</response>
-    /// <response code="400">Error reading MimeType from uploaded image.</response>
+    /// <response code="400">Error reading MimeType from uploaded image, or the image could not be decoded.</response>
     /// <response code="403">User does not have permission to upload splashscreen..</response>
     /// <exception cref="ArgumentException">Error reading the image format.</exception>
     [HttpPost("Branding/Splashscreen")]
@@ -1731,21 +1731,59 @@ public class ImageController : BaseJellyfinApiController
             return BadRequest("Incorrect ContentType.");
         }
 
-        var stream = GetFromBase64Stream(Request.Body);
-        await using (stream.ConfigureAwait(false))
+        // Decode into a temporary file first so a bad upload never replaces the current splashscreen or config.
+        Directory.CreateDirectory(_appPaths.TempDirectory);
+        var tempPath = Path.Combine(_appPaths.TempDirectory, "splashscreen-upload-" + Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture) + extension);
+        try
         {
+            var stream = GetFromBase64Stream(Request.Body);
+            await using (stream.ConfigureAwait(false))
+            {
+                var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
+                await using (fs.ConfigureAwait(false))
+                {
+                    await stream.CopyToAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+
+            ImageDimensions dimensions;
+            try
+            {
+                dimensions = _imageProcessor.GetImageDimensions(tempPath);
+            }
+            catch (NotImplementedException)
+            {
+                // No image encoder on this server (SkiaSharp unavailable); nothing to validate against.
+                dimensions = new ImageDimensions(1, 1);
+            }
+
+            if (dimensions.Width <= 0 || dimensions.Height <= 0)
+            {
+                return BadRequest("Unable to decode image.");
+            }
+
             var filePath = Path.Combine(_appPaths.DataPath, "splashscreen-upload" + extension);
+            System.IO.File.Move(tempPath, filePath, true);
+
             var brandingOptions = _serverConfigurationManager.GetConfiguration<BrandingOptions>("branding");
             brandingOptions.SplashscreenLocation = filePath;
             _serverConfigurationManager.SaveConfiguration("branding", brandingOptions);
 
-            var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, IODefaults.FileStreamBufferSize, FileOptions.Asynchronous);
-            await using (fs.ConfigureAwait(false))
-            {
-                await stream.CopyToAsync(fs, CancellationToken.None).ConfigureAwait(false);
-            }
-
             return NoContent();
+        }
+        finally
+        {
+            if (System.IO.File.Exists(tempPath))
+            {
+                try
+                {
+                    System.IO.File.Delete(tempPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Unable to remove temporary file '{TempPath}'", tempPath);
+                }
+            }
         }
     }
 

--- a/tests/Jellyfin.Server.Integration.Tests/Controllers/ImageControllerTests.cs
+++ b/tests/Jellyfin.Server.Integration.Tests/Controllers/ImageControllerTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Branding;
+using Microsoft.Extensions.DependencyInjection;
+using SkiaSharp;
+using Xunit;
+
+namespace Jellyfin.Server.Integration.Tests.Controllers;
+
+public sealed class ImageControllerTests : IClassFixture<JellyfinApplicationFactory>
+{
+    private const string SplashscreenUrl = "/Branding/Splashscreen";
+    private static string? _accessToken;
+    private readonly JellyfinApplicationFactory _factory;
+
+    public ImageControllerTests(JellyfinApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Theory]
+    [InlineData("image/png")] // mislabeled body
+    [InlineData("image/tiff")] // maps to an extension, so it clears the mime check; body still is not an image
+    public async Task UploadCustomSplashscreen_UndecodableBody_BadRequestAndConfigUntouched(string contentType)
+    {
+        var client = await GetAuthenticatedClientAsync();
+        var before = GetBrandingOptions().SplashscreenLocation;
+
+        var notAnImage = Encoding.UTF8.GetBytes("this is not an image");
+        using var content = new StringContent(Convert.ToBase64String(notAnImage), Encoding.UTF8, contentType);
+        using var response = await client.PostAsync(SplashscreenUrl, content, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(before, GetBrandingOptions().SplashscreenLocation);
+    }
+
+    [Fact]
+    public async Task UploadCustomSplashscreen_UnknownImageMimeType_BadRequest()
+    {
+        // image/jxl (the format from the issue) has no extension mapping, so it is rejected at the mime step.
+        var client = await GetAuthenticatedClientAsync();
+        var before = GetBrandingOptions().SplashscreenLocation;
+
+        using var content = new StringContent(Convert.ToBase64String(CreatePng()), Encoding.UTF8, "image/jxl");
+        using var response = await client.PostAsync(SplashscreenUrl, content, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(before, GetBrandingOptions().SplashscreenLocation);
+    }
+
+    [Fact]
+    public async Task UploadCustomSplashscreen_ValidPng_SavedAndServed()
+    {
+        var client = await GetAuthenticatedClientAsync();
+
+        using var content = new StringContent(Convert.ToBase64String(CreatePng()), Encoding.UTF8, "image/png");
+        using var uploadResponse = await client.PostAsync(SplashscreenUrl, content, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NoContent, uploadResponse.StatusCode);
+
+        var location = GetBrandingOptions().SplashscreenLocation;
+        Assert.NotNull(location);
+        Assert.True(File.Exists(location));
+
+        using var getResponse = await client.GetAsync(SplashscreenUrl, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.StartsWith("image/", getResponse.Content.Headers.ContentType?.MediaType, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UpdateBrandingConfiguration_ViaNamedConfigurationRoute_PreservesSplashscreenLocation()
+    {
+        // jellyfin-web saves the branding form by POSTing to /System/Configuration/branding with a DTO
+        // that has no SplashscreenLocation. The literal Configuration/Branding route must win over
+        // Configuration/{key}, otherwise the location is wiped on every save (issue step 3-4).
+        var client = await GetAuthenticatedClientAsync();
+
+        using var upload = new StringContent(Convert.ToBase64String(CreatePng()), Encoding.UTF8, "image/png");
+        using var uploadResponse = await client.PostAsync(SplashscreenUrl, upload, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NoContent, uploadResponse.StatusCode);
+        var location = GetBrandingOptions().SplashscreenLocation;
+        Assert.NotNull(location);
+
+        var dto = new BrandingOptionsDto { LoginDisclaimer = "hello", CustomCss = null, SplashscreenEnabled = true };
+        using var saveResponse = await client.PostAsJsonAsync("/System/Configuration/branding", dto, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.NoContent, saveResponse.StatusCode);
+
+        var after = GetBrandingOptions();
+        Assert.Equal(location, after.SplashscreenLocation);
+        Assert.Equal("hello", after.LoginDisclaimer);
+    }
+
+    private async Task<HttpClient> GetAuthenticatedClientAsync()
+    {
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.AddAuthHeader(_accessToken ??= await AuthHelper.CompleteStartupAsync(client));
+        return client;
+    }
+
+    private BrandingOptions GetBrandingOptions()
+        => _factory.Services.GetRequiredService<IServerConfigurationManager>().GetConfiguration<BrandingOptions>("branding");
+
+    private static byte[] CreatePng()
+    {
+        using var bitmap = new SKBitmap(2, 2);
+        bitmap.Erase(SKColors.Red);
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+}


### PR DESCRIPTION
**Changes**
The splashscreen upload endpoint saved the branding config before writing the file and never checked that the bytes were an image, so any `image/*` type that maps to an extension got persisted as the splashscreen, readable or not. Now the upload goes to a temp file, the image encoder has to read it, and only then is it moved into place and `SplashscreenLocation` saved. Bad uploads get a 400 and nothing changes on disk or in config. Servers without an image encoder behave as before, and integration tests cover the upload plus a check that saving the branding form keeps the location.

**Code assistance**
I used Claude Code to trace the code paths and draft the change and tests, then reviewed and ran everything locally.

**Issues**
Fixes #17666