### PR TITLE
Roll back failed database restores

### DIFF
--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -110,10 +110,11 @@ public class BackupService : IBackupService
             var manifestStream = await zipArchiveEntry.OpenAsync().ConfigureAwait(false);
             await using (manifestStream.ConfigureAwait(false))
             {
-                manifest = await JsonSerializer.DeserializeAsync<BackupManifest>(manifestStream, _serializerSettings).ConfigureAwait(false);
+                manifest = await JsonSerializer.DeserializeAsync<BackupManifest>(manifestStream, _serializerSettings).ConfigureAwait(false)
+                    ?? throw new InvalidOperationException("Cannot restore backup with an empty manifest.");
             }
 
-            if (manifest!.ServerVersion > _applicationHost.ApplicationVersion) // newer versions of Jellyfin should be able to load older versions as we have migrations.
+            if (manifest.ServerVersion > _applicationHost.ApplicationVersion) // newer versions of Jellyfin should be able to load older versions as we have migrations.
             {
                 throw new NotSupportedException($"The loaded archive '{archivePath}' is made for a newer version of Jellyfin ({manifest.ServerVersion}) and cannot be loaded in this version.");
             }
@@ -152,11 +153,14 @@ public class BackupService : IBackupService
                 }
             }
 
-            CopyDirectory("Config", _applicationPaths.ConfigurationDirectoryPath);
-            CopyDirectory("Data", _applicationPaths.DataPath, exclude: ["metadata", "metadata-default"]);
-            CopyDirectory("Root", _applicationPaths.RootFolderPath);
-            CopyDirectory("Data/metadata", _applicationPaths.InternalMetadataPath);
-            CopyDirectory("Data/metadata-default", _applicationPaths.DefaultInternalMetadataPath);
+            void RestoreFiles()
+            {
+                CopyDirectory("Config", _applicationPaths.ConfigurationDirectoryPath);
+                CopyDirectory("Data", _applicationPaths.DataPath, exclude: ["metadata", "metadata-default"]);
+                CopyDirectory("Root", _applicationPaths.RootFolderPath);
+                CopyDirectory("Data/metadata", _applicationPaths.InternalMetadataPath);
+                CopyDirectory("Data/metadata-default", _applicationPaths.DefaultInternalMetadataPath);
+            }
 
             if (manifest.Options.Database)
             {
@@ -164,94 +168,111 @@ public class BackupService : IBackupService
                 var dbContext = await _dbProvider.CreateDbContextAsync().ConfigureAwait(false);
                 await using (dbContext.ConfigureAwait(false))
                 {
-                    // restore migration history manually
-                    var historyEntry = zipArchive.GetEntry(NormalizePathSeparator(Path.Combine("Database", $"{nameof(HistoryRow)}.json")));
-                    if (historyEntry is null)
-                    {
-                        _logger.LogInformation("No backup of the history table in archive. This is required for Jellyfin operation");
-                        throw new InvalidOperationException("Cannot restore backup that has no History data.");
-                    }
+                    var entityTypes = typeof(JellyfinDbContext).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                        .Where(e => e.PropertyType.IsAssignableTo(typeof(IQueryable)))
+                        .Select(e => (Type: e.PropertyType.GetGenericArguments()[0], SourceName: dbContext.Model.FindEntityType(e.PropertyType.GetGenericArguments()[0])!.GetSchemaQualifiedTableName()!))
+                        .ToArray();
+                    ValidateDatabaseEntries(zipArchive, manifest, entityTypes.Select(e => e.SourceName));
 
+                    var historyEntry = zipArchive.GetEntry($"Database/{nameof(HistoryRow)}.json")!;
                     HistoryRow[] historyEntries;
                     var historyArchive = await historyEntry.OpenAsync().ConfigureAwait(false);
                     await using (historyArchive.ConfigureAwait(false))
                     {
-                        historyEntries = await JsonSerializer.DeserializeAsync<HistoryRow[]>(historyArchive).ConfigureAwait(false) ??
-                            throw new InvalidOperationException("Cannot restore backup that has no History data.");
+                        historyEntries = await JsonSerializer.DeserializeAsync<HistoryRow[]>(historyArchive).ConfigureAwait(false)
+                            ?? throw new InvalidOperationException("Cannot restore backup that has no History data.");
                     }
-
-                    var historyRepository = dbContext.GetService<IHistoryRepository>();
-                    await historyRepository.CreateIfNotExistsAsync().ConfigureAwait(false);
-
-                    foreach (var item in await historyRepository.GetAppliedMigrationsAsync(CancellationToken.None).ConfigureAwait(false))
-                    {
-                        var insertScript = historyRepository.GetDeleteScript(item.MigrationId);
-                        await dbContext.Database.ExecuteSqlRawAsync(insertScript).ConfigureAwait(false);
-                    }
-
-                    foreach (var item in historyEntries)
-                    {
-                        var insertScript = historyRepository.GetInsertScript(item);
-                        await dbContext.Database.ExecuteSqlRawAsync(insertScript).ConfigureAwait(false);
-                    }
-
-                    dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-                    var entityTypes = typeof(JellyfinDbContext).GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                        .Where(e => e.PropertyType.IsAssignableTo(typeof(IQueryable)))
-                        .Select(e => (Type: e, Set: e.GetValue(dbContext) as IQueryable))
-                        .ToArray();
-
-                    var tableNames = entityTypes.Select(f => dbContext.Model.FindEntityType(f.Type.PropertyType.GetGenericArguments()[0])!.GetSchemaQualifiedTableName()!);
-                    _logger.LogInformation("Begin purging database");
-                    await _jellyfinDatabaseProvider.PurgeDatabase(dbContext, tableNames).ConfigureAwait(false);
-                    _logger.LogInformation("Database Purged");
 
                     foreach (var entityType in entityTypes)
                     {
-                        _logger.LogInformation("Read backup of {Table}", entityType.Type.Name);
+                        _logger.LogInformation("Read backup of {Table}", entityType.SourceName);
 
-                        var zipEntry = zipArchive.GetEntry(NormalizePathSeparator(Path.Combine("Database", $"{entityType.Type.Name}.json")));
+                        var zipEntry = zipArchive.GetEntry($"Database/{entityType.SourceName}.json");
                         if (zipEntry is null)
                         {
-                            _logger.LogInformation("No backup of expected table {Table} is present in backup, continuing anyway", entityType.Type.Name);
+                            // Tables added since this backup was created have no rows to import.
                             continue;
                         }
 
                         var zipEntryStream = await zipEntry.OpenAsync().ConfigureAwait(false);
                         await using (zipEntryStream.ConfigureAwait(false))
                         {
-                            _logger.LogInformation("Restore backup of {Table}", entityType.Type.Name);
+                            _logger.LogInformation("Restore backup of {Table}", entityType.SourceName);
                             var records = 0;
                             await foreach (var item in JsonSerializer.DeserializeAsyncEnumerable<JsonObject>(zipEntryStream, _serializerSettings).ConfigureAwait(false))
                             {
-                                var entity = item.Deserialize(entityType.Type.PropertyType.GetGenericArguments()[0]);
+                                var entity = item?.Deserialize(entityType.Type);
                                 if (entity is null)
                                 {
                                     throw new InvalidOperationException($"Cannot deserialize entity '{item}'");
                                 }
 
-                                try
-                                {
-                                    records++;
-                                    dbContext.Add(entity);
-                                }
-                                catch (Exception ex)
-                                {
-                                    _logger.LogError(ex, "Could not store entity {Entity}, continuing anyway", item);
-                                }
+                                dbContext.Add(entity);
+                                records++;
                             }
 
-                            _logger.LogInformation("Prepared to restore {Number} entries for {Table}", records, entityType.Type.Name);
+                            _logger.LogInformation("Prepared to restore {Number} entries for {Table}", records, entityType.SourceName);
                         }
                     }
 
-                    _logger.LogInformation("Try restore Database");
-                    await dbContext.SaveChangesAsync().ConfigureAwait(false);
-                    _logger.LogInformation("Restored database");
+                    RestoreFiles();
+                    var transaction = await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false);
+                    await using (transaction.ConfigureAwait(false))
+                    {
+                        var historyRepository = dbContext.GetService<IHistoryRepository>();
+                        await historyRepository.CreateIfNotExistsAsync().ConfigureAwait(false);
+                        foreach (var item in await historyRepository.GetAppliedMigrationsAsync().ConfigureAwait(false))
+                        {
+                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetDeleteScript(item.MigrationId)).ConfigureAwait(false);
+                        }
+
+                        foreach (var item in historyEntries)
+                        {
+                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetInsertScript(item)).ConfigureAwait(false);
+                        }
+
+                        _logger.LogInformation("Begin purging database");
+                        await _jellyfinDatabaseProvider.PurgeDatabase(dbContext, entityTypes.Select(e => e.SourceName)).ConfigureAwait(false);
+                        _logger.LogInformation("Database Purged");
+                        await dbContext.SaveChangesAsync().ConfigureAwait(false);
+                        await transaction.CommitAsync().ConfigureAwait(false);
+                        _logger.LogInformation("Restored database");
+                    }
                 }
+            }
+            else
+            {
+                RestoreFiles();
             }
 
             _logger.LogInformation("Restored Jellyfin system from {Date}", manifest.DateCreated);
+        }
+    }
+
+    private static void ValidateDatabaseEntries(ZipArchive archive, BackupManifest manifest, IEnumerable<string> tableNames)
+    {
+        if (manifest.DatabaseTables is null || manifest.DatabaseTables.Length == 0)
+        {
+            throw new InvalidOperationException("Cannot restore backup with no database table manifest.");
+        }
+
+        var entries = archive.Entries
+            .Where(e => e.FullName.StartsWith("Database/", StringComparison.Ordinal) && e.FullName.EndsWith(".json", StringComparison.Ordinal))
+            .Select(e => e.FullName["Database/".Length..^".json".Length])
+            .ToHashSet(StringComparer.Ordinal);
+        var knownTables = tableNames.Append(nameof(HistoryRow)).ToHashSet(StringComparer.Ordinal);
+        var legacyManifest = manifest.DatabaseTables.All(e => e == typeof(DbSet<>).Name || e == nameof(HistoryRow));
+
+        // Older 0.2 archives recorded DbSet`1 instead of table names. Their table count still
+        // identifies a missing entry, without requiring tables introduced by later versions.
+        var expectedTables = legacyManifest ? entries : manifest.DatabaseTables.ToHashSet(StringComparer.Ordinal);
+        if (entries.Count != manifest.DatabaseTables.Length
+            || !entries.SetEquals(expectedTables)
+            || !entries.Contains(nameof(HistoryRow))
+            || !entries.IsSubsetOf(knownTables)
+            || archive.Entries.Count(e => e.FullName.StartsWith("Database/", StringComparison.Ordinal) && e.FullName.EndsWith(".json", StringComparison.Ordinal)) != entries.Count)
+        {
+            throw new InvalidOperationException("Cannot restore backup with missing, duplicate or unsupported database table entries.");
         }
     }
 
@@ -330,15 +351,15 @@ public class BackupService : IBackupService
                     var historyRepository = dbContext.GetService<IHistoryRepository>();
                     var migrations = await historyRepository.GetAppliedMigrationsAsync().ConfigureAwait(false);
 
-                    ICollection<(Type Type, string SourceName, Func<IAsyncEnumerable<object>> ValueFactory)> entityTypes =
+                    ICollection<(string SourceName, Func<IAsyncEnumerable<object>> ValueFactory)> entityTypes =
                     [
                         .. typeof(JellyfinDbContext)
                             .GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                             .Where(e => e.PropertyType.IsAssignableTo(typeof(IQueryable)))
-                            .Select(e => (Type: e.PropertyType, dbContext.Model.FindEntityType(e.PropertyType.GetGenericArguments()[0])!.GetSchemaQualifiedTableName()!, ValueFactory: new Func<IAsyncEnumerable<object>>(() => GetValues((IQueryable)e.GetValue(dbContext)!)))),
-                        (Type: typeof(HistoryRow), SourceName: nameof(HistoryRow), ValueFactory: () => migrations.ToAsyncEnumerable())
+                            .Select(e => (SourceName: dbContext.Model.FindEntityType(e.PropertyType.GetGenericArguments()[0])!.GetSchemaQualifiedTableName()!, ValueFactory: new Func<IAsyncEnumerable<object>>(() => GetValues((IQueryable)e.GetValue(dbContext)!)))),
+                        (SourceName: nameof(HistoryRow), ValueFactory: () => migrations.ToAsyncEnumerable())
                     ];
-                    manifest.DatabaseTables = entityTypes.Select(e => e.Type.Name).ToArray();
+                    manifest.DatabaseTables = entityTypes.Select(e => e.SourceName).ToArray();
                     var transaction = await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false);
 
                     await using (transaction.ConfigureAwait(false))

--- a/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
+++ b/Jellyfin.Server.Implementations/FullSystemBackup/BackupService.cs
@@ -110,7 +110,7 @@ public class BackupService : IBackupService
             var manifestStream = await zipArchiveEntry.OpenAsync().ConfigureAwait(false);
             await using (manifestStream.ConfigureAwait(false))
             {
-                manifest = await JsonSerializer.DeserializeAsync<BackupManifest>(manifestStream, _serializerSettings).ConfigureAwait(false)
+                manifest = await JsonSerializer.DeserializeAsync<BackupManifest>(manifestStream, _serializerSettings, CancellationToken.None).ConfigureAwait(false)
                     ?? throw new InvalidOperationException("Cannot restore backup with an empty manifest.");
             }
 
@@ -179,7 +179,7 @@ public class BackupService : IBackupService
                     var historyArchive = await historyEntry.OpenAsync().ConfigureAwait(false);
                     await using (historyArchive.ConfigureAwait(false))
                     {
-                        historyEntries = await JsonSerializer.DeserializeAsync<HistoryRow[]>(historyArchive).ConfigureAwait(false)
+                        historyEntries = await JsonSerializer.DeserializeAsync<HistoryRow[]>(historyArchive, cancellationToken: CancellationToken.None).ConfigureAwait(false)
                             ?? throw new InvalidOperationException("Cannot restore backup that has no History data.");
                     }
 
@@ -216,26 +216,26 @@ public class BackupService : IBackupService
                     }
 
                     RestoreFiles();
-                    var transaction = await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false);
+                    var transaction = await dbContext.Database.BeginTransactionAsync(CancellationToken.None).ConfigureAwait(false);
                     await using (transaction.ConfigureAwait(false))
                     {
                         var historyRepository = dbContext.GetService<IHistoryRepository>();
                         await historyRepository.CreateIfNotExistsAsync().ConfigureAwait(false);
-                        foreach (var item in await historyRepository.GetAppliedMigrationsAsync().ConfigureAwait(false))
+                        foreach (var item in await historyRepository.GetAppliedMigrationsAsync(CancellationToken.None).ConfigureAwait(false))
                         {
-                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetDeleteScript(item.MigrationId)).ConfigureAwait(false);
+                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetDeleteScript(item.MigrationId), CancellationToken.None).ConfigureAwait(false);
                         }
 
                         foreach (var item in historyEntries)
                         {
-                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetInsertScript(item)).ConfigureAwait(false);
+                            await dbContext.Database.ExecuteSqlRawAsync(historyRepository.GetInsertScript(item), CancellationToken.None).ConfigureAwait(false);
                         }
 
                         _logger.LogInformation("Begin purging database");
                         await _jellyfinDatabaseProvider.PurgeDatabase(dbContext, entityTypes.Select(e => e.SourceName)).ConfigureAwait(false);
                         _logger.LogInformation("Database Purged");
                         await dbContext.SaveChangesAsync().ConfigureAwait(false);
-                        await transaction.CommitAsync().ConfigureAwait(false);
+                        await transaction.CommitAsync(CancellationToken.None).ConfigureAwait(false);
                         _logger.LogInformation("Restored database");
                     }
                 }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -11,6 +11,8 @@ using MediaBrowser.Common.Configuration;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Database.Providers.Sqlite;
@@ -207,15 +209,16 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
     {
         ArgumentNullException.ThrowIfNull(tableNames);
 
-        var deleteQueries = new List<string>();
-        foreach (var tableName in tableNames)
-        {
-            deleteQueries.Add($"DELETE FROM \"{tableName}\";");
-        }
-
         // Defer checks until the entire import commits; disabling foreign_keys inside
         // a transaction has no effect.
-        var deleteAllQuery = $"PRAGMA defer_foreign_keys = ON;\n{string.Join('\n', deleteQueries)}";
+        var sqlGenerationHelper = dbContext.GetService<ISqlGenerationHelper>();
+        var deleteQueries = new List<string> { "PRAGMA defer_foreign_keys = ON;" };
+        foreach (var tableName in tableNames)
+        {
+            deleteQueries.Add($"DELETE FROM {sqlGenerationHelper.DelimitIdentifier(tableName)};");
+        }
+
+        var deleteAllQuery = string.Join('\n', deleteQueries);
         if (dbContext.Database.CurrentTransaction is not null)
         {
             await dbContext.Database.ExecuteSqlRawAsync(deleteAllQuery).ConfigureAwait(false);

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -215,13 +215,17 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
 
         // Defer checks until the entire import commits; disabling foreign_keys inside
         // a transaction has no effect.
-        await using var transaction = dbContext.Database.CurrentTransaction is null
-            ? await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false)
-            : null;
         var deleteAllQuery = $"PRAGMA defer_foreign_keys = ON;\n{string.Join('\n', deleteQueries)}";
-        await dbContext.Database.ExecuteSqlRawAsync(deleteAllQuery).ConfigureAwait(false);
-        if (transaction is not null)
+        if (dbContext.Database.CurrentTransaction is not null)
         {
+            await dbContext.Database.ExecuteSqlRawAsync(deleteAllQuery).ConfigureAwait(false);
+            return;
+        }
+
+        var transaction = await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false);
+        await using (transaction.ConfigureAwait(false))
+        {
+            await dbContext.Database.ExecuteSqlRawAsync(deleteAllQuery).ConfigureAwait(false);
             await transaction.CommitAsync().ConfigureAwait(false);
         }
     }

--- a/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
+++ b/src/Jellyfin.Database/Jellyfin.Database.Providers.Sqlite/SqliteDatabaseProvider.cs
@@ -213,13 +213,16 @@ public sealed class SqliteDatabaseProvider : IJellyfinDatabaseProvider
             deleteQueries.Add($"DELETE FROM \"{tableName}\";");
         }
 
-        var deleteAllQuery =
-        $"""
-        PRAGMA foreign_keys = OFF;
-        {string.Join('\n', deleteQueries)}
-        PRAGMA foreign_keys = ON;
-        """;
-
+        // Defer checks until the entire import commits; disabling foreign_keys inside
+        // a transaction has no effect.
+        await using var transaction = dbContext.Database.CurrentTransaction is null
+            ? await dbContext.Database.BeginTransactionAsync().ConfigureAwait(false)
+            : null;
+        var deleteAllQuery = $"PRAGMA defer_foreign_keys = ON;\n{string.Join('\n', deleteQueries)}";
         await dbContext.Database.ExecuteSqlRawAsync(deleteAllQuery).ConfigureAwait(false);
+        if (transaction is not null)
+        {
+            await transaction.CommitAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations;
@@ -15,6 +16,8 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.SystemBackupService;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -38,7 +41,7 @@ public sealed class BackupServiceTests : IDisposable
 
     public BackupServiceTests()
     {
-        _connection = new SqliteConnection("Data Source=:memory:");
+        _connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
         _connection.Open();
 
         _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
@@ -107,6 +110,14 @@ public sealed class BackupServiceTests : IDisposable
         Assert.True(File.Exists(manifest.Path));
 
         using var archive = await ZipFile.OpenReadAsync(manifest.Path, cancellationToken).ConfigureAwait(true);
+        await using (var manifestStream = await archive.GetEntry("manifest.json")!.OpenAsync(cancellationToken))
+        {
+            using var manifestDocument = await JsonDocument.ParseAsync(manifestStream, cancellationToken: cancellationToken);
+            var declaredTables = manifestDocument.RootElement.GetProperty("DatabaseTables").EnumerateArray().Select(e => e.GetString()).Order().ToArray();
+            var archivedTables = archive.Entries.Where(e => e.FullName.StartsWith("Database/", StringComparison.Ordinal)).Select(e => Path.GetFileNameWithoutExtension(e.Name)).Order().ToArray();
+            Assert.Equal(archivedTables, declaredTables);
+        }
+
         var keyframeEntry = archive.GetEntry("Database/KeyframeData.json");
         Assert.NotNull(keyframeEntry);
 
@@ -120,6 +131,178 @@ public sealed class BackupServiceTests : IDisposable
         Assert.Equal(validItemId, singleRow.GetProperty("ItemId").GetGuid());
     }
 
+    [Theory]
+    [InlineData("missing")]
+    [InlineData("malformed")]
+    [InlineData("duplicate")]
+    [InlineData("constraint")]
+    public async Task RestoreBackupAsync_InvalidDatabase_PreservesExistingDataAndHistory(string failure)
+    {
+        var archivePath = await CreateRestoreArchiveAsync();
+        using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
+        {
+            var entry = archive.GetEntry("Database/BaseItems.json")!;
+            JsonArray? items = null;
+            if (failure is "duplicate" or "constraint")
+            {
+                await using var stream = await entry.OpenAsync(TestContext.Current.CancellationToken);
+                items = (await JsonNode.ParseAsync(stream, cancellationToken: TestContext.Current.CancellationToken))!.AsArray();
+            }
+
+            entry.Delete();
+            if (failure != "missing")
+            {
+                await using var writer = new StreamWriter(await archive.CreateEntry("Database/BaseItems.json").OpenAsync(TestContext.Current.CancellationToken));
+                if (failure == "malformed")
+                {
+                    await writer.WriteAsync("[{".AsMemory(), TestContext.Current.CancellationToken);
+                }
+                else
+                {
+                    if (failure == "duplicate")
+                    {
+                        items!.Add(items[0]!.DeepClone());
+                    }
+                    else
+                    {
+                        items![0]!["ParentId"] = Guid.NewGuid();
+                    }
+
+                    await writer.WriteAsync(items.ToJsonString().AsMemory(), TestContext.Current.CancellationToken);
+                }
+            }
+        }
+
+        var exception = await Record.ExceptionAsync(() => CreateBackupService().RestoreBackupAsync(archivePath));
+
+        if (failure == "constraint")
+        {
+            Assert.True(exception is DbUpdateException or SqliteException, exception?.ToString());
+        }
+        else
+        {
+            Assert.IsType(failure == "malformed" ? typeof(JsonException) : typeof(InvalidOperationException), exception);
+        }
+
+        await AssertExistingDatabaseAsync();
+        if (failure != "constraint")
+        {
+            Assert.Equal("existing config", await File.ReadAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), TestContext.Current.CancellationToken));
+        }
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task RestoreBackupAsync_ValidDatabase_ReplacesRowsAndHistoryAndKeepsForeignKeysEnabled(bool legacyManifest, bool olderTables)
+    {
+        var archivePath = await CreateRestoreArchiveAsync();
+
+        if (legacyManifest)
+        {
+            await UseLegacyManifestAsync(archivePath, olderTables);
+        }
+
+        await CreateBackupService().RestoreBackupAsync(archivePath);
+
+        using var context = CreateDbContext();
+        Assert.Equal(new[] { "Archived Child", "Archived Movie" }, context.BaseItems.Where(e => e.Type != "PLACEHOLDER").OrderBy(e => e.Name).Select(e => e.Name).ToArray());
+        var link = Assert.Single(context.LinkedChildren);
+        Assert.Equal("Archived Movie", context.BaseItems.Single(e => e.Id.Equals(link.ParentId)).Name);
+        Assert.Equal("Archived Child", context.BaseItems.Single(e => e.Id.Equals(link.ChildId)).Name);
+        Assert.Equal("backup", Assert.Single(await context.GetService<IHistoryRepository>().GetAppliedMigrationsAsync(TestContext.Current.CancellationToken)).MigrationId);
+        Assert.Equal("archived config", await File.ReadAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), TestContext.Current.CancellationToken));
+        await AssertForeignKeysEnabledAsync(context);
+    }
+
+    [Fact]
+    public async Task RestoreBackupAsync_LegacyManifestMissingTable_RejectsBeforeReplacingData()
+    {
+        var archivePath = await CreateRestoreArchiveAsync();
+        await UseLegacyManifestAsync(archivePath, false);
+        using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
+        {
+            archive.GetEntry("Database/BaseItems.json")!.Delete();
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => CreateBackupService().RestoreBackupAsync(archivePath));
+
+        await AssertExistingDatabaseAsync();
+        Assert.Equal("existing config", await File.ReadAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), TestContext.Current.CancellationToken));
+    }
+
+    private static async Task UseLegacyManifestAsync(string archivePath, bool olderTables)
+    {
+        using var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken);
+        var entry = archive.GetEntry("manifest.json")!;
+        JsonObject manifest;
+        await using (var stream = await entry.OpenAsync(TestContext.Current.CancellationToken))
+        {
+            manifest = (await JsonNode.ParseAsync(stream, cancellationToken: TestContext.Current.CancellationToken))!.AsObject();
+        }
+
+        if (olderTables)
+        {
+            archive.GetEntry("Database/MediaSegments.json")!.Delete();
+        }
+
+        manifest["DatabaseTables"] = new JsonArray(archive.Entries
+            .Where(e => e.FullName.StartsWith("Database/", StringComparison.Ordinal))
+            .Select(e => (JsonNode)JsonValue.Create(e.Name == "HistoryRow.json" ? "HistoryRow" : "DbSet`1")!)
+            .ToArray());
+        entry.Delete();
+        await using var output = await archive.CreateEntry("manifest.json").OpenAsync(TestContext.Current.CancellationToken);
+        await JsonSerializer.SerializeAsync(output, manifest, cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    private async Task<string> CreateRestoreArchiveAsync()
+    {
+        using var context = CreateDbContext();
+        var archived = CreateMovieEntity(Guid.NewGuid(), "Archived Movie");
+        var archivedChild = CreateMovieEntity(Guid.NewGuid(), "Archived Child");
+        context.BaseItems.AddRange(archived, archivedChild);
+        context.LinkedChildren.Add(new LinkedChildEntity { ParentId = archived.Id, ChildId = archivedChild.Id, ChildType = LinkedChildType.Manual });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var history = context.GetService<IHistoryRepository>();
+        await history.CreateIfNotExistsAsync(TestContext.Current.CancellationToken);
+        await context.Database.ExecuteSqlRawAsync(history.GetInsertScript(new HistoryRow("backup", "10.0.0")), TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), "archived config", TestContext.Current.CancellationToken);
+        var archive = await CreateBackupService().CreateBackupAsync(new BackupOptionsDto());
+        context.ChangeTracker.Clear();
+        await context.LinkedChildren.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+        await context.BaseItems.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+        var existing = CreateMovieEntity(Guid.NewGuid(), "Existing Movie");
+        var existingChild = CreateMovieEntity(Guid.NewGuid(), "Existing Child");
+        context.BaseItems.AddRange(existing, existingChild);
+        context.LinkedChildren.Add(new LinkedChildEntity { ParentId = existing.Id, ChildId = existingChild.Id, ChildType = LinkedChildType.Manual });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        await context.Database.ExecuteSqlRawAsync(history.GetDeleteScript("backup"), TestContext.Current.CancellationToken);
+        await context.Database.ExecuteSqlRawAsync(history.GetInsertScript(new HistoryRow("existing", "10.0.0")), TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), "existing config", TestContext.Current.CancellationToken);
+        return archive.Path;
+    }
+
+    private async Task AssertExistingDatabaseAsync()
+    {
+        using var context = CreateDbContext();
+        Assert.Equal(new[] { "Existing Child", "Existing Movie" }, context.BaseItems.OrderBy(e => e.Name).Select(e => e.Name).ToArray());
+        Assert.Single(context.LinkedChildren);
+        Assert.Equal("existing", Assert.Single(await context.GetService<IHistoryRepository>().GetAppliedMigrationsAsync(TestContext.Current.CancellationToken)).MigrationId);
+        await AssertForeignKeysEnabledAsync(context);
+    }
+
+    private static async Task AssertForeignKeysEnabledAsync(JellyfinDbContext context)
+    {
+        await using var command = context.Database.GetDbConnection().CreateCommand();
+        command.CommandText = "PRAGMA foreign_keys;";
+        Assert.Equal(1L, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        command.CommandText = "PRAGMA defer_foreign_keys;";
+        Assert.Equal(0L, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        context.BaseItems.Add(new BaseItemEntity { Id = Guid.NewGuid(), Type = "Movie", ParentId = Guid.NewGuid() });
+        await Assert.ThrowsAsync<DbUpdateException>(() => context.SaveChangesAsync(TestContext.Current.CancellationToken));
+    }
+
     private BackupService CreateBackupService()
     {
         var factory = new Mock<IDbContextFactory<JellyfinDbContext>>();
@@ -131,15 +314,13 @@ public sealed class BackupServiceTests : IDisposable
 
         var applicationPaths = new Mock<IServerApplicationPaths>();
         applicationPaths.Setup(a => a.BackupPath).Returns(_backupPath);
+        applicationPaths.Setup(a => a.CachePath).Returns(Path.Combine(_testRoot, "Cache"));
+        applicationPaths.Setup(a => a.ProgramDataPath).Returns(_testRoot);
         applicationPaths.Setup(a => a.ConfigurationDirectoryPath).Returns(_configurationDirectoryPath);
         applicationPaths.Setup(a => a.DataPath).Returns(Path.Combine(_testRoot, "Data"));
         applicationPaths.Setup(a => a.RootFolderPath).Returns(Path.Combine(_testRoot, "Root"));
         applicationPaths.Setup(a => a.InternalMetadataPath).Returns(Path.Combine(_testRoot, "Metadata"));
         applicationPaths.Setup(a => a.DefaultInternalMetadataPath).Returns(Path.Combine(_testRoot, "MetadataDefault"));
-
-        var jellyfinDatabaseProvider = new Mock<IJellyfinDatabaseProvider>();
-        jellyfinDatabaseProvider.Setup(p => p.RunScheduledOptimisation(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        jellyfinDatabaseProvider.Setup(p => p.PurgeDatabase(It.IsAny<JellyfinDbContext>(), It.IsAny<System.Collections.Generic.IEnumerable<string>>())).Returns(Task.CompletedTask);
 
         var applicationLifetime = new Mock<IHostApplicationLifetime>();
 
@@ -151,7 +332,7 @@ public sealed class BackupServiceTests : IDisposable
             factory.Object,
             applicationHost.Object,
             applicationPaths.Object,
-            jellyfinDatabaseProvider.Object,
+            new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance),
             applicationLifetime.Object,
             libraryManager.Object);
     }

--- a/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
@@ -232,6 +232,25 @@ public sealed class BackupServiceTests : IDisposable
         Assert.Equal("existing config", await File.ReadAllTextAsync(Path.Combine(_configurationDirectoryPath, "system.xml"), TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task PurgeDatabase_QuotedTableName_RemovesRows()
+    {
+        await using var context = CreateDbContext();
+        await context.Database.ExecuteSqlRawAsync(
+            """"
+            CREATE TABLE "Restore ""items""" (Id INTEGER);
+            INSERT INTO "Restore ""items""" VALUES (1);
+            """",
+            TestContext.Current.CancellationToken);
+
+        var provider = new SqliteDatabaseProvider(null!, NullLogger<SqliteDatabaseProvider>.Instance);
+        await provider.PurgeDatabase(context, ["Restore \"items\""]);
+
+        await using var command = _connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM \"Restore \"\"items\"\"\";";
+        Assert.Equal(0L, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+    }
+
     private static async Task UseLegacyManifestAsync(string archivePath, bool olderTables)
     {
         await using var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken);

--- a/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/FullSystemBackup/BackupServiceTests.cs
@@ -109,7 +109,7 @@ public sealed class BackupServiceTests : IDisposable
 
         Assert.True(File.Exists(manifest.Path));
 
-        using var archive = await ZipFile.OpenReadAsync(manifest.Path, cancellationToken).ConfigureAwait(true);
+        await using var archive = await ZipFile.OpenReadAsync(manifest.Path, cancellationToken).ConfigureAwait(true);
         await using (var manifestStream = await archive.GetEntry("manifest.json")!.OpenAsync(cancellationToken))
         {
             using var manifestDocument = await JsonDocument.ParseAsync(manifestStream, cancellationToken: cancellationToken);
@@ -139,7 +139,7 @@ public sealed class BackupServiceTests : IDisposable
     public async Task RestoreBackupAsync_InvalidDatabase_PreservesExistingDataAndHistory(string failure)
     {
         var archivePath = await CreateRestoreArchiveAsync();
-        using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
+        await using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
         {
             var entry = archive.GetEntry("Database/BaseItems.json")!;
             JsonArray? items = null;
@@ -221,7 +221,7 @@ public sealed class BackupServiceTests : IDisposable
     {
         var archivePath = await CreateRestoreArchiveAsync();
         await UseLegacyManifestAsync(archivePath, false);
-        using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
+        await using (var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken))
         {
             archive.GetEntry("Database/BaseItems.json")!.Delete();
         }
@@ -234,7 +234,7 @@ public sealed class BackupServiceTests : IDisposable
 
     private static async Task UseLegacyManifestAsync(string archivePath, bool olderTables)
     {
-        using var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken);
+        await using var archive = await ZipFile.OpenAsync(archivePath, ZipArchiveMode.Update, TestContext.Current.CancellationToken);
         var entry = archive.GetEntry("manifest.json")!;
         JsonObject manifest;
         await using (var stream = await entry.OpenAsync(TestContext.Current.CancellationToken))


### PR DESCRIPTION
**Changes**
A failed restore can leave the database purged or migration history changed. Validate archive contents before modifying existing data, then restore rows and migration history in one transaction.

Defer SQLite foreign-key checks until commit and fix the table names written to backup manifests, while supporting older manifests. Rollback covers database changes; copied configuration and data files are not rolled back.

**Validation**
- Release build and all 9 backup/restore tests pass
- Full Release suite: 3779 passed / 8 skipped before removing two redundant tests
- Regression coverage includes invalid archives, legacy backups and rollback after a foreign-key failure

**Code assistance**
Used Codex to investigate the issue and write tests for the fix.

**Issues**
Related to #17449. This does not address schema initialization when restoring onto a new instance.