### PR TITLE
Stop requesting unused credits when looking up a TMDb person

### DIFF
--- a/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
+++ b/MediaBrowser.Providers/Plugins/Tmdb/TmdbClientManager.cs
@@ -326,7 +326,7 @@ namespace MediaBrowser.Providers.Plugins.Tmdb
             person = await _tmDbClient.GetPersonAsync(
                 personTmdbId,
                 TmdbUtils.NormalizeLanguage(language, countryCode),
-                PersonMethods.TvCredits | PersonMethods.MovieCredits | PersonMethods.Images | PersonMethods.ExternalIds,
+                PersonMethods.Images | PersonMethods.ExternalIds,
                 cancellationToken).ConfigureAwait(false);
 
             if (person is not null)


### PR DESCRIPTION
Apparently some fields can be null but TMDbLib treats them as non-null.

**Changes**
Lucky for us, we do not use these fields so just not fetch them.

**Code assistance**
None

**Issues**
Fixes #17967