### PR TITLE
Fix SyncPlayAccessHandler throwing on missing user claim

### DIFF
--- a/Jellyfin.Api/Auth/SyncPlayAccessPolicy/SyncPlayAccessHandler.cs
+++ b/Jellyfin.Api/Auth/SyncPlayAccessPolicy/SyncPlayAccessHandler.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Jellyfin.Api.Extensions;
 using Jellyfin.Data.Enums;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Extensions;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.SyncPlay;
@@ -34,6 +35,11 @@ namespace Jellyfin.Api.Auth.SyncPlayAccessPolicy
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, SyncPlayAccessRequirement requirement)
         {
             var userId = context.User.GetUserId();
+            if (userId.IsEmpty())
+            {
+                return Task.CompletedTask;
+            }
+
             var user = _userManager.GetUserById(userId);
             if (user is null)
             {

--- a/tests/Jellyfin.Api.Tests/Auth/SyncPlayAccessPolicy/SyncPlayAccessHandlerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Auth/SyncPlayAccessPolicy/SyncPlayAccessHandlerTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Jellyfin.Api.Auth.SyncPlayAccessPolicy;
+using Jellyfin.Api.Constants;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Common.Extensions;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Authorization;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Auth.SyncPlayAccessPolicy
+{
+    public class SyncPlayAccessHandlerTests
+    {
+        private readonly Mock<IUserManager> _userManagerMock;
+        private readonly SyncPlayAccessHandler _sut;
+
+        public SyncPlayAccessHandlerTests()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+            _userManagerMock = fixture.Freeze<Mock<IUserManager>>();
+            _sut = fixture.Create<SyncPlayAccessHandler>();
+        }
+
+        [Fact]
+        public async Task ShouldNotSucceedWithoutUserId()
+        {
+            _userManagerMock
+                .Setup(userManager => userManager.GetUserById(Guid.Empty))
+                .Throws(new ArgumentException("Guid can't be empty", "id"));
+
+            var requirement = new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.HasAccess);
+            var context = new AuthorizationHandlerContext(
+                new List<IAuthorizationRequirement> { requirement },
+                new ClaimsPrincipal(new ClaimsIdentity()),
+                null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task ShouldThrowWhenUserDoesNotExist()
+        {
+            var userId = Guid.NewGuid();
+            _userManagerMock
+                .Setup(userManager => userManager.GetUserById(userId))
+                .Returns<User?>(null);
+
+            var requirement = new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.HasAccess);
+            var context = new AuthorizationHandlerContext(
+                new List<IAuthorizationRequirement> { requirement },
+                CreatePrincipal(userId),
+                null);
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => _sut.HandleAsync(context));
+        }
+
+        [Fact]
+        public async Task ShouldSucceedWhenUserCanJoinGroups()
+        {
+            var userId = Guid.NewGuid();
+            var user = new User("jellyfin", "auth-provider", "reset-provider")
+            {
+                SyncPlayAccess = SyncPlayUserAccessType.JoinGroups
+            };
+            _userManagerMock
+                .Setup(userManager => userManager.GetUserById(userId))
+                .Returns(user);
+
+            var requirement = new SyncPlayAccessRequirement(SyncPlayAccessRequirementType.HasAccess);
+            var context = new AuthorizationHandlerContext(
+                new List<IAuthorizationRequirement> { requirement },
+                CreatePrincipal(userId),
+                null);
+
+            await _sut.HandleAsync(context);
+
+            Assert.True(context.HasSucceeded);
+        }
+
+        private static ClaimsPrincipal CreatePrincipal(Guid userId)
+        {
+            var claims = new[]
+            {
+                new Claim(InternalClaimTypes.UserId, userId.ToString("N", CultureInfo.InvariantCulture))
+            };
+
+            return new ClaimsPrincipal(new ClaimsIdentity(claims));
+        }
+    }
+}


### PR DESCRIPTION
**Changes**
`SyncPlayAccessHandler` calls `IUserManager.GetUserById` with whatever `context.User.GetUserId()` returns, but that extension returns an empty `Guid` (not a thrown error) whenever the user-id claim is missing or invalid. `GetUserById` explicitly throws `ArgumentException("Guid can't be empty")` on an empty `Guid`, so any request reaching this handler without a valid user claim throws instead of just failing the authorization requirement — matching the unhandled-exception flood described in #17920. `UserPermissionHandler` already guards this exact case with `userId.IsEmpty()`; this PR adds the same guard to `SyncPlayAccessHandler`, returning without succeeding the requirement when the id is empty. The existing "user id present but doesn't resolve to a real user" case is untouched and still throws `ResourceNotFoundException`.

Added `SyncPlayAccessHandlerTests` (new file, following the existing `Jellyfin.Api.Tests/Auth/*` pattern) covering: the empty-user-id case (previously threw, now fails the requirement cleanly), the missing-real-user case, and the existing happy path. Confirmed the new empty-user-id test fails on unpatched code with the exact `ArgumentException` from the issue, and all 3 tests pass with the fix.

**Code assistance**
I used an AI coding assistant to help implement this fix and its tests, then reviewed the change and the test run myself.

**Issues**
Fixes #17920
