### PR TITLE
Fix forced-only not overriding remembered subtitles

### DIFF
--- a/Emby.Server.Implementations/Library/MediaSourceManager.cs
+++ b/Emby.Server.Implementations/Library/MediaSourceManager.cs
@@ -494,7 +494,12 @@ namespace Emby.Server.Implementations.Library
             {
                 var index = userData.SubtitleStreamIndex.Value;
                 // Make sure the saved index is still valid
-                if (index == -1 || source.MediaStreams.Any(i => i.Type == MediaStreamType.Subtitle && i.Index == index))
+                var savedStream = source.MediaStreams.FirstOrDefault(i => i.Type == MediaStreamType.Subtitle && i.Index == index);
+                // "Only forced" rules out full tracks entirely, so a remembered one must not resurrect them.
+                // The client reports whatever is playing, so an index remembered under another mode sticks forever otherwise.
+                if (index == -1
+                    || (savedStream is not null
+                        && (user.SubtitleMode != SubtitlePlaybackMode.OnlyForced || savedStream.IsForced)))
                 {
                     source.DefaultSubtitleStreamIndex = index;
                     return;

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/MediaSourceManagerTests.cs
@@ -7,7 +7,9 @@ using Castle.Components.DictionaryAdapter;
 using Emby.Server.Implementations.IO;
 using Emby.Server.Implementations.Library;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Controller.MediaSegments;
@@ -147,6 +149,73 @@ namespace Jellyfin.Server.Implementations.Tests.Library
 
             _mediaSourceManager.SetDefaultAudioAndSubtitleStreamIndices(_item, mediaInfo, _user);
             Assert.Equal(expectedIndex, mediaInfo.DefaultAudioStreamIndex);
+        }
+
+        [Theory]
+        // A remembered full track must not survive a switch to "only forced" (it falls through to
+        // the forced track here); a remembered forced track and "off" still must.
+        [InlineData(SubtitlePlaybackMode.OnlyForced, 2, 3)]
+        [InlineData(SubtitlePlaybackMode.OnlyForced, 3, 3)]
+        [InlineData(SubtitlePlaybackMode.OnlyForced, -1, -1)]
+        [InlineData(SubtitlePlaybackMode.Default, 2, 2)]
+        [InlineData(SubtitlePlaybackMode.Always, 2, 2)]
+        [InlineData(SubtitlePlaybackMode.Smart, 2, 2)]
+        [InlineData(SubtitlePlaybackMode.None, 2, null)]
+        public void SetDefaultSubtitleStreamIndex_RememberedSelection_RespectsSubtitleMode(
+            SubtitlePlaybackMode mode,
+            int rememberedIndex,
+            int? expectedIndex)
+        {
+            _mockUserDataManager
+                .Setup(m => m.GetUserData(It.IsAny<User>(), It.IsAny<BaseItem>()))
+                .Returns(new UserItemData { Key = "key", SubtitleStreamIndex = rememberedIndex });
+
+            var mediaInfo = new MediaSourceInfo
+            {
+                MediaStreams = new MediaStream[]
+                {
+                    new() { Index = 0, Type = MediaStreamType.Video, IsDefault = true },
+                    new() { Index = 1, Type = MediaStreamType.Audio, Language = "eng", IsDefault = true },
+                    new() { Index = 2, Type = MediaStreamType.Subtitle, Language = "eng", IsDefault = true, IsForced = false },
+                    new() { Index = 3, Type = MediaStreamType.Subtitle, Language = "eng", IsDefault = false, IsForced = true }
+                }
+            };
+
+            _user.SubtitleMode = mode;
+            _user.SubtitleLanguagePreference = string.Empty;
+            _user.RememberSubtitleSelections = true;
+            _user.AudioLanguagePreference = string.Empty;
+
+            _mediaSourceManager.SetDefaultAudioAndSubtitleStreamIndices(_item, mediaInfo, _user);
+
+            Assert.Equal(expectedIndex, mediaInfo.DefaultSubtitleStreamIndex);
+        }
+
+        [Fact]
+        public void SetDefaultSubtitleStreamIndex_OnlyForcedRemembersFullTrackWithNoForcedStream_SelectsNothing()
+        {
+            _mockUserDataManager
+                .Setup(m => m.GetUserData(It.IsAny<User>(), It.IsAny<BaseItem>()))
+                .Returns(new UserItemData { Key = "key", SubtitleStreamIndex = 2 });
+
+            var mediaInfo = new MediaSourceInfo
+            {
+                MediaStreams = new MediaStream[]
+                {
+                    new() { Index = 0, Type = MediaStreamType.Video, IsDefault = true },
+                    new() { Index = 1, Type = MediaStreamType.Audio, Language = "eng", IsDefault = true },
+                    new() { Index = 2, Type = MediaStreamType.Subtitle, Language = "eng", IsDefault = true, IsForced = false }
+                }
+            };
+
+            _user.SubtitleMode = SubtitlePlaybackMode.OnlyForced;
+            _user.SubtitleLanguagePreference = string.Empty;
+            _user.RememberSubtitleSelections = true;
+            _user.AudioLanguagePreference = string.Empty;
+
+            _mediaSourceManager.SetDefaultAudioAndSubtitleStreamIndices(_item, mediaInfo, _user);
+
+            Assert.Null(mediaInfo.DefaultSubtitleStreamIndex);
         }
 
         [Fact]


### PR DESCRIPTION
When remembering is enabled and subtitle mode is set to force only, the latter is not respected if the previously played subtitle stream was not a forced one.

**Changes**
* Ignore the remembered stream if subtitle mode is forced-only and the stream is not forced.

**Code assistance**
Claude Opus 5 for tests

**Issues**
Fixes #17994
