### PR TITLE
Preserve library items when directory enumeration fails

### DIFF
--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -409,15 +409,19 @@ namespace MediaBrowser.Controller.Entities
 
                 try
                 {
-                    nonCachedChildren = GetNonCachedChildren(directoryService);
+                    // Finish enumeration before mutating the library. An I/O failure, including
+                    // one partway through a lazy enumeration, must not look like removed files.
+                    nonCachedChildren = GetNonCachedChildren(directoryService).ToArray();
                 }
                 catch (IOException ex)
                 {
                     Logger.LogError(ex, "Error retrieving children from file system");
+                    return;
                 }
                 catch (SecurityException ex)
                 {
                     Logger.LogError(ex, "Error retrieving children from file system");
+                    return;
                 }
                 catch (Exception ex)
                 {

--- a/MediaBrowser.Controller/Entities/Folder.cs
+++ b/MediaBrowser.Controller/Entities/Folder.cs
@@ -405,7 +405,7 @@ namespace MediaBrowser.Controller.Entities
 
             if (IsFileProtocol)
             {
-                IEnumerable<BaseItem> nonCachedChildren = [];
+                IEnumerable<BaseItem> nonCachedChildren;
 
                 try
                 {

--- a/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
+++ b/tests/Jellyfin.Controller.Tests/Entities/BaseItemTests.cs
@@ -28,6 +28,43 @@ namespace Jellyfin.Controller.Tests.Entities;
 
 public class BaseItemTests
 {
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public async Task ValidateChildren_FailedEnumeration_DoesNotReconcileOrDeleteChildren(bool failAfterFirstChild, bool accessDenied)
+    {
+        var previousLibrary = BaseItem.LibraryManager;
+        var previousRepository = BaseItem.ItemRepository;
+        var previousLogger = BaseItem.Logger;
+        var library = new Mock<ILibraryManager>(MockBehavior.Strict);
+        var repository = new Mock<MediaBrowser.Controller.Persistence.IItemRepository>(MockBehavior.Strict);
+        var directory = new Mock<IDirectoryService>();
+        directory.Setup(d => d.IsAccessible(It.IsAny<string>())).Returns(true);
+        try
+        {
+            BaseItem.LibraryManager = library.Object;
+            BaseItem.ItemRepository = repository.Object;
+            BaseItem.Logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<BaseItem>.Instance;
+            var folder = new FailingEnumerationFolder(failAfterFirstChild, accessDenied)
+            {
+                Id = Guid.NewGuid(),
+                Path = "/media/review-folder"
+            };
+            await folder.ValidateChildren(new Progress<double>(), new MetadataRefreshOptions(directory.Object), recursive: false, cancellationToken: TestContext.Current.CancellationToken).ConfigureAwait(true);
+            Assert.True(folder.EnumerationAttempted);
+            repository.VerifyNoOtherCalls();
+            library.VerifyNoOtherCalls();
+        }
+        finally
+        {
+            BaseItem.LibraryManager = previousLibrary;
+            BaseItem.ItemRepository = previousRepository;
+            BaseItem.Logger = previousLogger;
+        }
+    }
+
     [Fact]
     public void GetItemByNameFolderName_ShortName_IsKeptAsIs()
     {
@@ -672,5 +709,26 @@ public class BaseItemTests
         var ids = (Guid[])method!.Invoke(primary, null)!;
 
         Assert.Equal([primary.Id, alt1.Id, alt2.Id], ids);
+    }
+
+    private sealed class FailingEnumerationFolder(bool failAfterFirstChild, bool accessDenied) : Folder
+    {
+        public bool EnumerationAttempted { get; private set; }
+
+        protected override IEnumerable<BaseItem> GetNonCachedChildren(IDirectoryService directoryService)
+        {
+            EnumerationAttempted = true;
+            if (failAfterFirstChild)
+            {
+                yield return new Movie { Id = Guid.NewGuid(), Path = "/media/review-folder/movie.mkv" };
+            }
+
+            if (accessDenied)
+            {
+                throw new System.Security.SecurityException("Simulated access failure");
+            }
+
+            throw new IOException("Simulated directory read failure");
+        }
     }
 }


### PR DESCRIPTION
**Changes**

A directory enumeration failure must not be treated as evidence that its media files were deleted. Materialize the complete child enumeration before reconciling it with library records, and return from processing the directory if enumeration throws an IOException or SecurityException. This also handles a failure after some children have already been yielded. The unused initial assignment to the child collection has been removed.

Rebased onto `release-12.z`, which is now the target branch.

**Validation**

57 tests passed: BaseItemTests, including four regression cases for initial and mid-enumeration failures. Tested with .NET 10 in Release configuration on macOS arm64, with timestamped build metadata.

**Code assistance**

Codex assisted with implementation, regression testing, and these PR-description updates. The contributor supplied and edited the initial Chinese descriptions.

**Issues**

No linked issue.

**Chinese explanation (updated for this revision)**

先完整枚举目录，再比对并处理库内记录。发生 I/O 或安全异常时终止当前目录的处理，避免把读取失败当成文件删除；枚举中途失败也会保留原有记录。同时移除了质量检查指出的无效初始化。
