### PR TITLE
Add plugin repository manifest validation

### DIFF
--- a/Jellyfin.Api/Controllers/PackageController.cs
+++ b/Jellyfin.Api/Controllers/PackageController.cs
@@ -1,10 +1,17 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Extensions;
+using Jellyfin.Extensions.Json;
 using MediaBrowser.Common.Api;
+using MediaBrowser.Common.Net;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Common.Updates;
 using MediaBrowser.Controller.Configuration;
@@ -180,6 +187,59 @@ public class PackageController : BaseJellyfinApiController
         _serverConfigurationManager.Configuration.PluginRepositories = repositoryInfos;
         _serverConfigurationManager.SaveConfiguration();
         return NoContent();
+    }
+
+    /// <summary>
+    /// Validates a plugin repository without changing the configured repositories.
+    /// </summary>
+    /// <param name="repositoryInfo">The repository to validate.</param>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <response code="204">The repository manifest is valid.</response>
+    /// <response code="400">The repository could not be reached or its manifest is invalid.</response>
+    /// <returns>The validation result.</returns>
+    [HttpPost("Repositories/Validate")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> ValidateRepository(
+        [FromBody, Required] RepositoryInfo repositoryInfo,
+        [FromServices] IHttpClientFactory httpClientFactory,
+        CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(repositoryInfo.Url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return BadRequest("The repository URL must be an absolute HTTP or HTTPS URL.");
+        }
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+
+        try
+        {
+            var packages = await httpClientFactory.CreateClient(NamedClient.Default)
+                .GetFromJsonAsync<PackageInfo[]>(uri, JsonDefaults.Options, timeout.Token).ConfigureAwait(false);
+
+            // Empty repositories and plugins targeting a newer server are valid. Reject
+            // null entries that the catalog reader cannot process.
+            if (packages is null || packages.Any(package => package is null
+                || package.Versions is null || package.Versions.Any(version => version is null
+                    || (!string.IsNullOrEmpty(version.TargetAbi) && !Version.TryParse(version.TargetAbi, out _)))))
+            {
+                return BadRequest("The repository manifest is invalid.");
+            }
+
+            return NoContent();
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return BadRequest("The repository did not respond in time.");
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or JsonException or NotSupportedException
+            or FormatException or ArgumentException or OverflowException)
+        {
+            return BadRequest("The repository could not be reached or its manifest is invalid.");
+        }
     }
 
     private bool IsBundledPlugin(string name, Guid? assemblyGuid)

--- a/tests/Jellyfin.Api.Tests/Controllers/PackageControllerTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/PackageControllerTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Common.Api;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Common.Updates;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Configuration;
+using MediaBrowser.Model.Updates;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class PackageControllerTests
+{
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, "Not found", HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.OK, "<html>Error</html>", HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.OK, "[]", HttpStatusCode.NoContent)]
+    public async Task ValidateRepository_HttpRequest_DoesNotSaveConfiguration(
+        HttpStatusCode manifestStatus,
+        string manifest,
+        HttpStatusCode expectedStatus)
+    {
+        var configuration = new Mock<IServerConfigurationManager>(MockBehavior.Strict);
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(manifestStatus) { Content = new StringContent(manifest) });
+        using var manifestClient = new HttpClient(handler.Object);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(manifestClient);
+        using var host = await new HostBuilder().ConfigureWebHost(web => web.UseTestServer()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton(configuration.Object);
+                services.AddSingleton(Mock.Of<IInstallationManager>());
+                services.AddSingleton(Mock.Of<IPluginManager>());
+                services.AddSingleton(factory.Object);
+                services.AddControllers().AddApplicationPart(typeof(PackageController).Assembly);
+                services.AddAuthentication();
+                // Authentication has separate tests; exercise routing and model binding here.
+                services.AddAuthorization(options => options.AddPolicy(Policies.RequiresElevation, policy => policy.RequireAssertion(_ => true)));
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseAuthorization();
+                app.UseEndpoints(endpoints => endpoints.MapControllers());
+            })).StartAsync(TestContext.Current.CancellationToken);
+        using var client = host.GetTestClient();
+
+        using var response = await client.PostAsJsonAsync(
+            "/Repositories/Validate",
+            new RepositoryInfo { Name = "Test", Url = "https://example.com/manifest.json" },
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedStatus, response.StatusCode);
+        configuration.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void SetRepositories_PreservesLegacySaveWithoutValidation()
+    {
+        var configuration = new ServerConfiguration();
+        var manager = new Mock<IServerConfigurationManager>();
+        manager.SetupGet(x => x.Configuration).Returns(configuration);
+        var controller = new PackageController(Mock.Of<IInstallationManager>(), manager.Object, Mock.Of<IPluginManager>());
+        RepositoryInfo[] repositories = [new() { Name = "Missing", Url = "https://example.com/missing.json" }];
+
+        var result = controller.SetRepositories(repositories);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Same(repositories, configuration.PluginRepositories);
+        manager.Verify(x => x.SaveConfiguration(), Times.Once);
+    }
+}

--- a/tests/Jellyfin.Api.Tests/Controllers/RepositoryValidationTests.cs
+++ b/tests/Jellyfin.Api.Tests/Controllers/RepositoryValidationTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Api.Controllers;
+using MediaBrowser.Common.Plugins;
+using MediaBrowser.Common.Updates;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Updates;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Jellyfin.Api.Tests.Controllers;
+
+public class RepositoryValidationTests
+{
+    private readonly Mock<IServerConfigurationManager> _configuration = new(MockBehavior.Strict);
+    private readonly Mock<HttpMessageHandler> _handler = new();
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, "Not found")]
+    [InlineData(HttpStatusCode.OK, "<html>Not a manifest</html>")]
+    [InlineData(HttpStatusCode.OK, "null")]
+    [InlineData(HttpStatusCode.OK, "{}")]
+    [InlineData(HttpStatusCode.OK, "[null]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":null}]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":[null]}]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":[{\"version\":\"1.bad.0\"}]}]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":[{\"version\":\"1\"}]}]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":[{\"version\":\"999999999999.0\"}]}]")]
+    [InlineData(HttpStatusCode.OK, "[{\"versions\":[{\"version\":\"1.0\",\"targetAbi\":\"invalid\"}]}]")]
+    public async Task ValidateRepository_InvalidManifest_ReturnsBadRequest(HttpStatusCode status, string content)
+    {
+        SetupResponse(status, content);
+        Assert.IsType<BadRequestObjectResult>(await Validate("https://example.com/manifest.json", TestContext.Current.CancellationToken));
+        _configuration.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("[{\"name\":\"Test\",\"versions\":[]}]")]
+    [InlineData("[{\"name\":\"Future\",\"versions\":[{\"version\":\"1.0.0\",\"targetAbi\":\"999.0.0\"}]}]")]
+    public async Task ValidateRepository_ValidManifest_ReturnsNoContent(string content)
+    {
+        SetupResponse(HttpStatusCode.OK, content);
+        Assert.IsType<NoContentResult>(await Validate("https://example.com/manifest.json", TestContext.Current.CancellationToken));
+        _configuration.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("relative/path")]
+    [InlineData("file:///tmp/manifest.json")]
+    [InlineData("ftp://example.com/manifest.json")]
+    public async Task ValidateRepository_InvalidUrl_DoesNotMakeRequest(string? url)
+    {
+        Assert.IsType<BadRequestObjectResult>(await Validate(url, TestContext.Current.CancellationToken));
+        _handler.Protected().Verify("SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ValidateRepository_NetworkFailure_ReturnsBadRequest()
+    {
+        SetupException(new HttpRequestException("Connection failed"));
+        Assert.IsType<BadRequestObjectResult>(await Validate("https://example.com/manifest.json", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ValidateRepository_Timeout_ReturnsBadRequest()
+    {
+        SetupException(new TaskCanceledException("Timed out"));
+        Assert.IsType<BadRequestObjectResult>(await Validate("https://example.com/manifest.json", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ValidateRepository_RequestCancelled_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+        SetupException(new OperationCanceledException(cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Validate("https://example.com/manifest.json", cancellation.Token));
+    }
+
+    private void SetupResponse(HttpStatusCode status, string content) =>
+        _handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(status) { Content = new StringContent(content) });
+
+    private void SetupException(Exception exception) =>
+        _handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+
+    private async Task<ActionResult> Validate(string? url, CancellationToken cancellationToken = default)
+    {
+        using var client = new HttpClient(_handler.Object);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(client);
+        var controller = new PackageController(Mock.Of<IInstallationManager>(), _configuration.Object, Mock.Of<IPluginManager>());
+        return await controller.ValidateRepository(new RepositoryInfo { Url = url }, factory.Object, cancellationToken);
+    }
+}


### PR DESCRIPTION
**Changes**

I also encountered the problem reported in #14267: an invalid plugin repository can still be saved successfully.

Original Chinese: “无效插件仓库也能保存成功”“我也遇到了同样的问题”。

I have translated this from Chinese with an LLM.

**Code assistance**

OpenAI Codex: investigation, implementation, automated tests, and code review.

**Validation**

- Jellyfin.Api.Tests: 165 passed, 0 failed.

**Issues**

Related to #14267.

Companion web PR (draft): https://github.com/jellyfin/jellyfin-web/pull/8477
