### PR TITLE
Decode JPEGs at reduced size when resizing TMDb images

### DIFF
--- a/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
+++ b/src/Jellyfin.Drawing.Skia/SkiaEncoder.cs
@@ -30,6 +30,10 @@ public class SkiaEncoder : IImageEncoder
     private const float SharpenNeighborWeight = -0.1f;
 
     private static readonly HashSet<string> _transparentImageTypes = new(StringComparer.OrdinalIgnoreCase) { ".png", ".gif", ".webp" };
+
+    // The JPEG decoder also supports the other n/8 scales, but those lost detail compared to a full decode.
+    private static readonly float[] _jpegDecodeScales = [0.125f, 0.25f, 0.5f];
+
     private readonly ILogger<SkiaEncoder> _logger;
     private readonly IApplicationPaths _appPaths;
     private static readonly SKTypeface?[] _typefaces = InitializeTypefaces();
@@ -447,6 +451,92 @@ public class SkiaEncoder : IImageEncoder
         return Decode(path, false, orientation, out _);
     }
 
+    /// <summary>
+    /// Decode a JPEG at a reduced size when the requested output is much smaller than the image.
+    /// The JPEG decoder can produce 1/2, 1/4 or 1/8 of the full size for a fraction of the cost and memory of a full
+    /// decode, so the smallest of those that still covers the output is decoded and <see cref="ResizeImage"/> does the rest.
+    /// </summary>
+    /// <param name="path">The filepath of the image to decode.</param>
+    /// <param name="autoOrient">Whether to apply the EXIF orientation of the image.</param>
+    /// <param name="options">The processing options, used to determine the output size.</param>
+    /// <param name="originalSize">The full size of the oriented image, or <c>null</c> if no bitmap is returned.</param>
+    /// <returns>The decoded bitmap, or <c>null</c> if the image is not a JPEG or only a full decode covers the output.</returns>
+    internal SKBitmap? DecodeDownscaled(string path, bool autoOrient, ImageProcessingOptions options, out ImageDimensions? originalSize)
+    {
+        originalSize = null;
+
+        // Let Skia read the file: an exception thrown by a managed Stream while Skia is decoding cannot be caught
+        // and terminates the process, a failed native read just ends the decode.
+        var safePath = NormalizePath(path);
+        try
+        {
+            using var codec = SKCodec.Create(safePath, out var result);
+            return result == SKCodecResult.Success && codec.EncodedFormat == SKEncodedImageFormat.Jpeg
+                ? DecodeDownscaled(codec, autoOrient, options, out originalSize)
+                : null;
+        }
+        finally
+        {
+            if (!string.Equals(safePath, path, StringComparison.Ordinal))
+            {
+                try
+                {
+                    File.Delete(safePath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Unable to remove temporary file '{TempPath}'", safePath);
+                }
+            }
+        }
+    }
+
+    private SKBitmap? DecodeDownscaled(SKCodec codec, bool autoOrient, ImageProcessingOptions options, out ImageDimensions? originalSize)
+    {
+        originalSize = null;
+
+        var info = codec.Info;
+        var origin = autoOrient ? codec.EncodedOrigin : SKEncodedOrigin.TopLeft;
+        var swapAxes = origin is SKEncodedOrigin.LeftBottom or SKEncodedOrigin.LeftTop or SKEncodedOrigin.RightBottom or SKEncodedOrigin.RightTop;
+        var fullSize = swapAxes ? new ImageDimensions(info.Height, info.Width) : new ImageDimensions(info.Width, info.Height);
+        var outputSize = ImageHelper.GetNewImageSize(options, fullSize);
+
+        // Leave ResizeImage at least 1.5x to shrink, so it still goes through its mipmaps like it does from the full
+        // image. Decoding closer to the output size and resizing nearly 1:1 gave visibly softer results.
+        const double Headroom = 1.5;
+        var minWidth = Headroom * (swapAxes ? outputSize.Height : outputSize.Width);
+        var minHeight = Headroom * (swapAxes ? outputSize.Width : outputSize.Height);
+        var decodeSize = _jpegDecodeScales
+            .Select(codec.GetScaledDimensions)
+            .FirstOrDefault(size => size.Width >= minWidth && size.Height >= minHeight);
+        if (decodeSize.IsEmpty)
+        {
+            return null;
+        }
+
+        // Use the pixel format Decode would use: its SKCodec path (auto-orientation and Gray8) creates an
+        // opaque 32-bit bitmap, SKBitmap.Decode keeps the format of the codec.
+        var decodeInfo = autoOrient || info.ColorType == SKColorType.Gray8
+            ? new SKImageInfo(decodeSize.Width, decodeSize.Height, SKImageInfo.PlatformColorType, SKAlphaType.Opaque)
+            : info.WithSize(decodeSize.Width, decodeSize.Height);
+        var bitmap = SKBitmap.Decode(codec, decodeInfo);
+        if (bitmap is null)
+        {
+            return null;
+        }
+
+        originalSize = fullSize;
+        if (origin == SKEncodedOrigin.TopLeft)
+        {
+            return bitmap;
+        }
+
+        using (bitmap)
+        {
+            return OrientImage(bitmap, origin);
+        }
+    }
+
     private SKBitmap? GetBitmapFromSvg(string path)
     {
         if (!File.Exists(path))
@@ -553,32 +643,40 @@ public class SkiaEncoder : IImageEncoder
     /// <param name="targetInfo">This specifies the target size and other information required to create the surface.</param>
     /// <param name="isAntialias">This enables anti-aliasing on the SKPaint instance.</param>
     /// <param name="isDither">This enables dithering on the SKPaint instance.</param>
-    /// <returns>The resized image.</returns>
-    internal static SKImage ResizeImage(SKBitmap source, SKImageInfo targetInfo, bool isAntialias = false, bool isDither = false)
+    /// <returns>The resized bitmap.</returns>
+    internal static SKBitmap ResizeImage(SKBitmap source, SKImageInfo targetInfo, bool isAntialias = false, bool isDither = false)
     {
-        using var target = new SKBitmap(targetInfo);
-        using var canvas = new SKCanvas(target);
-        using var paint = new SKPaint();
-        paint.IsAntialias = isAntialias;
-        paint.IsDither = isDither;
+        var target = new SKBitmap(targetInfo);
+        try
+        {
+            using var canvas = new SKCanvas(target);
+            using var paint = new SKPaint();
+            paint.IsAntialias = isAntialias;
+            paint.IsDither = isDither;
 
-        // Historically, kHigh implied cubic filtering, but only when upsampling.
-        // If specified kHigh, and were down-sampling, Skia used to switch back to kMedium (bilinear filtering plus mipmaps).
-        // With current skia API, passing Mitchell cubic when down-sampling will cause serious quality degradation.
-        var samplingOptions = source.Width > targetInfo.Width || source.Height > targetInfo.Height
-            ? DefaultSamplingOptions
-            : UpscaleSamplingOptions;
+            // Historically, kHigh implied cubic filtering, but only when upsampling.
+            // If specified kHigh, and were down-sampling, Skia used to switch back to kMedium (bilinear filtering plus mipmaps).
+            // With current skia API, passing Mitchell cubic when down-sampling will cause serious quality degradation.
+            var samplingOptions = source.Width > targetInfo.Width || source.Height > targetInfo.Height
+                ? DefaultSamplingOptions
+                : UpscaleSamplingOptions;
 
-        canvas.DrawBitmap(
-            source,
-            SKRect.Create(0, 0, source.Width, source.Height),
-            SKRect.Create(0, 0, targetInfo.Width, targetInfo.Height),
-            samplingOptions,
-            paint);
+            canvas.DrawBitmap(
+                source,
+                SKRect.Create(0, 0, source.Width, source.Height),
+                SKRect.Create(0, 0, targetInfo.Width, targetInfo.Height),
+                samplingOptions,
+                paint);
 
-        SharpenInPlace(target);
+            SharpenInPlace(target);
 
-        return SKImage.FromBitmap(target);
+            return target;
+        }
+        catch
+        {
+            target.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -673,16 +771,18 @@ public class SkiaEncoder : IImageEncoder
         var blur = options.Blur ?? 0;
         var hasIndicator = options.UnplayedCount.HasValue || !options.PercentPlayed.Equals(0);
 
+        // Only set when the image is decoded at a reduced size, otherwise the bitmap has the original size.
+        ImageDimensions? fullImageSize = null;
         using var bitmap = inputFormat.Equals(SvgFormat, StringComparison.OrdinalIgnoreCase)
             ? GetBitmapFromSvg(inputPath)
-            : GetBitmap(inputPath, autoOrient, orientation);
+            : (DecodeDownscaled(inputPath, autoOrient, options, out fullImageSize) ?? GetBitmap(inputPath, autoOrient, orientation));
 
         if (bitmap is null)
         {
             throw new InvalidDataException($"Skia unable to read image {inputPath}");
         }
 
-        var originalImageSize = new ImageDimensions(bitmap.Width, bitmap.Height);
+        var originalImageSize = fullImageSize ?? new ImageDimensions(bitmap.Width, bitmap.Height);
 
         if (options.HasDefaultOptions(inputPath, originalImageSize) && !autoOrient)
         {
@@ -695,10 +795,9 @@ public class SkiaEncoder : IImageEncoder
         var width = newImageSize.Width;
         var height = newImageSize.Height;
 
-        // scale image (the FromImage creates a copy)
+        // scale image
         var imageInfo = new SKImageInfo(width, height, bitmap.ColorType, bitmap.AlphaType, bitmap.ColorSpace);
-        using var resizedImage = ResizeImage(bitmap, imageInfo);
-        using var resizedBitmap = SKBitmap.FromImage(resizedImage);
+        using var resizedBitmap = ResizeImage(bitmap, imageInfo);
 
         // If all we're doing is resizing then we can stop now
         if (!hasBackgroundColor && !hasForegroundColor && blur == 0 && !hasIndicator)
@@ -706,7 +805,6 @@ public class SkiaEncoder : IImageEncoder
             var outputDirectory = Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath));
             Directory.CreateDirectory(outputDirectory);
             using var outputStream = new SKFileWStream(outputPath);
-            using var pixmap = new SKPixmap(new SKImageInfo(width, height), resizedBitmap.GetPixels());
             resizedBitmap.Encode(outputStream, skiaOutputFormat, quality);
             return outputPath;
         }

--- a/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
+++ b/src/Jellyfin.Drawing.Skia/StripCollageBuilder.cs
@@ -112,7 +112,7 @@ public partial class StripCollageBuilder
         using var resizedBackdrop = SkiaEncoder.ResizeImage(backdrop, new SKImageInfo(width, backdropHeight, backdrop.ColorType, backdrop.AlphaType, backdrop.ColorSpace));
         using var paint = new SKPaint();
         // draw the backdrop
-        canvas.DrawImage(resizedBackdrop, 0, 0, SkiaEncoder.DefaultSamplingOptions, paint);
+        canvas.DrawBitmap(resizedBackdrop, 0, 0, SkiaEncoder.DefaultSamplingOptions, paint);
 
         // draw shadow rectangle
         using var paintColor = new SKPaint();
@@ -192,7 +192,7 @@ public partial class StripCollageBuilder
                 // draw this image into the strip at the next position
                 var xPos = x * cellWidth;
                 var yPos = y * cellHeight;
-                canvas.DrawImage(resizeImage, xPos, yPos, SkiaEncoder.DefaultSamplingOptions, paint);
+                canvas.DrawBitmap(resizeImage, xPos, yPos, SkiaEncoder.DefaultSamplingOptions, paint);
             }
         }
 

--- a/tests/Jellyfin.Drawing.Skia.Tests/Jellyfin.Drawing.Skia.Tests.csproj
+++ b/tests/Jellyfin.Drawing.Skia.Tests/Jellyfin.Drawing.Skia.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Jellyfin.Drawing.Skia.Tests/SkiaEncoderDecodeDownscaledTests.cs
+++ b/tests/Jellyfin.Drawing.Skia.Tests/SkiaEncoderDecodeDownscaledTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.IO;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Drawing;
+using MediaBrowser.Model.Drawing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SkiaSharp;
+using Xunit;
+
+namespace Jellyfin.Drawing.Skia.Tests;
+
+public sealed class SkiaEncoderDecodeDownscaledTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "jellyfin-skia-" + Guid.NewGuid().ToString("N"));
+    private readonly string _tempDirectory;
+    private readonly SkiaEncoder _encoder;
+
+    public SkiaEncoderDecodeDownscaledTests()
+    {
+        _tempDirectory = Path.Combine(_directory, "temp");
+        Directory.CreateDirectory(_tempDirectory);
+        _encoder = new(NullLogger<SkiaEncoder>.Instance, Mock.Of<IApplicationPaths>(p => p.TempDirectory == _tempDirectory));
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_directory, true);
+    }
+
+    [Theory]
+    [InlineData(2000, 3000, 150, 250, 375)] // 1/8
+    [InlineData(2000, 3000, 300, 500, 750)] // 1/4
+    [InlineData(1920, 1080, 600, 960, 540)] // 1/2, 1/4 would be less than 1.5x the output
+    public void DecodeDownscaled_Jpeg_DecodesSmallestScaleCoveringOutput(int width, int height, int maxWidth, int decodedWidth, int decodedHeight)
+    {
+        using var source = CreateTestPattern(width, height);
+        var input = WriteImage(source, SKEncodedImageFormat.Jpeg);
+
+        using var bitmap = _encoder.DecodeDownscaled(input, false, new ImageProcessingOptions { MaxWidth = maxWidth }, out var originalSize);
+
+        Assert.NotNull(bitmap);
+        Assert.Equal(decodedWidth, bitmap.Width);
+        Assert.Equal(decodedHeight, bitmap.Height);
+        Assert.Equal(new ImageDimensions(width, height), originalSize);
+    }
+
+    [Fact]
+    public void DecodeDownscaled_OnlyFullSizeCoversOutput_ReturnsNull()
+    {
+        // Half of 2000 is 1000, less than 1.5x the requested 700.
+        using var source = CreateTestPattern(2000, 3000);
+        var input = WriteImage(source, SKEncodedImageFormat.Jpeg);
+
+        using var bitmap = _encoder.DecodeDownscaled(input, false, new ImageProcessingOptions { MaxWidth = 700 }, out var originalSize);
+
+        Assert.Null(bitmap);
+        Assert.Null(originalSize);
+    }
+
+    [Fact]
+    public void DecodeDownscaled_NonLatinPath_RemovesTemporaryCopy()
+    {
+        using var source = CreateTestPattern(2000, 3000);
+        var input = Path.Combine(_directory, "ポスター.jpg");
+        File.Move(WriteImage(source, SKEncodedImageFormat.Jpeg), input);
+
+        using var bitmap = _encoder.DecodeDownscaled(input, false, new ImageProcessingOptions { MaxWidth = 300 }, out _);
+
+        Assert.NotNull(bitmap);
+        Assert.Equal(500, bitmap.Width);
+        Assert.Empty(Directory.GetFiles(_tempDirectory));
+    }
+
+    [Fact]
+    public void DecodeDownscaled_Png_ReturnsNull()
+    {
+        using var source = CreateTestPattern(2000, 3000);
+        var input = WriteImage(source, SKEncodedImageFormat.Png);
+
+        using var bitmap = _encoder.DecodeDownscaled(input, false, new ImageProcessingOptions { MaxWidth = 300 }, out _);
+
+        Assert.Null(bitmap);
+    }
+
+    [Theory]
+    [InlineData(SKEncodedImageFormat.Jpeg, 2000, 3000, 300, 450)]
+    [InlineData(SKEncodedImageFormat.Jpeg, 1000, 1500, 900, 1350)]
+    [InlineData(SKEncodedImageFormat.Png, 2000, 3000, 300, 450)]
+    public void EncodeImage_ProducesRequestedSize(SKEncodedImageFormat format, int width, int height, int maxWidth, int expectedHeight)
+    {
+        using var source = CreateTestPattern(width, height);
+        var input = WriteImage(source, format);
+
+        using var output = Encode(input, new ImageProcessingOptions { MaxWidth = maxWidth }, false);
+
+        Assert.Equal(maxWidth, output.Width);
+        Assert.Equal(expectedHeight, output.Height);
+    }
+
+    [Fact]
+    public void EncodeImage_DownscaledJpeg_MatchesFullDecode()
+    {
+        using var source = CreateTestPattern(2000, 3000);
+        var input = WriteImage(source, SKEncodedImageFormat.Jpeg);
+
+        using var output = Encode(input, new ImageProcessingOptions { MaxWidth = 300 }, false);
+
+        using var fullDecode = SKBitmap.Decode(input);
+        using var expected = SkiaEncoder.ResizeImage(fullDecode, new SKImageInfo(300, 450, fullDecode.ColorType, fullDecode.AlphaType, fullDecode.ColorSpace));
+        var difference = MeanAbsoluteDifference(expected, output);
+        Assert.True(difference < 2, $"Mean absolute difference per channel was {difference}");
+    }
+
+    [Fact]
+    public void EncodeImage_GrayscaleJpeg_KeepsTone()
+    {
+        using var source = new SKBitmap(new SKImageInfo(1000, 1000, SKColorType.Gray8, SKAlphaType.Opaque));
+        source.Erase(new SKColor(90, 90, 90));
+        var input = WriteImage(source, SKEncodedImageFormat.Jpeg);
+
+        using var output = Encode(input, new ImageProcessingOptions { MaxWidth = 100 }, false);
+
+        Assert.Equal(100, output.Width);
+        Assert.Equal(100, output.Height);
+        AssertColor(new SKColor(90, 90, 90), output.GetPixel(50, 50));
+    }
+
+    [Fact]
+    public void EncodeImage_AutoOrient_AppliesExifRotation()
+    {
+        var input = WriteRedLeftBlueRightJpeg(ExifOrientation(SKEncodedOrigin.RightTop));
+
+        using var output = Encode(input, new ImageProcessingOptions { MaxWidth = 100 }, true);
+
+        // Rotated 90 degrees clockwise: the left half of the stored image ends up on top.
+        Assert.Equal(100, output.Width);
+        Assert.Equal(200, output.Height);
+        AssertColor(SKColors.Red, output.GetPixel(50, 30));
+        AssertColor(SKColors.Blue, output.GetPixel(50, 170));
+    }
+
+    [Fact]
+    public void EncodeImage_NoAutoOrient_IgnoresExifRotation()
+    {
+        var input = WriteRedLeftBlueRightJpeg(ExifOrientation(SKEncodedOrigin.RightTop));
+
+        using var output = Encode(input, new ImageProcessingOptions { MaxWidth = 100 }, false);
+
+        Assert.Equal(100, output.Width);
+        Assert.Equal(50, output.Height);
+        AssertColor(SKColors.Red, output.GetPixel(15, 25));
+        AssertColor(SKColors.Blue, output.GetPixel(85, 25));
+    }
+
+    private SKBitmap Encode(string input, ImageProcessingOptions options, bool autoOrient)
+    {
+        // Lossless output, so the tests see the resized pixels.
+        var outputPath = Path.Combine(_directory, Guid.NewGuid().ToString("N") + ".png");
+        var result = _encoder.EncodeImage(input, DateTime.UtcNow, outputPath, autoOrient, null, 90, options, ImageFormat.Png);
+        Assert.Equal(outputPath, result);
+        return SKBitmap.Decode(outputPath);
+    }
+
+    private string WriteImage(SKBitmap bitmap, SKEncodedImageFormat format, byte[]? exif = null)
+    {
+        using var data = bitmap.Encode(format, 95);
+        var bytes = data.ToArray();
+        if (exif is not null)
+        {
+            // The APP1 segment goes right after the SOI marker.
+            bytes = [.. bytes.AsSpan(0, 2), .. exif, .. bytes.AsSpan(2)];
+        }
+
+        var path = Path.Combine(_directory, Guid.NewGuid().ToString("N") + (format == SKEncodedImageFormat.Png ? ".png" : ".jpg"));
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private string WriteRedLeftBlueRightJpeg(byte[] exif)
+    {
+        using var source = new SKBitmap(800, 400);
+        using var canvas = new SKCanvas(source);
+        canvas.Clear(SKColors.Blue);
+        using var red = new SKPaint { Color = SKColors.Red };
+        canvas.DrawRect(0, 0, 400, 400, red);
+        return WriteImage(source, SKEncodedImageFormat.Jpeg, exif);
+    }
+
+    private static SKBitmap CreateTestPattern(int width, int height)
+    {
+        var bitmap = new SKBitmap(width, height);
+        using var canvas = new SKCanvas(bitmap);
+        using var shader = SKShader.CreateLinearGradient(
+            new SKPoint(0, 0),
+            new SKPoint(width, height),
+            [SKColors.DarkBlue, SKColors.Orange, SKColors.White],
+            SKShaderTileMode.Clamp);
+        using var gradient = new SKPaint { Shader = shader };
+        canvas.DrawRect(0, 0, width, height, gradient);
+        using var black = new SKPaint { Color = SKColors.Black };
+        canvas.DrawRect(width / 4f, height / 4f, width / 2f, height / 2f, black);
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Builds a minimal big-endian EXIF APP1 segment holding only the orientation tag.
+    /// </summary>
+    private static byte[] ExifOrientation(SKEncodedOrigin origin) =>
+    [
+        0xFF, 0xE1, 0x00, 0x22, // APP1, length 34
+        (byte)'E', (byte)'x', (byte)'i', (byte)'f', 0x00, 0x00,
+        (byte)'M', (byte)'M', 0x00, 0x2A, 0x00, 0x00, 0x00, 0x08, // TIFF header, IFD0 at offset 8
+        0x00, 0x01, // one entry
+        0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, (byte)origin, 0x00, 0x00, // orientation, SHORT
+        0x00, 0x00, 0x00, 0x00 // no next IFD
+    ];
+
+    private static double MeanAbsoluteDifference(SKBitmap expected, SKBitmap actual)
+    {
+        Assert.Equal(expected.Width, actual.Width);
+        Assert.Equal(expected.Height, actual.Height);
+
+        long total = 0;
+        for (var y = 0; y < expected.Height; y++)
+        {
+            for (var x = 0; x < expected.Width; x++)
+            {
+                var a = expected.GetPixel(x, y);
+                var b = actual.GetPixel(x, y);
+                total += Math.Abs(a.Red - b.Red) + Math.Abs(a.Green - b.Green) + Math.Abs(a.Blue - b.Blue);
+            }
+        }
+
+        return total / (expected.Width * expected.Height * 3.0);
+    }
+
+    private static void AssertColor(SKColor expected, SKColor actual)
+    {
+        // JPEG compression shifts solid colors slightly.
+        Assert.InRange(actual.Red, Math.Max(expected.Red - 12, 0), Math.Min(expected.Red + 12, 255));
+        Assert.InRange(actual.Green, Math.Max(expected.Green - 12, 0), Math.Min(expected.Green + 12, 255));
+        Assert.InRange(actual.Blue, Math.Max(expected.Blue - 12, 0), Math.Min(expected.Blue + 12, 255));
+    }
+}


### PR DESCRIPTION
**Changes**

- On a resized-image cache miss, `SkiaEncoder` decodes the full source before shrinking it, meaning the standard TMDb 2000x3000
  posters at 24 MB have to be in memory to make a ~300x450 card.
- For JPEG sources (default TMDb format), ask libjpeg-turbo for 1/2, 1/4 or 1/8 of the size directly. The existing resize and sharpening then run on that smaller bitmap saving a lot of memory and a bit of compute.
- Everything else takes the old path: PNG/WebP/GIF/SVG, and any request that doesn't meet our threshold of less than ~33% of the full width and height.
- `ResizeImage` returns the bitmap it draws into, removing two copies of the output (`SKImage.FromBitmap`,
  `SKBitmap.FromImage`) and an `SKPixmap` that was never used.
- 100 cold encodes: peak memory -47% to -78%, CPU -8% to -23%, quality equal or in some cases near equal to master against an exact
  reference (see tables below).

<details>
<summary>Measurements</summary>

MacBook (Apple silicon, 10 cores), .NET 10.0.401, SkiaSharp 3.119.4. Sources: Big Buck Bunny poster (1500x2122, and
resized to 2000x3000) and an Elephants Dream frame (1920x1080), Blender Foundation, CC BY. Request shapes as sent by
jellyfin-web (fill + quality 96, WebP) and a mobile client (600x600, quality 90, JPEG).

100 cold encodes, 10 at a time (the encode limiter on a default install), mean of 3 runs:

| scenario | wall | CPU | peak RSS |
|---|---|---|---|
| poster 2000x3000 -> 298x446 | 491 -> 382 ms (-22%) | 4.08 -> 3.15 s (-23%) | 603 -> 130 MB (-78%) |
| poster 2000x3000 -> 600x900 | 511 -> 417 ms (-18%) | 4.21 -> 3.53 s (-16%) | 683 -> 278 MB (-59%) |
| poster 1500x2122 -> 316x446 | 448 -> 403 ms (-10%) | 3.59 -> 3.22 s (-10%) | 347 -> 161 MB (-54%) |
| thumb 1920x1080 -> 475x267 | 426 -> 367 ms (-14%) | 3.40 -> 3.12 s (-8%) | 282 -> 149 MB (-47%) |

One encode, BenchmarkDotNet mean:

| scenario | master | PR |
|---|---|---|
| poster 2000x3000 -> 298x446 | 35.23 ms | 28.19 ms |
| poster 2000x3000 -> 600x900 | 35.08 ms | 29.80 ms |
| poster 1500x2122 -> 316x446 | 32.00 ms | 28.96 ms |
| thumb 1920x1080 -> 475x267 | 30.69 ms | 28.39 ms |
| PNG (unchanged path for reference) | 59.04 ms | 59.28 ms |

While there are some compute savings for the resize the whole file is still Huffman-decoded so compute savings are limited by that operation. Memory savings are significant though.

</details>

<details>
<summary>Quality</summary>

To determine the quality of the resulting downscale I scored
both builds output against a reference: an exact area-average downscale of the full-resolution image with the
same sharpening kernel. PSNR in dB, higher is closer:

| scenario | master | PR |
|---|---|---|
| poster 2000x3000 -> 298x446 | 35.52 | 35.55 |
| poster 2000x3000 -> 600x900 | 39.16 | 39.01 |
| poster 1500x2122 -> 316x446 | 32.77 | 32.79 |
| thumb 1920x1080 -> 475x267 | 43.58 | 43.90 |

With my first naive resize to the fraction (1/2, 1/4..) images requested at resolutions just below those thresholds would become noticeably soft due to the downscale sampling simply shifting over a bit. Here some fine tuning can be done but I found that with a threshold of at least 1.5x the resolution of the requested size the images looked good while still cutting memory significantly.

Difference to master in dB for each option tried:

| headroom | decode sizes | 2000x3000 -> 298x446 | 2000x3000 -> 600x900 | 1500x2122 -> 316x446 | 1920x1080 -> 475x267 |
|---|---|---|---|---|---|
| 1x | any n/8 | +0.03 | -2.8 | -6.0 | -5.9 |
| 1.5x | any n/8 | +0.03 | -0.15 | -2.5 | +0.7 |
| 2x | 1/2, 1/4, 1/8 | +0.03 | 0.0 | +0.02 | +0.3 |
| **1.5x (this PR)** | **1/2, 1/4, 1/8** | **+0.03** | **-0.15** | **+0.02** | **+0.3** |

<img width="760" height="1920" alt="2 2-quality-panel" src="https://github.com/user-attachments/assets/371a963a-e6b0-453f-82b4-c02159f84160" />

4x crop of the 475x267 thumbnail: master, 1x (rejected due to noticeably softer look), 1.5x (this PR), reference. Elephants Dream (c) Blender Foundation, CC BY 2.5.

</details>

**Notes for reviewers**

- The file is opened by path like `Decode` does, found that with a managed `Stream`, an exception
  thrown while Skia reads from it can't be caught and aborts the process (reproduced; exit 134).
- For non-Latin paths it goes through `NormalizePath` and deletes its own temp copy, so a fallback
  never leaves more temp files than master.
- #17641 adds a dimension check inside `Decode`. This PR doesn't touch `Decode`, but if that is merged we should maybe add the same check to `DecodeDownscaled`.

**Found along the way (did not include in this PR)**

- **Possible server crash in `GetImageBlurHash`.** It passes a `FileStream` to `BlurHashEncoder.Encode`, so Skia reads
  the file through a callback into .NET. If that read throws
  the exception can't cross Skia's native frames: the `catch` never runs and the process aborts. Reproduced with a stream
  that throws halfway through a JPEG (exit code 134). Blurhashes are computed when image info is refreshed, e.g. during
  library scans. This might be related to #17646, but I haven't verified that.
  <details>
  <summary>Output of the reproduction</summary>

  ```
  Unhandled exception. System.IO.IOException: Input/output error (simulated)
     at FailingStream.Read(Byte[] buffer, Int32 offset, Int32 count)
     at SkiaSharp.SKManagedStream.OnReadManagedStream(IntPtr buffer, IntPtr size)
     at SkiaSharp.SKManagedStream.OnRead(IntPtr buffer, IntPtr size)
     at SkiaSharp.DelegateProxies.SKManagedStreamReadProxyImplementation(IntPtr s, Void* context, Void* buffer, IntPtr size)
  ```
  </details>
- **Temp-file leak in `Decode`.** For non-Latin paths, `NormalizePath` copies the image to the temp folder and `Decode`
  never deletes the copy, so every cold resize of such a file leaves one behind. The new path cleans up after itself;
  `Decode` is unchanged here.

**Code assistance**
I used Claude Opus 5 to discover possible angles for improving cold start poster loading times and brainstorm an improvement, I'm not experienced with Skia so a lot of the syntax was also written by it. I then let it run benchmarks and write tests supervised and check if I missed any edge cases.

**Issues**
No open issue for this. Related: #17776 (cold resizes after the SkiaSharp 3 update, fixed by #17775, which this builds on) and #17656 (a withdrawn approach to the same cold-cache cost using a cached WebP intermediate).
