### PR TITLE
Fix HLS segment container fallback ignoring incompatible audio codecs (TrueHD/DTS/FLAC/ALAC/Opus)

### DIFF
--- a/Jellyfin.Api/Controllers/DynamicHlsController.cs
+++ b/Jellyfin.Api/Controllers/DynamicHlsController.cs
@@ -1410,12 +1410,17 @@ public class DynamicHlsController : BaseJellyfinApiController
             segmentLength = (int)Math.Ceiling(segmentLength * (nearestIntFramerate / fps));
         }
 
+        // Resolve the effective segment container the same way the segment/variant-playlist
+        // endpoints do, so the main playlist reports fMP4 (#EXT-X-VERSION/init segment) exactly
+        // when the segments actually being served will be fMP4.
+        var resolvedSegmentContainer = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec).TrimStart('.');
+
         var request = new CreateMainPlaylistRequest(
             mediaSourceId is null ? null : Guid.Parse(mediaSourceId),
             state.MediaPath,
             segmentLength,
             state.RunTimeTicks ?? 0,
-            state.Request.SegmentContainer ?? string.Empty,
+            resolvedSegmentContainer,
             "hls1/main/",
             Request.QueryString.ToString(),
             EncodingHelper.IsCopyCodec(state.OutputVideoCodec));
@@ -1453,7 +1458,7 @@ public class DynamicHlsController : BaseJellyfinApiController
 
         var segmentPath = GetSegmentPath(state, playlistPath, segmentId);
 
-        var segmentExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer);
+        var segmentExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec);
 
         // Keep segment selection and transcoding replacement under the same playlist lock.
         // An out-of-order request must not replace a job while another request is using its output.
@@ -1585,7 +1590,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         var directory = Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath));
         var outputFileNameWithoutExtension = Path.GetFileNameWithoutExtension(outputPath);
         var outputPrefix = Path.Combine(directory, outputFileNameWithoutExtension);
-        var outputExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer);
+        var outputExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec);
         var outputTsArg = outputPrefix + "%d" + outputExtension;
 
         var segmentFormat = string.Empty;
@@ -1909,7 +1914,7 @@ public class DynamicHlsController : BaseJellyfinApiController
         var folder = Path.GetDirectoryName(playlist) ?? throw new ArgumentException($"Provided path ({playlist}) is not valid.", nameof(playlist));
         var filename = Path.GetFileNameWithoutExtension(playlist);
 
-        return Path.Combine(folder, filename + index.ToString(CultureInfo.InvariantCulture) + EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer));
+        return Path.Combine(folder, filename + index.ToString(CultureInfo.InvariantCulture) + EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec));
     }
 
     private async Task<ActionResult> GetSegmentResult(

--- a/Jellyfin.Api/Helpers/HlsHelpers.cs
+++ b/Jellyfin.Api/Helpers/HlsHelpers.cs
@@ -83,7 +83,7 @@ public static class HlsHelpers
         var directory = Path.GetDirectoryName(outputPath) ?? throw new ArgumentException($"Provided path ({outputPath}) is not valid.", nameof(outputPath));
         var outputFileNameWithoutExtension = Path.GetFileNameWithoutExtension(outputPath);
         var outputPrefix = Path.Combine(directory, outputFileNameWithoutExtension);
-        var outputExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer);
+        var outputExtension = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec);
 
         // on Linux/Unix
         // #EXT-X-MAP:URI="prefix-1.mp4"
@@ -113,7 +113,7 @@ public static class HlsHelpers
     {
         var text = File.ReadAllText(path);
 
-        var segmentFormat = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer).TrimStart('.');
+        var segmentFormat = EncodingHelper.GetSegmentFileExtension(state.Request.SegmentContainer, state.ActualOutputAudioCodec).TrimStart('.');
         if (string.Equals(segmentFormat, "mp4", StringComparison.OrdinalIgnoreCase))
         {
             var fmp4InitFileName = GetFmp4InitFileName(path, state, true);

--- a/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
+++ b/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs
@@ -1572,7 +1572,7 @@ namespace MediaBrowser.Controller.MediaEncoding
                 filters.Add(noiseFilter);
             }
 
-            var segmentFormat = GetSegmentFileExtension(segmentContainer).TrimStart('.');
+            var segmentFormat = GetSegmentFileExtension(segmentContainer, state.ActualOutputAudioCodec).TrimStart('.');
 
             // Apply aac_adtstoasc bitstream filter when media source is in mpegts.
             if (string.Equals(segmentFormat, "mp4", StringComparison.OrdinalIgnoreCase)
@@ -1621,11 +1621,22 @@ namespace MediaBrowser.Controller.MediaEncoding
                 seekSeconds);
         }
 
-        public static string GetSegmentFileExtension(string segmentContainer)
+        public static string GetSegmentFileExtension(string segmentContainer, string actualOutputAudioCodec = null)
         {
             if (!string.IsNullOrWhiteSpace(segmentContainer))
             {
                 return "." + segmentContainer;
+            }
+
+            // The client did not request a specific segment container. Defaulting to mpegts
+            // segments is only safe when the audio actually ending up on the wire (stream-copied
+            // or transcoded) is one mpegts can carry. Codecs such as TrueHD, DTS, FLAC, ALAC and
+            // Opus can only be muxed into fMP4 segments, so fall back to mp4 instead of silently
+            // forcing an unnecessary audio transcode down to a TS-compatible codec.
+            if (!string.IsNullOrWhiteSpace(actualOutputAudioCodec)
+                && !StreamBuilder.SupportedHlsAudioCodecsTs.Contains(actualOutputAudioCodec, StringComparer.OrdinalIgnoreCase))
+            {
+                return ".mp4";
             }
 
             return ".ts";

--- a/MediaBrowser.Model/Dlna/StreamBuilder.cs
+++ b/MediaBrowser.Model/Dlna/StreamBuilder.cs
@@ -46,6 +46,16 @@ namespace MediaBrowser.Model.Dlna
         }
 
         /// <summary>
+        /// Gets the audio codecs that can be carried in MPEG-TS HLS segments.
+        /// </summary>
+        public static IReadOnlyList<string> SupportedHlsAudioCodecsTs => _supportedHlsAudioCodecsTs;
+
+        /// <summary>
+        /// Gets the audio codecs that can be carried in fMP4 HLS segments.
+        /// </summary>
+        public static IReadOnlyList<string> SupportedHlsAudioCodecsMp4 => _supportedHlsAudioCodecsMp4;
+
+        /// <summary>
         /// Gets the optimal audio stream.
         /// </summary>
         /// <param name="options">The <see cref="MediaOptions"/> object to get the audio stream from.</param>

--- a/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSegmentContainerTests.cs
+++ b/tests/Jellyfin.Controller.Tests/MediaEncoding/EncodingHelperSegmentContainerTests.cs
@@ -1,0 +1,92 @@
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Entities;
+using Xunit;
+
+namespace Jellyfin.Controller.Tests.MediaEncoding;
+
+/// <summary>
+/// Regression tests for the HLS segment container fallback used when a client does not
+/// explicitly request a <c>segmentContainer</c>.
+///
+/// Bug: the server unconditionally defaulted to mpegts (.ts) segments when no container was
+/// requested, even though mpegts cannot carry audio codecs such as TrueHD, DTS, FLAC, ALAC or
+/// Opus. This forced the server to transcode those codecs down to AAC instead of stream-copying
+/// them, even for clients that had declared HLS/fMP4 support for the source codec.
+/// </summary>
+public class EncodingHelperSegmentContainerTests
+{
+    [Theory]
+    [InlineData("aac")]
+    [InlineData("ac3")]
+    [InlineData("eac3")]
+    [InlineData("mp3")]
+    [InlineData(null)]
+    public void GetSegmentFileExtension_NoContainerRequested_TsCompatibleAudio_DefaultsToTs(string? audioCodec)
+    {
+        Assert.Equal(".ts", EncodingHelper.GetSegmentFileExtension(null, audioCodec));
+        Assert.Equal(".ts", EncodingHelper.GetSegmentFileExtension(string.Empty, audioCodec));
+    }
+
+    [Theory]
+    [InlineData("truehd")]
+    [InlineData("dts")]
+    [InlineData("flac")]
+    [InlineData("alac")]
+    [InlineData("opus")]
+    [InlineData("TrueHD")]
+    public void GetSegmentFileExtension_NoContainerRequested_TsIncompatibleAudio_FallsBackToMp4(string audioCodec)
+    {
+        Assert.Equal(".mp4", EncodingHelper.GetSegmentFileExtension(null, audioCodec));
+        Assert.Equal(".mp4", EncodingHelper.GetSegmentFileExtension(string.Empty, audioCodec));
+    }
+
+    [Theory]
+    [InlineData("ts", "truehd")]
+    [InlineData("mp4", "aac")]
+    [InlineData("mkv", "dts")]
+    public void GetSegmentFileExtension_ExplicitContainerRequested_IsAlwaysHonored(string requestedContainer, string audioCodec)
+    {
+        Assert.Equal("." + requestedContainer, EncodingHelper.GetSegmentFileExtension(requestedContainer, audioCodec));
+    }
+
+    [Fact]
+    public void ActualOutputAudioCodec_StreamCopiedTrueHd_ResolvesToMp4Segments()
+    {
+        // Mirrors what DynamicHlsController/HlsHelpers see for a real request: the client
+        // asked to copy the audio (no server-side transcode needed) and the source audio is
+        // TrueHD, so the actual codec ending up on the wire is TrueHD, not the OutputAudioCodec
+        // placeholder value of "copy".
+        var state = new EncodingJobInfo(TranscodingJobType.Hls)
+        {
+            AudioStream = new MediaStream
+            {
+                Type = MediaStreamType.Audio,
+                Codec = "truehd"
+            },
+            OutputAudioCodec = "copy",
+            BaseRequest = new VideoRequestDto()
+        };
+
+        Assert.Equal("truehd", state.ActualOutputAudioCodec);
+        Assert.Equal(".mp4", EncodingHelper.GetSegmentFileExtension(null, state.ActualOutputAudioCodec));
+    }
+
+    [Fact]
+    public void ActualOutputAudioCodec_StreamCopiedAac_ResolvesToTsSegments()
+    {
+        var state = new EncodingJobInfo(TranscodingJobType.Hls)
+        {
+            AudioStream = new MediaStream
+            {
+                Type = MediaStreamType.Audio,
+                Codec = "aac"
+            },
+            OutputAudioCodec = "copy",
+            BaseRequest = new VideoRequestDto()
+        };
+
+        Assert.Equal("aac", state.ActualOutputAudioCodec);
+        Assert.Equal(".ts", EncodingHelper.GetSegmentFileExtension(null, state.ActualOutputAudioCodec));
+    }
+}


### PR DESCRIPTION
When an HLS client doesn't explicitly request a `segmentContainer`, the server unconditionally defaults to mpegts (`.ts`) segments, even when the audio ending up on the wire (stream-copied or transcoded) is TrueHD, DTS, FLAC, ALAC or Opus, none of which mpegts can carry. `StreamBuilder` already has the two authoritative lists (`_supportedHlsAudioCodecsTs` vs `_supportedHlsAudioCodecsMp4`) and uses them correctly when ranking a client's declared `TranscodingProfiles`, but that ranking is never consulted by the actual HLS master-playlist/segment-serving endpoints in `DynamicHlsController`/`HlsHelpers`. Those just call `EncodingHelper.GetSegmentFileExtension(segmentContainer)`, which hardcoded `.ts` whenever `segmentContainer` was empty. This silently forced a lossy AAC transcode instead of a stream-copy, even for clients (e.g. Android TV) that had declared an HLS/fMP4 `TranscodingProfile` supporting the source codec. Verified live against a production Jellyfin instance: manually adding `&SegmentContainer=mp4` to the same request made the server correctly stream-copy 8-channel TrueHD (confirmed via ffprobe on the downloaded fMP4 segments) instead of transcoding to AAC.

Fix: `GetSegmentFileExtension` now takes the actual output audio codec (`EncodingJobInfo.ActualOutputAudioCodec`, which already resolves `"copy"` to the real source codec) and falls back to `.mp4` instead of `.ts` when that codec isn't in `StreamBuilder`'s TS-compatible list (now exposed as `SupportedHlsAudioCodecsTs`/`SupportedHlsAudioCodecsMp4`). All 6 call sites across `EncodingHelper`, `DynamicHlsController` and `HlsHelpers` were updated to pass it through. Behavior when a client explicitly sends `segmentContainer` is unchanged.

**This fix alone is not sufficient for a real client.** The HLS segment endpoints this PR touches never consult a client's negotiated `TranscodingProfile` (that ranking only happens for the separate `PlaybackInfo` response) — they only see whatever `segmentContainer`/`audioCodec` query parameters the client explicitly sends on the request. Without an explicit `audioCodec`, the server falls back to inferring a target codec from the request's own file extension (`.mp4` → `aac`), which is meaningless for a video segment and forces a transcode regardless of container. **This PR and the companion Android TV app PR (jellyfin/jellyfin-androidtv#5817, which sends both `segmentContainer` and `audioCodec`) are both required together**, not independently — confirmed by testing each in isolation against production: `segmentContainer=mp4` alone still produced AAC; only adding an explicit `audioCodec` alongside it produced a real TrueHD copy.

Added `EncodingHelperSegmentContainerTests.cs` proving: TS-compatible audio (aac/ac3/eac3/mp3) still defaults to `.ts`; TS-incompatible audio (truehd/dts/flac/alac/opus) now falls back to `.mp4`; explicit client-requested containers are always honored regardless of audio codec; and the `ActualOutputAudioCodec`-to-container wiring works end-to-end for a stream-copy scenario.

## Test plan

Ran locally with .NET SDK 10.0.401 (`dotnet build`/`dotnet test`), not just relying on CI:

- [x] Reverted only the new fallback logic (kept the new signature) and confirmed 7/16 tests failed, exactly the TrueHD/DTS/Opus cases (`Expected .mp4, Actual .ts`); restored the fix and confirmed 16/16 pass.
- [x] `MediaBrowser.Model`, `MediaBrowser.Controller`, `Jellyfin.Api`, `Jellyfin.MediaEncoding.Hls` all build with 0 errors.
- [x] Full existing suites for every touched project pass with no regressions: `Jellyfin.Controller.Tests` 203/203, `Jellyfin.Model.Tests` 748/748, `Jellyfin.Api.Tests` 139/139, `Jellyfin.MediaEncoding.Hls.Tests` 18/18, `Jellyfin.MediaEncoding.Tests` 101/101.
- [x] Verified end-to-end together with jellyfin-androidtv#5817 against a real production server: the exact request that app now builds (`SegmentContainer=mp4&AudioCodec=alac,flac,opus,dts,truehd`) returns a real TrueHD 7.1 copy (confirmed via `ffprobe` on the downloaded segment), not a transcode.