### PR TITLE
Drop dead item data and fix query ordering and bound parameters

### DIFF
--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs
@@ -271,7 +271,7 @@ public sealed partial class BaseItemRepository
 
         if (filter.DtoOptions.EnableImages)
         {
-            dbQuery = dbQuery.Include(e => e.Images);
+            dbQuery = dbQuery.Include(e => e.Images!.OrderBy(i => i.Id));
         }
 
         // Include LinkedChildEntities for container types and videos that use them (BoxSet, Playlist,
@@ -291,7 +291,7 @@ public sealed partial class BaseItemRepository
         };
         if (filter.IncludeItemTypes.Length == 0 || filter.IncludeItemTypes.Any(linkedChildTypes.Contains))
         {
-            dbQuery = dbQuery.Include(e => e.LinkedChildEntities);
+            dbQuery = dbQuery.Include(e => e.LinkedChildEntities!.OrderBy(l => l.SortOrder));
         }
 
         if (filter.IncludeExtras)

--- a/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
+++ b/Jellyfin.Server.Implementations/Item/ItemPersistenceService.cs
@@ -268,7 +268,7 @@ public class ItemPersistenceService : IItemPersistenceService
         using var transaction = context.Database.BeginTransaction();
 
         var ids = tuples.Select(f => f.Item.Id).ToArray();
-        var existingItems = context.BaseItems.Where(e => ids.Contains(e.Id)).Select(f => f.Id).ToHashSet();
+        var existingItems = context.BaseItems.WhereOneOrMany(ids, e => e.Id).Select(f => f.Id).ToHashSet();
 
         foreach (var item in tuples)
         {
@@ -328,7 +328,7 @@ public class ItemPersistenceService : IItemPersistenceService
             .Select(f => (f.Item, Values: f.Values.Select(e => itemValuesStore[(e.MagicNumber, e.Value)]).DistinctBy(e => e.ItemValueId).ToArray()))
             .ToArray();
 
-        var mappedValues = context.ItemValuesMap.Where(e => ids.Contains(e.ItemId)).ToList();
+        var mappedValues = context.ItemValuesMap.WhereOneOrMany(ids, e => e.ItemId).ToList();
 
         foreach (var item in valueMap)
         {

--- a/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
+++ b/Jellyfin.Server.Implementations/Item/PeopleRepository.cs
@@ -238,7 +238,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         using var context = _dbProvider.CreateDbContext();
         var query = context.PeopleBaseItemMap
             .AsNoTracking()
-            .Where(m => itemIds.Contains(m.ItemId));
+            .WhereOneOrMany(itemIds, m => m.ItemId);
 
         if (personTypes.Count > 0)
         {
@@ -274,7 +274,7 @@ public class PeopleRepository(IDbContextFactory<JellyfinDbContext> dbProvider, I
         using var context = _dbProvider.CreateDbContext();
         var rows = context.PeopleBaseItemMap
             .AsNoTracking()
-            .Where(m => itemIds.Contains(m.ItemId))
+            .WhereOneOrMany(itemIds, m => m.ItemId)
             .OrderBy(m => m.ListOrder)
             .Select(m => new
             {

--- a/Jellyfin.Server/Migrations/Routines/20260911120000_StripEmbeddedLinkedChildren.cs
+++ b/Jellyfin.Server/Migrations/Routines/20260911120000_StripEmbeddedLinkedChildren.cs
@@ -1,0 +1,44 @@
+using Jellyfin.Database.Implementations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Server.Migrations.Routines;
+
+/// <summary>
+/// Drops keys that no current property reads or writes from the serialized <c>BaseItems.Data</c> blob.
+/// </summary>
+[JellyfinMigration("2026-09-11T12:00:00", nameof(StripEmbeddedLinkedChildren))]
+internal class StripEmbeddedLinkedChildren : IDatabaseMigrationRoutine
+{
+    private readonly ILogger<StripEmbeddedLinkedChildren> _logger;
+    private readonly IDbContextFactory<JellyfinDbContext> _dbProvider;
+
+    public StripEmbeddedLinkedChildren(
+        ILoggerFactory loggerFactory,
+        IDbContextFactory<JellyfinDbContext> dbProvider)
+    {
+        _logger = loggerFactory.CreateLogger<StripEmbeddedLinkedChildren>();
+        _dbProvider = dbProvider;
+    }
+
+    /// <inheritdoc/>
+    public void Perform()
+    {
+        using var context = _dbProvider.CreateDbContext();
+
+        // json_valid guards the rare malformed blob: json_remove would abort the statement on it,
+        // and one bad row must not cost every other row the fix.
+        var updated = context.Database.ExecuteSqlRaw(
+            """
+            UPDATE "BaseItems"
+            SET "Data" = json_remove("Data", '$.LinkedChildren', '$.ExtraIds', '$.SupportsExternalTransfer')
+            WHERE "Data" IS NOT NULL
+              AND json_valid("Data") = 1
+              AND ("Data" LIKE '%"LinkedChildren"%'
+                OR "Data" LIKE '%"ExtraIds"%'
+                OR "Data" LIKE '%"SupportsExternalTransfer"%')
+            """);
+
+        _logger.LogInformation("Dropped dead keys from the serialized data of {Count} items", updated);
+    }
+}


### PR DESCRIPTION
Servers with large playlists are OOM-killed within seconds of a client connecting.

The memory is SQLite's temp store. `BaseItems.Data` still carries a `LinkedChildren` array that embeds every child of a container along with its full path. That array is dead, so it is neither written nor read any more but it is not removed from rows already on disk, and a playlist is only re-serialized when it is edited. Every read of such a row still pays for it.

The cost is quadratic in container size, because the embedded copy makes the parent row grow with the playlist while the join repeats that row once per child.

On a test a single unlimited query over 54 playlists returns only 30,060 rows, but 17,784 MB of row data.

Thanks @Chryma for debugging it on his failing system.

**Changes**
* Prune dead item data
* Fix query ordering and bound parameters

**Code assistance**
None

**Issues**
Fixes #17934
Fixes #17949
Fixes #17918
