### PR TITLE
Fix custom metadata provider failure handling

### DIFF
--- a/MediaBrowser.Providers/Manager/MetadataService.cs
+++ b/MediaBrowser.Providers/Manager/MetadataService.cs
@@ -937,6 +937,7 @@ namespace MediaBrowser.Providers.Manager
             }
             catch (Exception ex)
             {
+                refreshResult.Failures++;
                 refreshResult.ErrorMessage = ex.Message;
                 Logger.LogError(ex, "Error in {Provider} for {Item}", provider.Name, logName);
             }

--- a/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceRefreshTests.cs
+++ b/tests/Jellyfin.Providers.Tests/Manager/MetadataServiceRefreshTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
+using MediaBrowser.Common;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -24,6 +25,45 @@ namespace Jellyfin.Providers.Tests.Manager
 {
     public class MetadataServiceRefreshTests
     {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RefreshWithProviders_ProbeFailure_IsCountedAsFailedRefresh(bool probeFails)
+        {
+            var item = new Movie { Name = "Probe regression test" };
+            var options = new MetadataRefreshOptions(Mock.Of<IDirectoryService>())
+            {
+                MetadataRefreshMode = MetadataRefreshMode.FullRefresh
+            };
+            var provider = new Mock<ICustomMetadataProvider<Movie>>(MockBehavior.Strict);
+            provider.SetupGet(p => p.Name).Returns("Probe Provider");
+            provider.Setup(p => p.FetchAsync(item, options, CancellationToken.None))
+                .Returns(probeFails
+                    ? Task.FromException<ItemUpdateType>(new FfmpegException("ffprobe failed - streams and format are both null."))
+                    : Task.FromResult(ItemUpdateType.MetadataImport));
+
+            var service = new TestMetadataService();
+            var result = await service.RefreshWithProvidersInternal(
+                new MetadataResult<Movie> { Item = item },
+                new MovieInfo { Name = item.Name },
+                options,
+                [provider.Object]).ConfigureAwait(true);
+
+            provider.Verify(p => p.FetchAsync(item, options, CancellationToken.None), Times.Once);
+
+            // Issue #17917: a swallowed probe exception must not look like a successful refresh
+            // to the caller deciding whether to advance DateLastRefreshed.
+            Assert.Equal(probeFails ? 1 : 0, result.Failures);
+            if (probeFails)
+            {
+                Assert.Equal("ffprobe failed - streams and format are both null.", result.ErrorMessage);
+            }
+            else
+            {
+                Assert.True(result.UpdateType.HasFlag(ItemUpdateType.MetadataImport));
+            }
+        }
+
         [Theory]
         // RemoveOldMetadata is only ever set by an explicit user action - a refresh with "replace all
         // metadata", or Identify. A provider failing must not silently downgrade that to a merge: the
@@ -285,6 +325,57 @@ namespace Jellyfin.Providers.Tests.Manager
             {
                 Assert.True(item.DateLastRefreshed > stampBefore);
             }
+        }
+
+        [Fact]
+        public async Task RefreshMetadata_ProbeFails_RetriesOverdueRefreshAndStopsAfterSuccess()
+        {
+            var item = new TestItem
+            {
+                Id = Guid.NewGuid(),
+                Name = "Probe test",
+                DateLastRefreshed = DateTime.UtcNow.AddDays(-60),
+                PreferredMetadataLanguage = "en",
+                PreferredMetadataCountryCode = "US"
+            };
+            item.PresentationUniqueKey = item.CreatePresentationUniqueKey();
+            var previousRefresh = item.DateLastRefreshed;
+            var options = new MetadataRefreshOptions(Mock.Of<IDirectoryService>())
+            {
+                MetadataRefreshMode = MetadataRefreshMode.Default,
+                ImageRefreshMode = MetadataRefreshMode.None
+            };
+            var provider = new Mock<ICustomMetadataProvider<TestItem>>();
+            provider.SetupGet(p => p.Name).Returns("Probe Provider");
+            provider.As<IHasItemChangeMonitor>()
+                .Setup(p => p.HasChanged(item, options.DirectoryService)).Returns(false);
+            provider.SetupSequence(p => p.FetchAsync(item, options, CancellationToken.None))
+                .ThrowsAsync(new FfmpegException("Probe failed"))
+                .ReturnsAsync(ItemUpdateType.MetadataImport);
+
+            var libraryManager = new Mock<ILibraryManager>();
+            libraryManager.Setup(l => l.GetLibraryOptions(item)).Returns(new LibraryOptions { AutomaticRefreshIntervalDays = 30 });
+            var providerManager = new Mock<IProviderManager>();
+            providerManager.Setup(p => p.GetImageProviders(item, It.IsAny<ImageRefreshOptions>()))
+                .Returns(Array.Empty<IImageProvider>());
+            providerManager.Setup(p => p.GetMetadataProviders<TestItem>(item, It.IsAny<LibraryOptions>()))
+                .Returns(new[] { (IMetadataProvider<TestItem>)provider.Object });
+            providerManager.Setup(p => p.GetMetadataSavers(item, It.IsAny<LibraryOptions>()))
+                .Returns(Array.Empty<IMetadataSaver>());
+            var repository = new Mock<IItemRepository>();
+            repository.Setup(r => r.ItemExistsAsync(item.Id)).ReturnsAsync(true);
+            var service = new TestItemMetadataService(libraryManager.Object, providerManager.Object, repository.Object);
+
+            await service.RefreshMetadata(item, options, CancellationToken.None).ConfigureAwait(true);
+            Assert.Equal(previousRefresh, item.DateLastRefreshed);
+
+            // No file change is reported: the failed refresh must remain overdue for retry.
+            await service.RefreshMetadata(item, options, CancellationToken.None).ConfigureAwait(true);
+            Assert.True(item.DateLastRefreshed > previousRefresh);
+            provider.Verify(p => p.FetchAsync(item, options, CancellationToken.None), Times.Exactly(2));
+
+            await service.RefreshMetadata(item, options, CancellationToken.None).ConfigureAwait(true);
+            provider.Verify(p => p.FetchAsync(item, options, CancellationToken.None), Times.Exactly(2));
         }
 
         /// <summary>


### PR DESCRIPTION
**Changes**

Custom metadata provider exceptions were logged but did not increment `RefreshResult.Failures`, allowing a failed probe to be treated as a completed refresh. Increment the failure count in `RunCustomProvider` so the existing refresh logic preserves `DateLastRefreshed` when a custom provider fails. Cancellation continues to propagate through the existing `OperationCanceledException` handler.

Add regression coverage for successful and failed providers, and for an overdue refresh that fails, retries on the next scan without a file change, and stops invoking the provider after success.

**Validation**

- Before the fix: the failed-provider regression failed with expected `Failures = 1`, actual `0`; the success case passed.
- After the fix: all 12 tests in `MetadataServiceRefreshTests` passed locally in Release using .NET SDK 10.0.103 on Windows.
- The full solution test suite and manual playback reproduction have not been run for this change.
- This change does not repair refresh timestamps already recorded incorrectly. Existing affected items may still require manual metadata refresh. The tests cover failure accounting and overdue-refresh retry, not every playback or retry scenario in the issue.

**CI status**

At this update, these workflows report `action_required`; none has produced passing validation results:

- [Tests](https://github.com/jellyfin/jellyfin/actions/runs/34487771370): full solution tests on Ubuntu, macOS and Windows
- [Format](https://github.com/jellyfin/jellyfin/actions/runs/34487771256)
- [ABI Compatibility](https://github.com/jellyfin/jellyfin/actions/runs/34487771301)
- [CodeQL](https://github.com/jellyfin/jellyfin/actions/runs/34487771422)
- [OpenAPI Check](https://github.com/jellyfin/jellyfin/actions/runs/34487771673)
- [Project Automation](https://github.com/jellyfin/jellyfin/actions/runs/34487771191)

**Code assistance**

Codex generated the production change and regression tests, inspected the code, and ran the focused tests. This draft description was also generated by Codex and requires author review and rewriting in the author's own words before requesting review, in accordance with the project's contribution policy.

**Issues**

Addresses #17917
