### PR TITLE
Fix transcode throttling not enabling on supported systems (caused by race condition)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -138,6 +138,7 @@
  - [SegiH](https://github.com/SegiH)
  - [SenorSmartyPants](https://github.com/SenorSmartyPants)
  - [shemanaev](https://github.com/shemanaev)
+ - [SimonvBez](https://github.com/SimonvBez)
  - [skaro13](https://github.com/skaro13)
  - [sl1288](https://github.com/sl1288)
  - [Smith00101010](https://github.com/Smith00101010)

--- a/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/EncoderValidator.cs
@@ -193,8 +193,6 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
         private readonly string _encoderPath;
 
-        private readonly Version _minFFmpegMultiThreadedCli = new Version(7, 0);
-
         public EncoderValidator(ILogger logger, string encoderPath)
         {
             _logger = logger;
@@ -552,9 +550,9 @@ namespace MediaBrowser.MediaEncoding.Encoder
             string output;
             try
             {
-                // With multi-threaded cli support, FFmpeg 7 is less sensitive to keyboard input
-                var duration = ffmpegVersion >= _minFFmpegMultiThreadedCli ? 10000 : 1000;
-                output = GetProcessOutput(_encoderPath, $"-hide_banner -f lavfi -i nullsrc=s=1x1:d={duration} -f null -", true, "?");
+                // Start a dummy encode of 1x1@1fps. Send '?' to stdin to get the help/keybind text, followed by 'q' to stop the job immediately
+                // As a safeguard in case 'q' doesn't stop the job, the dummy input has a max duration of 5 (realtime) seconds
+                output = GetProcessOutput(_encoderPath, $"-hide_banner -re -f lavfi -i nullsrc=s=1x1:r=1:d=5 -f null -", true, "?q");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://jellyfin.org/docs/general/contributing/issues/ page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Made the `CheckSupportedRuntimeKey()` function way more race condition resistent without increasing the runtime, as well as making it less resource intensive (by making the dummy job realtime).
This fixes transcode throttling not getting enabled on supported systems that completed the old dummy job so fast that ffmpeg was not able to write its runtime key commands to the stdout.

**Code assistance**
<!-- If code assistance was used, describe how it contributed
e.g., code generated by LLM, explanation of code base, debugging guidance. -->
Used ChatGPT to help understand what exactly all old ffmpeg arguments did.
NOT used for new code

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
Fixes #17905 (the issue also includes a root cause analysis)
