### PR TITLE
Prefer a matching media source extension when inferring the container

### DIFF
--- a/Jellyfin.Api/Helpers/StreamingHelpers.cs
+++ b/Jellyfin.Api/Helpers/StreamingHelpers.cs
@@ -288,7 +288,7 @@ public static class StreamingHelpers
     /// <param name="state">The state.</param>
     /// <param name="mediaSource">The mediaSource.</param>
     /// <returns>System.String.</returns>
-    private static string GetOutputFileExtension(StreamState state, MediaSourceInfo? mediaSource)
+    internal static string GetOutputFileExtension(StreamState state, MediaSourceInfo? mediaSource)
     {
         var ext = Path.GetExtension(state.RequestedUrl);
         if (!string.IsNullOrEmpty(ext))
@@ -296,73 +296,68 @@ public static class StreamingHelpers
             return ext;
         }
 
-        // Try to infer based on the desired video codec
-        if (state.IsVideoRequest)
+        var codecExtension = state.IsVideoRequest
+            ? GetVideoOutputFileExtension(state.Request.VideoCodec)
+            : GetAudioOutputFileExtension(state.Request.AudioCodec);
+        if (codecExtension is not null)
         {
-            var videoCodec = state.Request.VideoCodec;
-
-            if (string.Equals(videoCodec, "h264", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".ts";
-            }
-
-            if (string.Equals(videoCodec, "hevc", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(videoCodec, "av1", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".mp4";
-            }
-
-            if (string.Equals(videoCodec, "theora", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".ogv";
-            }
-
-            if (string.Equals(videoCodec, "vp8", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(videoCodec, "vp9", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(videoCodec, "vpx", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".webm";
-            }
-
-            if (string.Equals(videoCodec, "wmv", StringComparison.OrdinalIgnoreCase))
-            {
-                return ".asf";
-            }
-        }
-        else
-        {
-            // Try to infer based on the desired audio codec
-            var audioCodec = state.Request.AudioCodec;
-
-            if (string.Equals("aac", audioCodec, StringComparison.OrdinalIgnoreCase))
-            {
-                return ".aac";
-            }
-
-            if (string.Equals("mp3", audioCodec, StringComparison.OrdinalIgnoreCase))
-            {
-                return ".mp3";
-            }
-
-            if (string.Equals("vorbis", audioCodec, StringComparison.OrdinalIgnoreCase))
-            {
-                return ".ogg";
-            }
-
-            if (string.Equals("wma", audioCodec, StringComparison.OrdinalIgnoreCase))
-            {
-                return ".wma";
-            }
+            return codecExtension;
         }
 
-        // Fallback to the container of mediaSource
+        // Extensionless progressive routes such as /Videos/{itemId}/stream can reach this fallback
+        // when neither a container nor a recognized output codec was requested.
         if (!string.IsNullOrEmpty(mediaSource?.Container))
         {
+            var mediaSourceExtension = GetMediaSourceFileExtension(mediaSource);
+            if (!string.IsNullOrEmpty(mediaSourceExtension))
+            {
+                return mediaSourceExtension;
+            }
+
             var idx = mediaSource.Container.IndexOf(',', StringComparison.OrdinalIgnoreCase);
             return '.' + (idx == -1 ? mediaSource.Container : mediaSource.Container[..idx]).Trim();
         }
 
         throw new InvalidOperationException("Failed to find an appropriate file extension");
+    }
+
+    private static string? GetVideoOutputFileExtension(string? codec)
+        => codec?.ToLowerInvariant() switch
+        {
+            "h264" => ".ts",
+            "hevc" or "av1" => ".mp4",
+            "theora" => ".ogv",
+            "vp8" or "vp9" or "vpx" => ".webm",
+            "wmv" => ".asf",
+            _ => null
+        };
+
+    private static string? GetAudioOutputFileExtension(string? codec)
+        => codec?.ToLowerInvariant() switch
+        {
+            "aac" => ".aac",
+            "mp3" => ".mp3",
+            "vorbis" => ".ogg",
+            "wma" => ".wma",
+            _ => null
+        };
+
+    private static string? GetMediaSourceFileExtension(MediaSourceInfo mediaSource)
+    {
+        if (string.IsNullOrEmpty(mediaSource.Path) || string.IsNullOrEmpty(mediaSource.Container))
+        {
+            return null;
+        }
+
+        var extension = Path.GetExtension(mediaSource.Path);
+        if (string.IsNullOrEmpty(extension))
+        {
+            return null;
+        }
+
+        var extensionContainer = extension.TrimStart('.');
+        var containers = mediaSource.Container.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return containers.Contains(extensionContainer, StringComparer.OrdinalIgnoreCase) ? extension : null;
     }
 
     /// <summary>

--- a/tests/Jellyfin.Api.Tests/Helpers/StreamingHelpersTests.cs
+++ b/tests/Jellyfin.Api.Tests/Helpers/StreamingHelpersTests.cs
@@ -1,0 +1,111 @@
+using System;
+using Jellyfin.Api.Helpers;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dto;
+using Moq;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Helpers
+{
+    public static class StreamingHelpersTests
+    {
+        [Theory]
+        [InlineData("/media/show/episode.mp4", "mov,mp4,m4a,3gp,3g2,mj2", ".mp4")]
+        [InlineData("/media/show/episode.MP4", "mov, mp4, m4a, 3gp, 3g2, mj2", ".MP4")]
+        [InlineData("/media/show/episode.m4v", "mov,mp4,m4a,3gp,3g2,mj2", ".mov")]
+        [InlineData("/media/song.m4a", "mov,mp4,m4a,3gp,3g2,mj2", ".m4a")]
+        [InlineData("/media/show/episode", "mov,mp4,m4a,3gp,3g2,mj2", ".mov")]
+        [InlineData(null, "mov,mp4,m4a,3gp,3g2,mj2", ".mov")]
+        public static void GetOutputFileExtension_ExtensionlessProgressiveRoute_PrefersMatchingMediaSourceFileExtension(string? path, string container, string expected)
+        {
+            var state = CreateVideoStreamState();
+            state.RequestedUrl = $"/Videos/{Guid.Empty}/stream";
+            var mediaSource = new MediaSourceInfo
+            {
+                Path = path,
+                Container = container
+            };
+
+            Assert.Equal(expected, StreamingHelpers.GetOutputFileExtension(state, mediaSource));
+        }
+
+        [Fact]
+        public static void GetOutputFileExtension_RequestedExtension_ReturnsRequestedExtension()
+        {
+            var state = CreateVideoStreamState();
+            state.RequestedUrl = "stream.mkv";
+
+            var mediaSource = new MediaSourceInfo
+            {
+                Path = "/media/show/episode.mp4",
+                Container = "mov,mp4,m4a,3gp,3g2,mj2"
+            };
+
+            Assert.Equal(".mkv", StreamingHelpers.GetOutputFileExtension(state, mediaSource));
+        }
+
+        [Theory]
+        [InlineData("h264", ".ts")]
+        [InlineData("hevc", ".mp4")]
+        [InlineData("vp9", ".webm")]
+        [InlineData("AV1", ".mp4")]
+        [InlineData("THEORA", ".ogv")]
+        [InlineData("VP8", ".webm")]
+        [InlineData("VPX", ".webm")]
+        [InlineData("WMV", ".asf")]
+        [InlineData("unknown", ".mov")]
+        [InlineData(null, ".mov")]
+        public static void GetOutputFileExtension_RequestedCodec_TakesPrecedence(string? codec, string expected)
+        {
+            var state = CreateVideoStreamState();
+            state.Request.VideoCodec = codec;
+            var mediaSource = new MediaSourceInfo
+            {
+                Path = "/media/show/episode.mov",
+                Container = "mov,mp4,m4a,3gp,3g2,mj2"
+            };
+
+            Assert.Equal(expected, StreamingHelpers.GetOutputFileExtension(state, mediaSource));
+        }
+
+        [Theory]
+        [InlineData("AAC", ".aac")]
+        [InlineData("MP3", ".mp3")]
+        [InlineData("VORBIS", ".ogg")]
+        [InlineData("WMA", ".wma")]
+        [InlineData("unknown", ".m4a")]
+        [InlineData(null, ".m4a")]
+        public static void GetOutputFileExtension_AudioCodec_TakesPrecedence(string? codec, string expected)
+        {
+            var state = CreateVideoStreamState();
+            state.Request = new StreamingRequestDto { AudioCodec = codec };
+            var mediaSource = new MediaSourceInfo
+            {
+                Path = "/media/song.m4a",
+                Container = "mov,mp4,m4a"
+            };
+
+            Assert.Equal(expected, StreamingHelpers.GetOutputFileExtension(state, mediaSource));
+        }
+
+        [Fact]
+        public static void GetOutputFileExtension_NoExtensionCodecOrContainer_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => StreamingHelpers.GetOutputFileExtension(CreateVideoStreamState(), null));
+        }
+
+        private static StreamState CreateVideoStreamState()
+        {
+            return new StreamState(
+                Mock.Of<IMediaSourceManager>(),
+                TranscodingJobType.Progressive,
+                Mock.Of<ITranscodeManager>())
+            {
+                RequestedUrl = "stream",
+                Request = new VideoRequestDto()
+            };
+        }
+    }
+}


### PR DESCRIPTION
**Changes**

Container metadata can list several candidates, such as mov,mp4,m4a. Taking the first candidate gives an MP4 source a MOV extension. Prefer the source file extension when it matches a candidate, preserving requested-extension and codec precedence and the first-candidate fallback when no source extension matches. Codec-to-extension selection is split into small helpers to reduce the complexity of GetOutputFileExtension.

Rebased onto `release-12.z`, which is now the target branch.

**Validation**

24 tests passed: StreamingHelpersTests, including video/audio codec mappings, extension precedence, fallbacks, and missing-format errors. Tested with .NET 10 in Release configuration on macOS arm64, with timestamped build metadata.

**Code assistance**

Codex assisted with implementation, regression testing, and these PR-description updates. The contributor supplied and edited the initial Chinese descriptions.

**Issues**

No linked issue.

**Chinese explanation (updated for this revision)**

容器信息有多个候选格式时，优先匹配源文件扩展名；请求扩展名和编码仍具有原来的优先级，没有匹配项时继续使用首个候选格式。编码与扩展名的对应逻辑已拆成小函数，降低复杂度，并补充音视频编码及异常情况的回归测试。
