### PR TITLE
Fix slashed rating handling

### DIFF
--- a/Emby.Server.Implementations/Localization/LocalizationManager.cs
+++ b/Emby.Server.Implementations/Localization/LocalizationManager.cs
@@ -382,9 +382,21 @@ namespace Emby.Server.Implementations.Localization
                 return null;
             }
 
+            // Several rating systems contain a '/' inside a single rating (e.g. "M/12" in PT,
+            // "U/A 13+" in IN, "7/i/fig" in ES), so the value as a whole always wins over the split below.
+            var wholeValueScore = GetSingleRatingScore(rating, countryCode);
+            if (wholeValueScore is not null)
+            {
+                return wholeValueScore;
+            }
+
             // Some providers may list multiple ratings separated by '/' (e.g. "SE:15 / SE:15+ / SE:Från 15 år").
             // Try each one in order and use the first that resolves.
             var ratingValues = rating.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (ratingValues.Length == 1)
+            {
+                return null;
+            }
 
             foreach (var ratingValue in ratingValues)
             {

--- a/tests/Jellyfin.Controller.Tests/Entities/AggregateFolderTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/AggregateFolderTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("LibraryManagerTests")]
 public class AggregateFolderTests
 {
     [Fact]

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -26,6 +26,7 @@ using Xunit;
 
 namespace Jellyfin.Controller.Tests.Entities;
 
+[Collection("LibraryManagerTests")]
 public class BaseItemTests
 {
     [Fact]

--- a/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Localization/LocalizationManagerTests.cs
@@ -297,6 +297,32 @@ namespace Jellyfin.Server.Implementations.Tests.Localization
         }
 
         [Theory]
+        // Ratings that contain a '/' themselves must not be split into a list of ratings
+        [InlineData("M/3", "pt", 3, null)]
+        [InlineData("M/12", "pt", 12, null)]
+        [InlineData("M/18", "pt", 18, null)]
+        [InlineData("PT-M/12", "pt", 12, null)] // TMDB style country prefix
+        [InlineData("M/12", "us", 12, null)] // Resolved through the all-systems fallback
+        [InlineData("U/A 13+", "in", 13, null)]
+        [InlineData("7/i", "es", 11, null)]
+        [InlineData("7/i/fig", "es", 11, null)]
+        [InlineData("18/fig", "es", 18, null)]
+        public async Task GetRatingScore_RatingContainingSlash_IsNotSplit(string value, string countryCode, int expectedScore, int? expectedSubScore)
+        {
+            var localizationManager = Setup(new ServerConfiguration
+            {
+                MetadataCountryCode = countryCode
+            });
+            await localizationManager.LoadAll();
+
+            var score = localizationManager.GetRatingScore(value);
+
+            Assert.NotNull(score);
+            Assert.Equal(expectedScore, score.Score);
+            Assert.Equal(expectedSubScore, score.SubScore);
+        }
+
+        [Theory]
         [InlineData("-NO RATING SHOWN-")]
         [InlineData(":NO RATING SHOWN:")]
         public async Task GetRatingLevel_Split_Success(string value)


### PR DESCRIPTION
`LocalizationManager` wrongly split slashed ratings before ever comparing them to the ratings, resulting in wrong values.

**Changes**
Check slashed ratings against ratings before processing them further.

Since another PR already reset the recalculation migration, we don't reset it here again.

**Code assistance**
None

**Issues**
Fixes #18000
