### PR TITLE
Allow local metadata providers for extras

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -597,7 +597,7 @@ namespace MediaBrowser.Providers.Manager
             // An extra is a local file belonging to another item and has no identity of its own in an
             // online database. Looking it up matches whatever the surrounding folder happens to be
             // called and overwrites the extra's name with a different item's title.
-            if (item.ExtraType.HasValue)
+            if (item.ExtraType.HasValue && provider is IRemoteMetadataProvider)
             {
                 return false;
             }


### PR DESCRIPTION
This PR enables local metadata providers for extras. This way, metadata for extras can be be provided using local nfo files.

**Changes**
Only remote metadata providers are disabled for extras, not all metadata providers (as it is the case before this change).

**Code assistance**
No code assistance used.

**Issues**
No issue has been opened for this change.
