### PR TITLE
Preserve active scans when requesting a background library refresh

### DIFF
--- a/Emby.Server.Implementations/Library/LibraryManager.cs
+++ b/Emby.Server.Implementations/Library/LibraryManager.cs
@@ -318,7 +318,7 @@ namespace Emby.Server.Implementations.Library
 
             if (wizardChanged)
             {
-                _taskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>();
+                QueueLibraryScan();
             }
         }
 
@@ -3799,7 +3799,7 @@ namespace Emby.Server.Implementations.Library
 
                 if (refreshLibrary)
                 {
-                    StartScanInBackground();
+                    _ = StartScanInBackground();
                 }
                 else
                 {
@@ -3867,13 +3867,16 @@ namespace Emby.Server.Implementations.Library
             }
         }
 
-        private void StartScanInBackground()
+        internal Task StartScanInBackground()
         {
-            Task.Run(() =>
+            // An active scan already handles library structure changes, so this request can be dropped.
+            if (IsScanRunning)
             {
-                // No need to start if scanning the library because it will handle it
-                ValidateMediaLibrary(new Progress<double>(), CancellationToken.None);
-            });
+                return Task.CompletedTask;
+            }
+
+            // Queue instead of restarting so a scan that starts after the check is allowed to finish.
+            return Task.Run(QueueLibraryScan);
         }
 
         public void AddMediaPath(string virtualFolderName, MediaPathInfo mediaPath)
@@ -3984,7 +3987,7 @@ namespace Emby.Server.Implementations.Library
                 {
                     await ValidateTopLibraryFolders(CancellationToken.None, true).ConfigureAwait(false);
 
-                    StartScanInBackground();
+                    _ = StartScanInBackground();
                 }
                 else
                 {

--- a/Jellyfin.Api/Controllers/LibraryStructureController.cs
+++ b/Jellyfin.Api/Controllers/LibraryStructureController.cs
@@ -213,7 +213,7 @@ public class LibraryStructureController : BaseJellyfinApiController
                     {
                         _libraryManager.ClearIgnoreRuleCache();
                         // We don't know if this one can be validated individually, trigger a new validation
-                        await _libraryManager.ValidateMediaLibrary(new Progress<double>(), CancellationToken.None).ConfigureAwait(false);
+                        _libraryManager.QueueLibraryScan();
                     }
 
                     _libraryManager.ClearIgnoreRuleCache();
@@ -260,7 +260,7 @@ public class LibraryStructureController : BaseJellyfinApiController
                 // No need to start if scanning the library because it will handle it
                 if (refreshLibrary)
                 {
-                    await _libraryManager.ValidateMediaLibrary(new Progress<double>(), CancellationToken.None).ConfigureAwait(false);
+                    _libraryManager.QueueLibraryScan();
                 }
                 else
                 {
@@ -327,7 +327,7 @@ public class LibraryStructureController : BaseJellyfinApiController
                 // No need to start if scanning the library because it will handle it
                 if (refreshLibrary)
                 {
-                    await _libraryManager.ValidateMediaLibrary(new Progress<double>(), CancellationToken.None).ConfigureAwait(false);
+                    _libraryManager.QueueLibraryScan();
                 }
                 else
                 {

--- a/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
+++ b/src/Jellyfin.LiveTv/Recordings/RecordingsManager.cs
@@ -286,7 +286,7 @@ public sealed class RecordingsManager : IRecordingsManager, IDisposable
 
         if (requiresRefresh)
         {
-            await _libraryManager.ValidateMediaLibrary(new Progress<double>(), CancellationToken.None).ConfigureAwait(false);
+            _libraryManager.QueueLibraryScan();
         }
     }
 

--- a/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManagerScanTests.cs
+++ b/tests/Jellyfin.Server.Implementations.Tests/Library/LibraryManagerScanTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Emby.Naming.Common;
+using Emby.Server.Implementations.ScheduledTasks.Tasks;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Tasks;
+using Moq;
+using Xunit;
+using ServerLibraryManager = Emby.Server.Implementations.Library.LibraryManager;
+
+namespace Jellyfin.Server.Implementations.Tests.Library;
+
+public class LibraryManagerScanTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task StartScanInBackground_QueuesOnlyWhenIdle(bool scanRunning)
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        fixture.Register(() => new NamingOptions());
+        var configuration = fixture.Freeze<Mock<IServerConfigurationManager>>();
+        configuration.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        configuration.Setup(c => c.ApplicationPaths.ProgramDataPath).Returns("/data");
+        var tasks = fixture.Freeze<Mock<ITaskManager>>();
+        var manager = fixture.Create<ServerLibraryManager>();
+        typeof(ServerLibraryManager).GetProperty(nameof(ServerLibraryManager.IsScanRunning))!.SetValue(manager, scanRunning);
+
+        await manager.StartScanInBackground().ConfigureAwait(true);
+
+        tasks.Verify(t => t.QueueScheduledTask<RefreshMediaLibraryTask>(), scanRunning ? Times.Never() : Times.Once());
+        tasks.Verify(t => t.CancelIfRunningAndQueue<RefreshMediaLibraryTask>(), Times.Never());
+    }
+
+    [Fact]
+    public async Task ValidateMediaLibrary_RestartsScheduledScan()
+    {
+        var fixture = new Fixture().Customize(new AutoMoqCustomization());
+        fixture.Register(() => new NamingOptions());
+        var configuration = fixture.Freeze<Mock<IServerConfigurationManager>>();
+        configuration.Setup(c => c.Configuration).Returns(new ServerConfiguration());
+        configuration.Setup(c => c.ApplicationPaths.ProgramDataPath).Returns("/data");
+        var tasks = fixture.Freeze<Mock<ITaskManager>>();
+        var manager = fixture.Create<ServerLibraryManager>();
+
+        await manager.ValidateMediaLibrary(new Progress<double>(), CancellationToken.None).ConfigureAwait(true);
+
+        tasks.Verify(t => t.CancelIfRunningAndQueue<RefreshMediaLibraryTask>(), Times.Once());
+        tasks.Verify(t => t.QueueScheduledTask<RefreshMediaLibraryTask>(), Times.Never());
+    }
+}


### PR DESCRIPTION
**Changes**

Creating the collections library during post-scan processing requests a background refresh, which can cancel the scan that is creating it. Check IsScanRunning inside StartScanInBackground before asking the task manager to cancel and queue a scan. This shared entry point covers refresh requests from both library creation and removal; idle servers still schedule a refresh. CollectionManager continues to request a refresh normally.

Rebased onto `release-12.z`, which is now the target branch.

**Validation**

12 tests passed: LibraryManagerScanTests and the existing collection-related tests. Tested with .NET 10 in Release configuration on macOS arm64, with timestamped build metadata.

**Code assistance**

Codex assisted with implementation, regression testing, and these PR-description updates. The contributor supplied and edited the initial Chinese descriptions.

**Issues**

No linked issue.

**Chinese explanation (updated for this revision)**

把活动扫描判断移到 StartScanInBackground，在后台任务真正请求扫描前检查状态。新增或删除媒体库都经过这个公共入口，扫描运行期间不会再请求取消并重排任务；空闲时仍会正常刷新。合集创建处不再单独判断扫描状态。
