### PR TITLE
fix(localization): add Italian VM certification ratings

### DIFF
--- a/Emby.Server.Implementations/Localization/Ratings/it.json
+++ b/Emby.Server.Implementations/Localization/Ratings/it.json
@@ -3,28 +3,35 @@
     "supportsSubScores": false,
     "ratings": [
         {
-            "ratingStrings": ["T"],
+            "ratingStrings": ["T", "Per tutti"],
             "ratingScore": {
                 "score": 0,
                 "subScore": null
             }
         },
         {
-            "ratingStrings": ["6+"],
+            "ratingStrings": ["6+", "VM6", "VM 6"],
             "ratingScore": {
                 "score": 6,
                 "subScore": null
             }
         },
         {
-            "ratingStrings": ["14+"],
+            "ratingStrings": ["12+", "VM12", "VM 12"],
+            "ratingScore": {
+                "score": 12,
+                "subScore": null
+            }
+        },
+        {
+            "ratingStrings": ["14+", "VM14", "VM 14"],
             "ratingScore": {
                 "score": 14,
                 "subScore": null
             }
         },
         {
-            "ratingStrings": ["18+"],
+            "ratingStrings": ["18+", "VM18", "VM 18"],
             "ratingScore": {
                 "score": 18,
                 "subScore": null

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -199,6 +199,10 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         [InlineData("Rated: R", "US", 17, 0)]
         [InlineData("Rated R", "US", 17, 0)]
         [InlineData(" PG-13 ", "US", 13, 0)]
+        [InlineData("IT-VM14", "IT", 14, null)]
+        [InlineData("IT-VM18", "IT", 18, null)]
+        [InlineData("VM12", "IT", 12, null)]
+        [InlineData("IT-6+", "IT", 6, null)]
         public async Task GetRatingLevel_GivenValidString_Success(string value, string countryCode, int? expectedScore, int? expectedSubScore)
         {
             var localizationManager = Setup(new ServerConfiguration()


### PR DESCRIPTION
## Summary
Fixes #17932

Jellyfin failed to match Italian TMDB certifications using legal "VM" codes (\`VM12\`, \`VM14\`, \`VM18\`), treating adult titles as unrated and silently bypassing parental controls when \`MetadataCountryCode = IT\`.

## Changes
- Updated \`Emby.Server.Implementations/Localization/Ratings/it.json\`:
  - Added legal classification aliases: \`VM6\`, \`VM12\`, \`VM14\`, \`VM18\` (including space variants).
  - Added missing \`12\` level (\`VM12\`).
  - Added \`Per tutti\` alias for \`T\`.
- Updated \`tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs\`:
  - Added test cases covering \`IT-VM14\`, \`IT-VM18\`, \`VM12\`, and \`IT-6+\`.

## Testing
- Verified failure on upstream master and confirmed all 15 tests pass with this fix via \`dotnet test\`.