### PR TITLE
Match artist creation lookups using CleanName

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -1343,7 +1343,6 @@ namespace Emby.Server.Implementations.Library
                 {
                     IncludeItemTypes = [BaseItemKind.MusicArtist],
                     Name = name,
-                    UseRawName = true,
                     DtoOptions = options
                 }).Cast<MusicArtist>()
                 .OrderBy(i => i.IsAccessedByName ? 1 : 0)

--- a/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
+++ b/Jellyfin.Server.Implementations/Item/BaseItemRepository.TranslateQuery.cs
@@ -476,16 +476,8 @@ public sealed partial class BaseItemRepository
 
         if (!string.IsNullOrWhiteSpace(filter.Name))
         {
-            if (filter.UseRawName == true)
-            {
-                var nameLower = filter.Name.ToLowerInvariant();
-                baseQuery = baseQuery.Where(e => e.Name!.ToLower() == nameLower);
-            }
-            else
-            {
-                var cleanName = filter.Name.GetCleanValue();
-                baseQuery = baseQuery.Where(e => e.CleanName == cleanName);
-            }
+            var cleanName = filter.Name.GetCleanValue();
+            baseQuery = baseQuery.Where(e => e.CleanName == cleanName);
         }
 
         var nameContains = filter.NameContains;

--- a/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
+++ b/MediaBrowser.Controller/Entities/InternalItemsQuery.cs
@@ -235,8 +235,6 @@ namespace MediaBrowser.Controller.Entities
 
         public string? Name { get; set; }
 
-        public bool? UseRawName { get; set; }
-
         public string? Person { get; set; }
 
         public Guid[] PersonIds { get; set; }

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/ArtistNameLookupTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/ArtistNameLookupTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Emby.Naming.Common;
+using Emby.Server.Implementations.Data;
+using Jellyfin.Data.Enums;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Extensions;
+using Jellyfin.Server.Implementations.Item;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Persistence;
+using MediaBrowser.Model.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+using Xunit;
+using ServerLibraryManager = Emby.Server.Implementations.Library.LibraryManager;
+
+namespace Jellyfin.Server.Implementations.Tests.Item;
+
+public sealed class ArtistNameLookupTests : SqliteDbTestFixture
+{
+    private readonly CommandRecorder _recorder;
+
+    public ArtistNameLookupTests()
+        : this(new CommandRecorder())
+    {
+    }
+
+    private ArtistNameLookupTests(CommandRecorder recorder)
+        : base(recorder)
+    {
+        _recorder = recorder;
+    }
+
+    [Theory]
+    [InlineData("Björk", "bjork")]
+    [InlineData("AC/DC", "ac dc")]
+    [InlineData("An Artist", " AN   ARTIST ")]
+    [InlineData("Artist", "ARTIST")]
+    public void GetArtist_UsesSameNormalizedNameAsFindArtists(string storedName, string requestedName)
+    {
+        var lookup = new ItemTypeLookup();
+        var artistId = Guid.NewGuid();
+        using (var context = CreateDbContext())
+        {
+            context.BaseItems.AddRange(
+                new BaseItemEntity
+                {
+                    Id = artistId,
+                    Name = storedName,
+                    CleanName = storedName.GetCleanValue(),
+                    Type = lookup.BaseItemKindNames[BaseItemKind.MusicArtist]
+                },
+                new BaseItemEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = storedName,
+                    CleanName = storedName.GetCleanValue(),
+                    Type = lookup.BaseItemKindNames[BaseItemKind.Person]
+                });
+            context.SaveChanges();
+        }
+
+        var manager = CreateLibraryManager(lookup);
+        _recorder.Commands.Clear();
+
+        Assert.Equal(artistId, manager.GetArtist(requestedName).Id);
+        var query = Assert.Single(_recorder.Commands, c => c.Sql.Contains("\"CleanName\" =", StringComparison.Ordinal));
+        Assert.Contains(Explain(query), line => line.Contains("IX_BaseItems_Type_CleanName (Type=? AND CleanName=?)", StringComparison.Ordinal));
+        Assert.Equal(artistId, Assert.Single(manager.GetArtists([requestedName])[requestedName]).Id);
+    }
+
+    [Fact]
+    public void GetArtist_PrefersFilesystemArtistWhenNormalizedNamesMatch()
+    {
+        var lookup = new ItemTypeLookup();
+        var parentId = Guid.NewGuid();
+        var artistId = Guid.NewGuid();
+        using (var context = CreateDbContext())
+        {
+            context.BaseItems.AddRange(
+                new BaseItemEntity
+                {
+                    Id = parentId,
+                    Name = "Music",
+                    Type = lookup.BaseItemKindNames[BaseItemKind.Folder]
+                },
+                new BaseItemEntity
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Bjork",
+                    CleanName = "Bjork".GetCleanValue(),
+                    Type = lookup.BaseItemKindNames[BaseItemKind.MusicArtist]
+                },
+                new BaseItemEntity
+                {
+                    Id = artistId,
+                    ParentId = parentId,
+                    Name = "Björk",
+                    CleanName = "Björk".GetCleanValue(),
+                    Type = lookup.BaseItemKindNames[BaseItemKind.MusicArtist]
+                });
+            context.SaveChanges();
+        }
+
+        Assert.Equal(artistId, CreateLibraryManager(lookup).GetArtist("Bjork").Id);
+    }
+
+    private ServerLibraryManager CreateLibraryManager(ItemTypeLookup lookup)
+    {
+        var repository = CreateBaseItemRepository(lookup);
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        fixture.Register(() => new NamingOptions());
+        var configuration = fixture.Freeze<Mock<IServerConfigurationManager>>();
+        configuration.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        configuration.Setup(c => c.ApplicationPaths.ProgramDataPath).Returns("/data");
+        fixture.Inject<IItemRepository>(repository);
+        fixture.Inject<ILinkedChildrenService>(new LinkedChildrenService(CreateDbContextFactory(), lookup, repository));
+        return fixture.Create<ServerLibraryManager>();
+    }
+
+    private string[] Explain(RecordedCommand query)
+    {
+        using var context = CreateDbContext();
+        using var command = context.Database.GetDbConnection().CreateCommand();
+#pragma warning disable CA2100 // query.Sql is generated by EF Core; query values remain bound parameters.
+        command.CommandText = "EXPLAIN QUERY PLAN " + query.Sql;
+#pragma warning restore CA2100
+        foreach (var value in query.Parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = value.Name;
+            parameter.Value = value.Value;
+            command.Parameters.Add(parameter);
+        }
+
+        using var reader = command.ExecuteReader();
+        var plan = new List<string>();
+        while (reader.Read())
+        {
+            plan.Add(reader.GetString(3));
+        }
+
+        return plan.ToArray();
+    }
+
+    private sealed record RecordedCommand(string Sql, (string Name, object? Value)[] Parameters);
+
+    private sealed class CommandRecorder : DbCommandInterceptor
+    {
+        public List<RecordedCommand> Commands { get; } = [];
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            Record(command);
+            return result;
+        }
+
+        private void Record(DbCommand command) => Commands.Add(new RecordedCommand(
+            command.CommandText,
+            command.Parameters.Cast<DbParameter>().Select(p => (p.ParameterName, p.Value)).ToArray()));
+    }
+}

--- a/tests/Jellyfin.Server.Implementations.Tests/Item/SqliteDbTestFixture.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Item/SqliteDbTestFixture.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Model.Configuration;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -26,7 +27,7 @@ public abstract class SqliteDbTestFixture : IDisposable
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<JellyfinDbContext> _dbOptions;
 
-    protected SqliteDbTestFixture()
+    protected SqliteDbTestFixture(params IInterceptor[] interceptors)
     {
         ApplicationPaths = new Mock<IApplicationPaths>().Object;
 
@@ -35,6 +36,7 @@ public abstract class SqliteDbTestFixture : IDisposable
 
         _dbOptions = new DbContextOptionsBuilder<JellyfinDbContext>()
             .UseSqlite(_connection)
+            .AddInterceptors(interceptors)
             .Options;
 
         using var context = CreateDbContext();


### PR DESCRIPTION
**Changes**

The single-artist lookup used by CreateItemByName still matches lower(Name), while FindArtists matches CleanName. Names that differ only in accents, punctuation, or whitespace can therefore resolve differently in the two paths. Remove the MusicArtist lookup's UseRawName override so both use the same normalization and the existing IX_BaseItems_Type_CleanName index. The preference for a filesystem artist over a by-name artist is preserved. No new index or database migration is needed.

Rebased onto `release-12.z`, which is now the target branch.

**Validation**

5 tests passed: ArtistNameLookupTests, covering normalization, the actual SQLite query plan, and filesystem-artist precedence. Tested with .NET 10 in Release configuration on macOS arm64, with timestamped build metadata.

**Code assistance**

Codex assisted with implementation, regression testing, and these PR-description updates. The contributor supplied and edited the initial Chinese descriptions.

**Issues**

No linked issue.

**Chinese explanation (updated for this revision)**

艺术家的单条查询仍使用原始名称，而批量查询已使用 CleanName，导致重音符号、标点或空格不同的名称可能得到不一致的结果。按维护者建议移除单条查询的 UseRawName 覆盖，复用现有 Type + CleanName 索引，并保留优先选择文件夹内艺术家的行为。新增索引及数据库迁移已撤掉。
