### PR TITLE
Fix null reference when refreshing images for shadow views

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -241,6 +241,7 @@
  - [m0g3r](https://github.com/m0g3r)
  - [martin-77](https://github.com/martin-77)
  - [Oggeb1](https://github.com/Oggeb1)
+ - [Adamstuhltrager](https://github.com/Adamstuhltrager)
 
 # Emby Contributors
 

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -516,8 +516,19 @@ namespace MediaBrowser.Controller.Entities
         /// </summary>
         public bool UserHasContentRestrictions { get; private set; }
 
-        public void SetUser(User user)
+        /// <summary>
+        /// Applies the parental rating, unrated item, and tag restrictions of <paramref name="user"/> to the query.
+        /// A <c>null</c> user leaves the query user-agnostic, the same way <see cref="InternalItemsQuery(User)"/> does,
+        /// so that a shadow view or any other item without a user of its own can be queried without restrictions.
+        /// </summary>
+        /// <param name="user">The user whose restrictions apply, or <c>null</c> for no user context.</param>
+        public void SetUser(User? user)
         {
+            if (user is null)
+            {
+                return;
+            }
+
             var maxRating = user.MaxParentalRatingScore;
             if (maxRating.HasValue)
             {

--- a/tests/Jellyfin.Controller.Tests/Entities/InternalItemsQueryTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/InternalItemsQueryTests.cs
@@ -23,4 +23,19 @@ public class InternalItemsQueryTests
         var query = new InternalItemsQuery();
         Assert.Throws<ArgumentException>(() => query.ApplyFilters(filters));
     }
+
+    [Fact]
+    public void SetUser_NullUser_LeavesQueryUserAgnostic()
+    {
+        var query = new InternalItemsQuery();
+
+        query.SetUser(null);
+
+        Assert.Null(query.User);
+        Assert.Null(query.MaxParentalRating);
+        Assert.Empty(query.BlockUnratedItems);
+        Assert.Empty(query.ExcludeInheritedTags);
+        Assert.Empty(query.IncludeInheritedTags);
+        Assert.False(query.UserHasContentRestrictions);
+    }
 }


### PR DESCRIPTION
**Changes**
`InternalItemsQuery.SetUser` dereferenced its argument without a null check. `UserViewBuilder` passes the query's own `User` into it on every recursive movie and TV path, and that user is null whenever the view has no user of its own. `DynamicImageProvider` queries exactly such views: the shadow views that `UserViewManager.GetUserViews` creates for preset view types carry no `UserId`, so refreshing their images logged

```
[ERR] MediaBrowser.Providers.Folders.UserViewMetadataService: Error in Dynamic Image Provider for C:\...\root\default\Movies
System.NullReferenceException: Object reference not set to an instance of an object.
   at MediaBrowser.Controller.Entities.InternalItemsQuery.SetUser(User user)
   at MediaBrowser.Controller.Entities.UserViewBuilder.GetMovieFolders(Folder parent, User user, InternalItemsQuery query)
   at MediaBrowser.Controller.Entities.UserViewBuilder.GetUserItems(Folder queryParent, Folder displayParent, Nullable`1 viewType, InternalItemsQuery query)
   at MediaBrowser.Controller.Entities.UserView.GetItemsInternal(InternalItemsQuery query)
   at MediaBrowser.Controller.Entities.Folder.GetItemList(InternalItemsQuery query)
```

and the view never got a primary image. The same happens for the TV Shows shadow view via `GetTvView`.

`SetUser` now treats a null user as "no user context", which is what the `InternalItemsQuery(User)` constructor already does, so the query stays user-agnostic instead of throwing. A unit test covers the null case.

Reproduced on 12.0.0 by requesting `GET /Users/{userId}/Views?PresetViews=movies,tvshows` on a library with Movies and TV Shows collection folders: both errors appear in the log within a minute. With this change, a full image refresh of both shadow views completes cleanly and each view gets its collage image.

**Code assistance**
Claude (Fable 5.1) was used to trace the stack, draft the change, the test, and this description. The fix was built, unit tested, and verified end to end against a copy of a real 12.0-migrated library before opening the PR.

**Issues**
None filed; the error was found while investigating #17949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
