### PR TITLE
Fix metadata refresh on folders without a filesystem path

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -724,7 +724,9 @@ namespace MediaBrowser.Controller.Entities
 
                 if (validChildrenNeedGeneration)
                 {
-                    validChildren = Children.ToList();
+                    // A folder with no filesystem path skips the resolver step that fills
+                    // accessibleChildren, so every stored child counts as accessible.
+                    accessibleChildren = Children.ToList();
                     validChildrenNeedGeneration = false;
                 }
 
@@ -764,7 +766,7 @@ namespace MediaBrowser.Controller.Entities
                     if (validChildrenNeedGeneration)
                     {
                         Children = null; // invalidate cached children.
-                        validChildren = Children.ToList();
+                        accessibleChildren = Children.ToList();
                     }
 
                     await RefreshMetadataRecursive(accessibleChildren, refreshOptions, recursive, innerProgress, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
**Changes**

Refreshing a season of a series with a flat episode layout (no `Season NN` folders) did nothing to its episodes. Those seasons are created by `SeriesMetadataService` with no `Path`, so `Folder.ValidateChildrenInternal2` skips the `IsFileProtocol` branch, which is the only place `accessibleChildren` gets filled. The fallback rebuilt the child list into `validChildren` and then handed the empty `accessibleChildren` to the refresh anyway.

**Code assistance**

No.

**Issues**

Fixes #