### PR TITLE
Fix metadata provider order needing a restart to apply

### DIFF
--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -76,7 +76,8 @@ namespace MediaBrowser.Providers.Manager
 
         /// <summary>
         /// Cache for ordered metadata providers per library/item type combination.
-        /// Key: (LibraryPath, ItemTypeName, IncludeDisabled, ForceEnableInternetMetadata).
+        /// Key: (LibraryPath, ItemTypeName, IncludeDisabled, ForceEnableInternetMetadata), where
+        /// LibraryPath is the collection folder path the library options are stored against.
         /// Value: Array of ordered metadata providers (before per-item filtering).
         /// </summary>
         private readonly ConcurrentDictionary<MetadataProviderCacheKey, IMetadataProvider[]> _metadataProviderCache = new();
@@ -136,6 +137,7 @@ namespace MediaBrowser.Providers.Manager
             _similarItemsManager = similarItemsManager;
 
             CollectionFolder.LibraryOptionsUpdated += OnLibraryOptionsUpdated;
+            _configurationManager.ConfigurationUpdated += OnConfigurationUpdated;
         }
 
         /// <inheritdoc/>
@@ -476,15 +478,15 @@ namespace MediaBrowser.Providers.Manager
             return GetMetadataProvidersInternal<T>(item, libraryOptions, globalMetadataOptions, includeDisabled, false, libraryPath);
         }
 
-        private static string GetLibraryPathForItem(BaseItem item)
+        private string GetLibraryPathForItem(BaseItem item)
         {
             if (item is CollectionFolder collectionFolder)
             {
                 return collectionFolder.Path ?? string.Empty;
             }
 
-            var topParent = item.GetTopParent();
-            return topParent?.Path ?? string.Empty;
+            return _libraryManager.GetCollectionFolders(item)
+                .Find(folder => folder is CollectionFolder)?.Path ?? string.Empty;
         }
 
         /// <inheritdoc />
@@ -1314,6 +1316,7 @@ namespace MediaBrowser.Providers.Manager
             if (disposing)
             {
                 CollectionFolder.LibraryOptionsUpdated -= OnLibraryOptionsUpdated;
+                _configurationManager.ConfigurationUpdated -= OnConfigurationUpdated;
 
                 if (!_disposeCancellationTokenSource.IsCancellationRequested)
                 {
@@ -1341,6 +1344,11 @@ namespace MediaBrowser.Providers.Manager
             _logger.LogDebug("Invalidated metadata provider cache for library: {LibraryPath}", e.LibraryPath);
         }
 
+        private void OnConfigurationUpdated(object? sender, EventArgs e)
+        {
+            ClearMetadataProviderCache();
+        }
+
         internal void ClearMetadataProviderCache()
         {
             _metadataProviderCache.Clear();
@@ -1350,7 +1358,7 @@ namespace MediaBrowser.Providers.Manager
         /// <summary>
         /// Cache key for metadata provider lookups.
         /// </summary>
-        /// <param name="LibraryPath">The library path for the collection folder.</param>
+        /// <param name="LibraryPath">The path of the collection folder providing the library options.</param>
         /// <param name="ItemTypeName">The item type name.</param>
         /// <param name="IncludeDisabled">Whether to include disabled providers.</param>
         /// <param name="ForceEnableInternetMetadata">Whether internet metadata is force-enabled.</param>

--- a/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/ProviderManagerTests.cs
@@ -677,6 +677,8 @@ namespace Jellyfin.Providers.Tests.Manager
                 var libraryManagerMock = new Mock<ILibraryManager>(MockBehavior.Strict);
                 libraryManagerMock.Setup(i => i.GetLibraryOptions(It.IsAny<BaseItem>()))
                     .Returns(libraryOptions ?? new LibraryOptions());
+                libraryManagerMock.Setup(i => i.GetCollectionFolders(It.IsAny<BaseItem>()))
+                    .Returns(new List<Folder>());
                 libraryManager = libraryManagerMock.Object;
             }
 


### PR DESCRIPTION
The ordered metadata providers are cached per library, keyed by the path of the item's top parent. That top parent is the *physical* media folder of the library, while the library options and its event that invalidates the cache are keyed by the collection folder path under root/default. The two never match, so the cache was never invalidated and a changed metadata downloader order only took effect after a restart.

**Changes**
* Resolve the collection folder the same way the library options themselves are resolved
* Drop the cache when the server configuration changes, since the global MetadataOptions provide the fallback order

**Code assistance**

**Issues**
Fixes #17937
